### PR TITLE
[arci-ros] Make arci-ros as a ROS package

### DIFF
--- a/arci-ros/CMakeLists.txt
+++ b/arci-ros/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(arci-ros)
+find_package(catkin REQUIRED)
+catkin_package()

--- a/arci-ros/README.md
+++ b/arci-ros/README.md
@@ -1,0 +1,7 @@
+# arci-ros
+
+ROS1 implementation for arci.
+
+## Dependencies
+
+See package.xml.

--- a/arci-ros/package.xml
+++ b/arci-ros/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>arci-ros</name>
+  <version>0.0.1</version>
+  <description>ROS1 implementation of arci</description>
+
+  <maintainer email="ogura@smilerobotics.com">Takashi Ogura</maintainer>
+  <license>Apache2</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>actionlib-msgs</build_depend>
+  <build_depend>control-msgs</build_depend>
+  <build_depend>geometry-msgs</build_depend>
+  <build_depend>sensor-msgs</build_depend>
+  <build_depend>tf2-msgs</build_depend>
+  <build_depend>trajectory-msgs</build_depend>
+  <build_depend>move-base-msgs</build_depend>
+
+  <export>
+  </export>
+</package>


### PR DESCRIPTION
This is to resolve the dependencies using rosdep.
I'm thinking that make it possible to build without
any ros system, just only download msg files in the
future.