### PR TITLE
Use #[non_exhaustive] on Error enums

### DIFF
--- a/arci-ros/src/error.rs
+++ b/arci-ros/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("arci_ros: No joint_state is available")]
     NoJointStateAvailable,

--- a/arci/src/error.rs
+++ b/arci/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("arci: {:?}", .0)]
     InterpolationError(String),

--- a/openrr-apps/src/error.rs
+++ b/openrr-apps/src/error.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("openrr-apps: No ConfigPath is specified.")]
     NoConfigPath,

--- a/openrr-client/src/error.rs
+++ b/openrr-client/src/error.rs
@@ -3,6 +3,7 @@ use thiserror::Error;
 use urdf_rs::UrdfError;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("openrr-cleint: No JointTrajectoryClient={} is found.", .0)]
     NoJointTrajectoryClient(String),

--- a/openrr-command/src/error.rs
+++ b/openrr-command/src/error.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("openrr-client: No IkClient={} is found.", .0)]
     NoIkClient(String),

--- a/openrr-planner/src/errors.rs
+++ b/openrr-planner/src/errors.rs
@@ -23,8 +23,9 @@ pub enum CollisionPart {
     End,
 }
 
-#[derive(Debug, Error)]
 /// Error for `openrr_planner`
+#[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("{}", error)]
     Other { error: String },


### PR DESCRIPTION
This allows avoiding breakage due to adding new variants.

Refs: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute