### PR TITLE
[arci-urdf-viz] send_joint_positions in one thread

### DIFF
--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 anyhow = "1.0"
 arci = { version = "0.0.1", path = "../arci" }
 async-trait = "0.1"
+log = "0.4"
 nalgebra = "0.23"
 openrr-planner = { version = "0.0.1", default-features = false }
 openrr-sleep = { version = "0.0.1", path = "../openrr-sleep" }

--- a/arci-urdf-viz/src/client.rs
+++ b/arci-urdf-viz/src/client.rs
@@ -4,12 +4,18 @@ use arci::{
     Navigation, SetCompleteCondition, TotalJointDiffCondition,
 };
 use async_trait::async_trait;
+use log::debug;
 use nalgebra as na;
 use openrr_sleep::ScopedSleep;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread::{sleep, JoinHandle},
+    time::Duration,
 };
 use url::Url;
 
@@ -32,6 +38,7 @@ pub fn create_joint_trajectory_clients(
         total_complete_allowable_error,
         complete_timeout_sec,
     )));
+    all_client.run_send_joint_positions_thread();
     let all_client = Arc::new(all_client);
     for config in configs {
         let client =
@@ -49,22 +56,34 @@ pub fn create_joint_trajectory_clients(
     clients
 }
 
+struct SendJointPositionsTarget {
+    positions: Vec<f64>,
+    duration: Duration,
+}
+
 pub struct UrdfVizWebClient {
     base_url: Url,
     joint_names: Vec<String>,
     velocity: Arc<Mutex<BaseVelocity>>,
+    send_joint_positions_target: Arc<Mutex<Option<SendJointPositionsTarget>>>,
     complete_condition: Box<dyn CompleteCondition>,
+    send_joint_positions_thread: Option<JoinHandle<()>>,
+    is_dropping: Arc<AtomicBool>,
 }
 
 impl UrdfVizWebClient {
     pub fn try_new(base_url: Url) -> Result<Self, anyhow::Error> {
         let joint_state = get_joint_positions(&base_url)?;
         let velocity = Arc::new(Mutex::new(BaseVelocity::default()));
+        let send_joint_positions_target = Arc::new(Mutex::new(None));
         Ok(Self {
             base_url,
             joint_names: joint_state.names,
             velocity,
+            send_joint_positions_target,
             complete_condition: Box::new(TotalJointDiffCondition::default()),
+            send_joint_positions_thread: None,
+            is_dropping: Arc::new(AtomicBool::new(false)),
         })
     }
     pub fn run_thread(&self) {
@@ -83,6 +102,77 @@ impl UrdfVizWebClient {
             pose.quaternion = quaternion_from_euler_angles(rpy.0, rpy.1, rpy.2);
             send_robot_origin(&base_url, pose).unwrap();
         });
+    }
+    pub fn run_send_joint_positions_thread(&mut self) {
+        if self.send_joint_positions_thread.is_some() {
+            panic!("send_joint_positions_thread is running.");
+        }
+        let send_joint_positions_target_arc_mutex = self.send_joint_positions_target.clone();
+        let base_url = self.base_url.clone();
+        let joint_names = self.joint_names.clone();
+        let is_dropping_arc_mutex = self.is_dropping.clone();
+
+        self.send_joint_positions_thread = Some(std::thread::spawn(move || {
+            while !is_dropping_arc_mutex.load(Ordering::Relaxed) {
+                const UNIT_DURATION: Duration = Duration::from_millis(10);
+                let send_joint_positions_target =
+                    { send_joint_positions_target_arc_mutex.lock().unwrap().take() };
+                if let Some(target) = send_joint_positions_target {
+                    let current = get_joint_positions(&base_url)
+                        .map_err(|e| arci::Error::Connection {
+                            message: format!("{:?}", e),
+                        })
+                        .unwrap()
+                        .positions;
+                    let duration_sec = target.duration.as_secs_f64();
+                    let unit_sec = UNIT_DURATION.as_secs_f64();
+                    let trajectories = openrr_planner::interpolate(
+                        &[current, target.positions.to_vec()],
+                        duration_sec,
+                        unit_sec,
+                    )
+                    .ok_or_else(|| arci::Error::InterpolationError("".to_owned()))
+                    .unwrap();
+
+                    for traj in trajectories {
+                        if send_joint_positions_target_arc_mutex
+                            .lock()
+                            .unwrap()
+                            .is_some()
+                        {
+                            debug!("Abort old target.");
+                            break;
+                        }
+                        let start_time = std::time::Instant::now();
+                        let target_state = JointState {
+                            names: joint_names.clone(),
+                            positions: traj.position,
+                        };
+                        send_joint_positions(&base_url, target_state)
+                            .map_err(|e| arci::Error::Connection {
+                                message: format!("{:?}", e),
+                            })
+                            .unwrap();
+                        let elapsed = start_time.elapsed();
+                        if UNIT_DURATION > elapsed {
+                            let sleep_duration = UNIT_DURATION - elapsed;
+                            sleep(sleep_duration);
+                        }
+                    }
+                } else {
+                    sleep(UNIT_DURATION);
+                }
+            }
+        }));
+    }
+}
+
+impl Drop for UrdfVizWebClient {
+    fn drop(&mut self) {
+        if let Some(t) = self.send_joint_positions_thread.take() {
+            self.is_dropping.swap(true, Ordering::Relaxed);
+            t.join().unwrap();
+        }
     }
 }
 
@@ -107,40 +197,14 @@ impl JointTrajectoryClient for UrdfVizWebClient {
     async fn send_joint_positions(
         &self,
         positions: Vec<f64>,
-        duration: std::time::Duration,
+        duration: Duration,
     ) -> Result<(), arci::Error> {
-        const UNIT_DURATION: std::time::Duration = std::time::Duration::from_millis(10);
-        let current = self.current_joint_positions()?;
-        let duration_sec = duration.as_secs_f64();
-        let unit_sec = UNIT_DURATION.as_secs_f64();
-        let trajectories =
-            openrr_planner::interpolate(&[current, positions.to_vec()], duration_sec, unit_sec)
-                .ok_or_else(|| arci::Error::InterpolationError("".to_owned()))?;
-
-        let url = self.base_url.clone();
-        let joint_names = self.joint_names.clone();
-        let _handle = std::thread::spawn(move || {
-            for traj in trajectories {
-                let start_time = std::time::Instant::now();
-                let target_state = JointState {
-                    names: joint_names.clone(),
-                    positions: traj.position,
-                };
-                let re = send_joint_positions(&url, target_state).map_err(|e| {
-                    arci::Error::Connection {
-                        message: format!("{:?}", e),
-                    }
-                })?;
-                if !re.is_ok {
-                    return Err(arci::Error::Connection { message: re.reason });
-                }
-                let elapsed = start_time.elapsed();
-                if UNIT_DURATION > elapsed {
-                    let sleep_duration = UNIT_DURATION - elapsed;
-                    std::thread::sleep(sleep_duration);
-                }
-            }
-            Ok(())
+        if self.send_joint_positions_thread.is_none() {
+            panic!("Call run_joint_positions_thread.");
+        }
+        *self.send_joint_positions_target.lock().unwrap() = Some(SendJointPositionsTarget {
+            positions: positions.clone(),
+            duration,
         });
         self.complete_condition.wait(self, &positions)
     }
@@ -149,7 +213,7 @@ impl JointTrajectoryClient for UrdfVizWebClient {
         &self,
         trajectory: Vec<arci::TrajectoryPoint>,
     ) -> Result<(), arci::Error> {
-        let mut last_time = std::time::Duration::default();
+        let mut last_time = Duration::default();
         for traj in trajectory {
             self.send_joint_positions(traj.positions, traj.time_from_start - last_time)
                 .await?;
@@ -165,7 +229,7 @@ impl Navigation for UrdfVizWebClient {
         &self,
         goal: na::Isometry2<f64>,
         _frame_id: &str,
-        _timeout: std::time::Duration,
+        _timeout: Duration,
     ) -> Result<(), arci::Error> {
         // JUMP!
         let re = send_robot_origin(&self.base_url, goal.into()).map_err(|e| {

--- a/arci-urdf-viz/tests/test_client.rs
+++ b/arci-urdf-viz/tests/test_client.rs
@@ -128,9 +128,10 @@ async fn test_send_joint_positions() {
     }));
     std::thread::spawn(move || web_server.start());
     std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
-    let client =
+    let mut client =
         UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
             .unwrap();
+    client.run_send_joint_positions_thread();
     let result = client
         .send_joint_positions(vec![0.0], std::time::Duration::from_secs(1))
         .await;
@@ -147,13 +148,14 @@ async fn test_send_joint_trajectory() {
     }));
     std::thread::spawn(move || web_server.start());
     std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
-    let client =
+    let mut client =
         UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
             .unwrap();
     let trajectory = vec![
         TrajectoryPoint::new(vec![0.0], std::time::Duration::from_millis(100)),
         TrajectoryPoint::new(vec![0.0], std::time::Duration::from_millis(200)),
     ];
+    client.run_send_joint_positions_thread();
     let result = client.send_joint_trajectory(trajectory).await;
     assert!(result.is_ok());
 }


### PR DESCRIPTION
- to avoid multiple spawning of send_joint_positions thread.
- to follow latest target.