### PR TITLE
[openrr-gui] Add openrr-gui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "openrr-apps",
     "openrr-client",
     "openrr-command",
+    "openrr-gui",
     "openrr-planner",
     "openrr-sleep",
     "openrr-teleop",
@@ -26,6 +27,7 @@ members = [
 "openrr-apps" = {path = "openrr-apps"}
 "openrr-client" = {path = "openrr-client"}
 "openrr-command" = {path = "openrr-command"}
+"openrr-gui" = {path = "openrr-gui"}
 "openrr-planner" = {path = "openrr-planner"}
 "openrr-sleep" = {path = "openrr-sleep"}
 "openrr-teleop" = {path = "openrr-teleop"}

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Open Rust Robotics platform.
 ### Linux
 
 ```bash
-sudo apt install cmake build-essential libudev-dev
+sudo apt install cmake build-essential libudev-dev xorg-dev libglu1-mesa-dev
 ```
 
 * cmake build-essential (openrr-planner (assimp-sys))
 * libudev-dev (arci-gamepad-gilrs)
+* xorg-dev libglu1-mesa-dev (openrr-gui (iced))
 
 ## Architecture
 

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "openrr-gui"
+version = "0.0.1"
+authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+arci = { version = "0.0.1", path = "../arci" }
+openrr-client = { version = "0.0.1", path = "../openrr-client" }
+
+iced = "0.2"
+log = "0.4"
+rand = "0.8"
+thiserror = "1"
+urdf-rs = "0.4"
+
+[dev-dependencies]
+toml = "0.5"
+k = "0.21"
+env_logger = "0.8"
+arci-urdf-viz = { version = "0.0.1", path = "../arci-urdf-viz" }
+structopt = "0.3.21"
+openrr-apps = { version = "0.0.1", path = "../openrr-apps" }
+anyhow = "1"
+arci-ros = { version = "0.0.1", path = "../arci-ros" }

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -6,20 +6,15 @@ edition = "2018"
 
 [dependencies]
 arci = { version = "0.0.1", path = "../arci" }
-openrr-client = { version = "0.0.1", path = "../openrr-client" }
-
 iced = "0.2"
 log = "0.4"
+openrr-client = { version = "0.0.1", path = "../openrr-client" }
 rand = "0.8"
 thiserror = "1"
 urdf-rs = "0.4"
 
 [dev-dependencies]
-toml = "0.5"
-k = "0.21"
-env_logger = "0.8"
-arci-urdf-viz = { version = "0.0.1", path = "../arci-urdf-viz" }
-structopt = "0.3.21"
-openrr-apps = { version = "0.0.1", path = "../openrr-apps" }
 anyhow = "1"
-arci-ros = { version = "0.0.1", path = "../arci-ros" }
+env_logger = "0.8"
+openrr-apps = { version = "0.0.1", path = "../openrr-apps" }
+structopt = "0.3.21"

--- a/openrr-gui/README.md
+++ b/openrr-gui/README.md
@@ -1,0 +1,43 @@
+# OpenRR GUI
+
+## Examples
+
+### Sample robot
+
+- Launch urdf-viz.
+
+  ```bash
+  urdf-viz ./openrr-planner/sample.urdf
+  ```
+
+- Launch joint_position_sender.
+
+  ```bash
+  cargo run -p openrr-gui --example joint_position_sender -- \
+    ./openrr-apps/config/sample_robot_client_config_for_command_urdf_viz.toml \
+    ./openrr-planner/sample.urdf
+  ```
+
+  or
+
+  ```bash
+  cargo build --release -p openrr-gui --example joint_position_sender
+  ./target/release/examples/joint_position_sender \
+    ./openrr-apps/config/sample_robot_client_config_for_command_urdf_viz.toml \
+    ./openrr-planner/sample.urdf
+  ```
+
+## Troubleshooting
+
+- Q. Fails to compile.
+
+  A. Try to install dependencies mentioned in root [README.md](../README.md).
+
+- Q. Fails to launch GUI.
+
+  A. There are several possibilities:
+
+  - If the error is command-line arguments or IO related, it's likely that the argument is wrong.
+  - If you get the error that "GraphicsAdapterNotFound", try passing the "--features iced/glow" argument to `cargo build` or `cargo run`.
+  - If that doesn't fix the problem, try passing the `LIBGL_ALWAYS_SOFTWARE=1` environment variable.
+  - On VM (e.g., VirtualBox), you may need to disable hardware acceleration.

--- a/openrr-gui/examples/joint_position_sender.rs
+++ b/openrr-gui/examples/joint_position_sender.rs
@@ -1,0 +1,24 @@
+// TODO: move to openrr-apps?
+
+use log::debug;
+use openrr_apps::RobotConfig;
+use openrr_client::BoxRobotClient;
+use openrr_gui::joint_position_sender;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+struct Opt {
+    config_path: String,
+    urdf_path: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let opt = Opt::from_args();
+    debug!("opt: {:?}", opt);
+    let config = RobotConfig::try_new(&opt.config_path)?;
+    let client: BoxRobotClient = config.create_robot_client()?;
+
+    joint_position_sender(client, opt.urdf_path)?;
+    Ok(())
+}

--- a/openrr-gui/src/error.rs
+++ b/openrr-gui/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("iced: {:?}", .0)]
+    Iced(String),
+    #[error("urdf: {:?}", .0)]
+    Urdf(#[from] urdf_rs::UrdfError),
+    #[error("arci: {:?}", .0)]
+    Arci(#[from] arci::Error),
+}
+
+impl From<iced::Error> for Error {
+    fn from(e: iced::Error) -> Self {
+        // TODO: iced::Error doesn't implement Send/Sync, so for now, convert it to a string.
+        // Without this, it cannot be used in combination with `anyhow::Result`.
+        // https://github.com/hecrj/iced/issues/516
+        Self::Iced(e.to_string())
+    }
+}

--- a/openrr-gui/src/joint_position_sender.rs
+++ b/openrr-gui/src/joint_position_sender.rs
@@ -1,11 +1,9 @@
 use std::{collections::HashMap, f64, path::Path, sync::Arc, time::Duration, usize};
 
 use arci::{JointTrajectoryClient, MoveBase, Navigation, Speaker};
-#[allow(unused_imports)]
 use iced::{
-    button, scrollable, slider, window, Align, Application, Button, Checkbox, Column, Command,
-    Container, Element, HorizontalAlignment, Length, PickList, ProgressBar, Radio, Row, Rule,
-    Sandbox, Scrollable, Settings, Slider, Space, Text, TextInput,
+    button, scrollable, slider, window, Application, Button, Column, Command, Container, Element,
+    HorizontalAlignment, Length, PickList, Row, Scrollable, Settings, Slider, Text, TextInput,
 };
 use iced::{pick_list, text_input};
 use log::{debug, error, warn};
@@ -26,7 +24,6 @@ struct JointState {
 }
 
 struct Robot {
-    _robot: urdf_rs::Robot,
     joints: HashMap<String, urdf_rs::Joint>,
 }
 
@@ -35,10 +32,9 @@ impl From<urdf_rs::Robot> for Robot {
         Self {
             joints: robot
                 .joints
-                .iter()
-                .map(|joint| (joint.name.clone(), joint.clone()))
+                .into_iter()
+                .map(|joint| (joint.name.clone(), joint))
                 .collect(),
-            _robot: robot,
         }
     }
 }

--- a/openrr-gui/src/joint_position_sender.rs
+++ b/openrr-gui/src/joint_position_sender.rs
@@ -1,0 +1,396 @@
+use std::{collections::HashMap, path::Path, sync::Arc, time::Duration, usize};
+
+use arci::{JointTrajectoryClient, MoveBase, Navigation, Speaker};
+#[allow(unused_imports)]
+use iced::{
+    button, scrollable, slider, window, Align, Application, Button, Checkbox, Column, Command,
+    Container, Element, HorizontalAlignment, Length, PickList, ProgressBar, Radio, Row, Rule,
+    Sandbox, Scrollable, Settings, Slider, Space, Text, TextInput,
+};
+use iced::{pick_list, text_input};
+use log::{debug, error, warn};
+use openrr_client::RobotClient;
+use rand::Rng;
+
+use crate::{style, Error};
+
+const THEME: style::Theme = style::Theme;
+
+#[derive(Default)]
+struct JointState {
+    name: String,
+    slider: slider::State,
+    text_input: text_input::State,
+    position: f64,
+}
+
+struct Robot {
+    _robot: urdf_rs::Robot,
+    joints: HashMap<String, urdf_rs::Joint>,
+}
+
+impl From<urdf_rs::Robot> for Robot {
+    fn from(robot: urdf_rs::Robot) -> Self {
+        Self {
+            joints: robot
+                .joints
+                .iter()
+                .map(|joint| (joint.name.clone(), joint.clone()))
+                .collect(),
+            _robot: robot,
+        }
+    }
+}
+
+/// Launches GUI that send joint positions from GUI to the given `robot_client`.
+pub fn joint_position_sender<S, M, N>(
+    robot_client: RobotClient<S, M, N>,
+    urdf_path: impl AsRef<Path>,
+) -> Result<(), Error>
+where
+    S: Speaker + 'static,
+    M: MoveBase + 'static,
+    N: Navigation + 'static,
+{
+    // TODO: If the urdf file read by `robot_client` and this urdf file are different, we should emit an error.
+    let robot = urdf_rs::read_file(urdf_path)?;
+
+    let mut joint_trajectory_client_names = robot_client.joint_trajectory_clients_names();
+    joint_trajectory_client_names.sort_unstable();
+    debug!("{:?}", joint_trajectory_client_names);
+
+    let joint_states = joint_trajectory_client_names
+        .iter()
+        .map(|client_name| {
+            (
+                client_name.clone(),
+                robot_client.joint_trajectory_clients()[client_name]
+                    .joint_names()
+                    .iter()
+                    .map(|joint_name| JointState {
+                        name: joint_name.clone(),
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect();
+
+    let mut gui = JointPositionSender {
+        robot_client,
+        robot: robot.into(),
+        current_joint_trajectory_client: joint_trajectory_client_names[0].clone(),
+        joint_trajectory_client_names,
+        pick_list: Default::default(),
+        scroll: Default::default(),
+        randomize_button: Default::default(),
+        center_button: Default::default(),
+        joint_states,
+    };
+
+    let joint_trajectory_client = gui.current_joint_trajectory_client();
+    for (index, position) in joint_trajectory_client
+        .current_joint_positions()?
+        .into_iter()
+        .enumerate()
+    {
+        gui.joint_states
+            .get_mut(&gui.current_joint_trajectory_client)
+            .unwrap()[index]
+            .position = position;
+    }
+
+    // Should we expose some of the settings to the user?
+    let settings = Settings {
+        flags: Some(gui),
+        window: window::Settings {
+            size: (400, 500),
+            ..window::Settings::default()
+        },
+        ..Settings::default()
+    };
+
+    JointPositionSender::run(settings)?;
+    Ok(())
+}
+
+struct JointPositionSender<S, M, N>
+where
+    S: Speaker + 'static,
+    M: MoveBase + 'static,
+    N: Navigation + 'static,
+{
+    robot_client: RobotClient<S, M, N>,
+    robot: Robot,
+
+    joint_trajectory_client_names: Vec<String>,
+    // pick list for joint_trajectory_clients
+    pick_list: pick_list::State<String>,
+    current_joint_trajectory_client: String,
+
+    scroll: scrollable::State,
+    randomize_button: button::State,
+    center_button: button::State,
+    // TODO: Currently, we have separate states for each joint_trajectory_client,
+    // but we initialize/update joint_positions based on current_joint_positions
+    // when joint_trajectory_client changed. Do we really need to separate state?
+    joint_states: HashMap<String, Vec<JointState>>,
+}
+
+impl<S, M, N> JointPositionSender<S, M, N>
+where
+    S: Speaker + 'static,
+    M: MoveBase + 'static,
+    N: Navigation + 'static,
+{
+    fn current_joint_trajectory_client(&self) -> Arc<dyn JointTrajectoryClient> {
+        self.robot_client.joint_trajectory_clients()[&self.current_joint_trajectory_client].clone()
+    }
+
+    fn current_joint_positions(&self) -> Vec<f64> {
+        self.joint_states[&self.current_joint_trajectory_client]
+            .iter()
+            .map(|joint| joint.position)
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    Ignore,
+    // Update all positions in current joint_trajectory_client
+    UpdateAll(Vec<f64>),
+    CenterButtonPressed,
+    RandomizeButtonPressed,
+    SliderChanged { index: usize, position: f64 },
+    TextInputChanged { index: usize, position: String },
+    PickListChanged(String),
+}
+
+impl<S, M, N> Application for JointPositionSender<S, M, N>
+where
+    S: Speaker + 'static,
+    M: MoveBase + 'static,
+    N: Navigation + 'static,
+{
+    type Executor = iced::executor::Default;
+    type Message = Message;
+    // wrap in option due to Self doesn't impl Deffault.
+    type Flags = Option<Self>;
+
+    fn new(flags: Self::Flags) -> (Self, Command<Message>) {
+        (flags.unwrap(), Command::none())
+    }
+
+    fn title(&self) -> String {
+        "Joint Position Sender".into()
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::Ignore => return Command::none(),
+            Message::PickListChanged(client_name) => {
+                self.current_joint_trajectory_client = client_name;
+                let joint_trajectory_client = self.current_joint_trajectory_client();
+                let len = joint_trajectory_client.joint_names().len();
+                return Command::perform(
+                    // Initializing joint_positions based on current_joint_positions.
+                    async move { joint_trajectory_client.current_joint_positions() },
+                    move |res| match res {
+                        Ok(positions) => Message::UpdateAll(positions),
+                        Err(e) => {
+                            error!("{}", e);
+                            // TODO: Decide how to handle errors.
+                            Message::UpdateAll(vec![Default::default(); len])
+                        }
+                    },
+                );
+            }
+            Message::UpdateAll(positions) => {
+                for (index, position) in positions.into_iter().enumerate() {
+                    self.joint_states
+                        .get_mut(&self.current_joint_trajectory_client)
+                        .unwrap()[index]
+                        .position = position;
+                }
+            }
+            Message::RandomizeButtonPressed => {
+                for joint_state in self
+                    .joint_states
+                    .get_mut(&self.current_joint_trajectory_client)
+                    .unwrap()
+                {
+                    let limit = &self.robot.joints[&joint_state.name].limit;
+                    joint_state.position = rand::thread_rng().gen_range(limit.lower..=limit.upper);
+                }
+            }
+            Message::CenterButtonPressed => {
+                for joint_state in self
+                    .joint_states
+                    .get_mut(&self.current_joint_trajectory_client)
+                    .unwrap()
+                {
+                    // TODO: is the center always 0.00?
+                    joint_state.position = 0.0;
+                }
+            }
+            Message::SliderChanged { index, position } => {
+                let joint_state = &mut self
+                    .joint_states
+                    .get_mut(&self.current_joint_trajectory_client)
+                    .unwrap()[index];
+                if (position * 100.0) as i64 == (joint_state.position * 100.0) as i64 {
+                    // Ignore if the position has not changed at all.
+                    return Command::none();
+                }
+                joint_state.position = position;
+            }
+            Message::TextInputChanged { index, position } => match position.parse::<f64>() {
+                Ok(position) => {
+                    // round position: https://stackoverflow.com/questions/28655362/how-does-one-round-a-floating-point-number-to-a-specified-number-of-digits
+                    let position = format!("{:.2}", position);
+                    let position = position.parse::<f64>().unwrap();
+
+                    let joint_state = &mut self
+                        .joint_states
+                        .get_mut(&self.current_joint_trajectory_client)
+                        .unwrap()[index];
+                    let limit = &self.robot.joints[&joint_state.name].limit;
+                    if (position * 100.0) as i64 == (joint_state.position * 100.0) as i64 {
+                        // Ignore if the position has not changed at all.
+                        return Command::none();
+                    }
+                    if (limit.lower..=limit.upper).contains(&position) {
+                        joint_state.position = position;
+                    } else {
+                        warn!(
+                            "out of limit (ignored): input = {:.2}, limit {:.2}..={:.2}",
+                            position, limit.lower, limit.upper
+                        );
+                        return Command::none();
+                    }
+                }
+                Err(e) => {
+                    warn!(
+                        "invalid input (ignored): input = {}, error = {}",
+                        position, e
+                    );
+                    return Command::none();
+                }
+            },
+        }
+
+        let joint_positions = self.current_joint_positions();
+        let joint_trajectory_client = self.current_joint_trajectory_client();
+        debug!("send_joint_positions: {:?}", joint_positions);
+        Command::perform(
+            async move {
+                joint_trajectory_client
+                    .send_joint_positions(joint_positions, Duration::from_nanos(1))
+                    .await
+            },
+            |res| match res {
+                Ok(()) => Message::Ignore,
+                Err(e) => {
+                    error!("{}", e);
+                    // TODO: Decide how to handle errors.
+                    Message::Ignore
+                }
+            },
+        )
+    }
+
+    fn view(&mut self) -> Element<Message> {
+        let pick_list = if self.joint_trajectory_client_names.len() > 1 {
+            let pick_list = PickList::new(
+                &mut self.pick_list,
+                &self.joint_trajectory_client_names,
+                Some(self.current_joint_trajectory_client.clone()),
+                Message::PickListChanged,
+            )
+            .style(THEME)
+            .width(Length::Fill);
+            Some(pick_list)
+        } else {
+            None
+        };
+
+        let randomize_button = Button::new(
+            &mut self.randomize_button,
+            Text::new("Randomize")
+                .horizontal_alignment(HorizontalAlignment::Center)
+                .width(Length::Fill),
+        )
+        .padding(10)
+        .on_press(Message::RandomizeButtonPressed)
+        .style(THEME)
+        .width(Length::Fill);
+
+        let center_button = Button::new(
+            &mut self.center_button,
+            Text::new("Center")
+                .horizontal_alignment(HorizontalAlignment::Center)
+                .width(Length::Fill),
+        )
+        .padding(10)
+        .on_press(Message::CenterButtonPressed)
+        .style(THEME)
+        .width(Length::Fill);
+
+        let mut sliders = Scrollable::new(&mut self.scroll).style(THEME);
+        for (index, joint_state) in self
+            .joint_states
+            .get_mut(&self.current_joint_trajectory_client)
+            .unwrap()
+            .iter_mut()
+            .enumerate()
+        {
+            let limit = &self.robot.joints[&joint_state.name].limit;
+            let slider = Slider::new(
+                &mut joint_state.slider,
+                // TODO: tests continuous joints, which range from -Pi to +Pi.
+                limit.lower..=limit.upper,
+                joint_state.position,
+                move |position| Message::SliderChanged { index, position },
+            )
+            .style(THEME)
+            .step(0.01);
+
+            let joint_name = Text::new(&self.robot.joints[&joint_state.name].name)
+                .horizontal_alignment(HorizontalAlignment::Left)
+                .width(Length::Fill);
+
+            // TODO: set horizontal_alignment on TextInput, once https://github.com/hecrj/iced/pull/373 merged and released.
+            let current_position = TextInput::new(
+                &mut joint_state.text_input,
+                "",
+                &format!("{:.2}", joint_state.position),
+                move |position| Message::TextInputChanged { index, position },
+            )
+            .style(THEME);
+
+            let content = Column::new()
+                .push(Row::new().push(joint_name).push(current_position))
+                .push(slider);
+            sliders = sliders.push(content);
+        }
+
+        let mut content = Column::new().spacing(20).padding(20).max_width(400);
+        if let Some(pick_list) = pick_list {
+            content = content.push(pick_list);
+        }
+        content = content
+            .push(randomize_button)
+            .push(center_button)
+            .push(sliders)
+            .height(Length::Fill);
+
+        Container::new(content)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .center_x()
+            .center_y()
+            .style(THEME)
+            .into()
+    }
+}

--- a/openrr-gui/src/lib.rs
+++ b/openrr-gui/src/lib.rs
@@ -1,0 +1,6 @@
+mod error;
+mod joint_position_sender;
+mod style;
+
+pub use error::*;
+pub use joint_position_sender::*;

--- a/openrr-gui/src/style.rs
+++ b/openrr-gui/src/style.rs
@@ -1,0 +1,362 @@
+// TODO: It's painful to recompile this crate every time I change the style.
+// So remove and replace with https://github.com/taiki-e/iced_style_config or alternatives.
+
+// Based on https://github.com/hecrj/iced/blob/d1c4239ac7ffdf299e4f9fae36406361cfef9267/examples/styling/src/main.rs#L269-L535
+
+use iced::{
+    button, checkbox, container, pick_list, progress_bar, radio, rule, scrollable, slider,
+    text_input, Color,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Theme;
+
+impl From<Theme> for Box<dyn container::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        Container.into()
+    }
+}
+
+impl From<Theme> for Box<dyn radio::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        Radio.into()
+    }
+}
+
+impl From<Theme> for Box<dyn text_input::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        TextInput.into()
+    }
+}
+
+impl From<Theme> for Box<dyn button::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        Button.into()
+    }
+}
+
+impl From<Theme> for Box<dyn scrollable::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        Scrollable.into()
+    }
+}
+
+impl From<Theme> for Box<dyn slider::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        Slider.into()
+    }
+}
+
+impl From<Theme> for Box<dyn progress_bar::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        ProgressBar.into()
+    }
+}
+
+impl From<Theme> for Box<dyn checkbox::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        Checkbox.into()
+    }
+}
+
+impl From<Theme> for Box<dyn rule::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        Rule.into()
+    }
+}
+
+impl From<Theme> for Box<dyn pick_list::StyleSheet> {
+    fn from(_: Theme) -> Self {
+        PickList.into()
+    }
+}
+
+const SURFACE: Color = Color::from_rgb(
+    0x40 as f32 / 255.0,
+    0x44 as f32 / 255.0,
+    0x4B as f32 / 255.0,
+);
+
+const ACCENT: Color = Color::from_rgb(
+    0x6F as f32 / 255.0,
+    0xFF as f32 / 255.0,
+    0xE9 as f32 / 255.0,
+);
+
+const ACTIVE: Color = Color::from_rgb(
+    0x72 as f32 / 255.0,
+    0x89 as f32 / 255.0,
+    0xDA as f32 / 255.0,
+);
+
+const HOVERED: Color = Color::from_rgb(
+    0x67 as f32 / 255.0,
+    0x7B as f32 / 255.0,
+    0xC4 as f32 / 255.0,
+);
+
+pub struct Container;
+
+impl container::StyleSheet for Container {
+    fn style(&self) -> container::Style {
+        container::Style {
+            background: Color::from_rgb8(0x36, 0x39, 0x3F).into(),
+            text_color: Color::WHITE.into(),
+            ..container::Style::default()
+        }
+    }
+}
+
+pub struct Radio;
+
+impl radio::StyleSheet for Radio {
+    fn active(&self) -> radio::Style {
+        radio::Style {
+            background: SURFACE.into(),
+            dot_color: ACTIVE,
+            border_width: 1.0,
+            border_color: ACTIVE,
+        }
+    }
+
+    fn hovered(&self) -> radio::Style {
+        radio::Style {
+            background: Color { a: 0.5, ..SURFACE }.into(),
+            ..self.active()
+        }
+    }
+}
+
+pub struct TextInput;
+
+impl text_input::StyleSheet for TextInput {
+    fn active(&self) -> text_input::Style {
+        text_input::Style {
+            background: SURFACE.into(),
+            border_radius: 2.0,
+            border_width: 0.0,
+            border_color: Color::TRANSPARENT,
+        }
+    }
+
+    fn focused(&self) -> text_input::Style {
+        text_input::Style {
+            border_width: 1.0,
+            border_color: ACCENT,
+            ..self.active()
+        }
+    }
+
+    fn hovered(&self) -> text_input::Style {
+        text_input::Style {
+            border_width: 1.0,
+            border_color: Color { a: 0.3, ..ACCENT },
+            ..self.focused()
+        }
+    }
+
+    fn placeholder_color(&self) -> Color {
+        Color::from_rgb(0.4, 0.4, 0.4)
+    }
+
+    fn value_color(&self) -> Color {
+        Color::WHITE
+    }
+
+    fn selection_color(&self) -> Color {
+        ACTIVE
+    }
+}
+
+pub struct Button;
+
+impl button::StyleSheet for Button {
+    fn active(&self) -> button::Style {
+        button::Style {
+            background: ACTIVE.into(),
+            border_radius: 3.0,
+            text_color: Color::WHITE,
+            ..button::Style::default()
+        }
+    }
+
+    fn hovered(&self) -> button::Style {
+        button::Style {
+            background: HOVERED.into(),
+            text_color: Color::WHITE,
+            ..self.active()
+        }
+    }
+
+    fn pressed(&self) -> button::Style {
+        button::Style {
+            border_width: 1.0,
+            border_color: Color::WHITE,
+            ..self.hovered()
+        }
+    }
+}
+
+pub struct Scrollable;
+
+impl scrollable::StyleSheet for Scrollable {
+    fn active(&self) -> scrollable::Scrollbar {
+        scrollable::Scrollbar {
+            background: SURFACE.into(),
+            border_radius: 2.0,
+            border_width: 0.0,
+            border_color: Color::TRANSPARENT,
+            scroller: scrollable::Scroller {
+                color: ACTIVE,
+                border_radius: 2.0,
+                border_width: 0.0,
+                border_color: Color::TRANSPARENT,
+            },
+        }
+    }
+
+    fn hovered(&self) -> scrollable::Scrollbar {
+        let active = self.active();
+
+        scrollable::Scrollbar {
+            background: Color { a: 0.5, ..SURFACE }.into(),
+            scroller: scrollable::Scroller {
+                color: HOVERED,
+                ..active.scroller
+            },
+            ..active
+        }
+    }
+
+    fn dragging(&self) -> scrollable::Scrollbar {
+        let hovered = self.hovered();
+
+        scrollable::Scrollbar {
+            scroller: scrollable::Scroller {
+                color: Color::from_rgb(0.85, 0.85, 0.85),
+                ..hovered.scroller
+            },
+            ..hovered
+        }
+    }
+}
+
+pub struct Slider;
+
+impl slider::StyleSheet for Slider {
+    fn active(&self) -> slider::Style {
+        slider::Style {
+            rail_colors: (ACTIVE, Color { a: 0.1, ..ACTIVE }),
+            handle: slider::Handle {
+                shape: slider::HandleShape::Circle { radius: 9.0 },
+                color: ACTIVE,
+                border_width: 0.0,
+                border_color: Color::TRANSPARENT,
+            },
+        }
+    }
+
+    fn hovered(&self) -> slider::Style {
+        let active = self.active();
+
+        slider::Style {
+            handle: slider::Handle {
+                color: HOVERED,
+                ..active.handle
+            },
+            ..active
+        }
+    }
+
+    fn dragging(&self) -> slider::Style {
+        let active = self.active();
+
+        slider::Style {
+            handle: slider::Handle {
+                color: Color::from_rgb(0.85, 0.85, 0.85),
+                ..active.handle
+            },
+            ..active
+        }
+    }
+}
+
+pub struct ProgressBar;
+
+impl progress_bar::StyleSheet for ProgressBar {
+    fn style(&self) -> progress_bar::Style {
+        progress_bar::Style {
+            background: SURFACE.into(),
+            bar: ACTIVE.into(),
+            border_radius: 10.0,
+        }
+    }
+}
+
+pub struct Checkbox;
+
+impl checkbox::StyleSheet for Checkbox {
+    fn active(&self, is_checked: bool) -> checkbox::Style {
+        checkbox::Style {
+            background: if is_checked { ACTIVE } else { SURFACE }.into(),
+            checkmark_color: Color::WHITE,
+            border_radius: 2.0,
+            border_width: 1.0,
+            border_color: ACTIVE,
+        }
+    }
+
+    fn hovered(&self, is_checked: bool) -> checkbox::Style {
+        checkbox::Style {
+            background: Color {
+                a: 0.8,
+                ..if is_checked { ACTIVE } else { SURFACE }
+            }
+            .into(),
+            ..self.active(is_checked)
+        }
+    }
+}
+
+pub struct Rule;
+
+impl rule::StyleSheet for Rule {
+    fn style(&self) -> rule::Style {
+        rule::Style {
+            color: SURFACE,
+            width: 2,
+            radius: 1.0,
+            fill_mode: rule::FillMode::Padded(15),
+        }
+    }
+}
+
+pub struct PickList;
+
+impl pick_list::StyleSheet for PickList {
+    fn menu(&self) -> pick_list::Menu {
+        pick_list::Menu {
+            background: SURFACE.into(),
+            border_width: 0.0,
+            text_color: Color::WHITE,
+            selected_background: HOVERED.into(),
+            ..Default::default()
+        }
+    }
+
+    fn active(&self) -> pick_list::Style {
+        pick_list::Style {
+            background: ACTIVE.into(),
+            text_color: Color::WHITE,
+            border_width: 0.0,
+            ..Default::default()
+        }
+    }
+
+    fn hovered(&self) -> pick_list::Style {
+        pick_list::Style {
+            background: HOVERED.into(),
+            ..self.active()
+        }
+    }
+}


### PR DESCRIPTION
## Library

### APIs

```rust
/// Launches GUI that send joint positions from GUI to the given `robot_client`.
pub fn joint_position_sender<S, M, N>(
    robot_client: RobotClient<S, M, N>, 
    urdf: impl AsRef<Path>,
) -> Result<(), Error> { /* ... */ }

pub enum Error { /* ... */ }
```

### Example

```rust
use log::debug;
use openrr_apps::RobotConfig;
use openrr_client::BoxRobotClient;
use openrr_gui::joint_position_sender;
use structopt::StructOpt;

#[derive(StructOpt, Debug)]
struct Opt {
    config_path: String,
    urdf_path: String,
}

fn main() -> anyhow::Result<()> {
    env_logger::init();
    let opt = Opt::from_args();
    debug!("opt: {:?}", opt);
    let config = RobotConfig::try_new(&opt.config_path)?;
    let client: BoxRobotClient = config.create_robot_client()?;

    joint_position_sender(client, opt.urdf_path)?;
    Ok(())
}
```

## GUI

### Example

- Launch urdf-viz.

  ```bash
  urdf-viz ./openrr-planner/sample.urdf
  ```

- Launch joint_position_sender.

  ```bash
  cargo run -p openrr-gui --example joint_position_sender -- \
    ./openrr-apps/config/sample_robot_client_config_for_command_urdf_viz.toml \
    ./openrr-planner/sample.urdf
  ```

  or

  ```bash
  cargo build --release -p openrr-gui --example joint_position_sender
  ./target/release/examples/joint_position_sender \
    ./openrr-apps/config/sample_robot_client_config_for_command_urdf_viz.toml \
    ./openrr-planner/sample.urdf
  ```

https://user-images.githubusercontent.com/43724913/105806527-81851a00-5fe7-11eb-89da-b221c51b4c55.mov

Closes #76
