### PR TITLE
[openrr-client] Add LocalMove

### DIFF
--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -18,6 +18,7 @@ k = { version = "0.22.1", features = ["serde-serialize"] }
 openrr-planner = "0.0.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+toml = "0.5"
 tracing = { version = "0.1", features = ["log"] }
 urdf-rs = "0.6"
 

--- a/openrr-client/src/clients.rs
+++ b/openrr-client/src/clients.rs
@@ -2,10 +2,12 @@ mod chain_wrapper;
 mod collision_avoid_client;
 mod collision_check_client;
 mod ik_client;
+mod local_move;
 mod print_speaker;
 
 pub use chain_wrapper::*;
 pub use collision_avoid_client::*;
 pub use collision_check_client::*;
 pub use ik_client::*;
+pub use local_move::*;
 pub use print_speaker::*;

--- a/openrr-client/src/clients/local_move.rs
+++ b/openrr-client/src/clients/local_move.rs
@@ -51,12 +51,12 @@ impl LocalMove {
             && pose_error.rotation.angle().abs() < self.config.reach_angle_threshold
     }
 
-    pub fn send_zero_vel(&self) -> Result<(), arci::Error> {
+    pub fn send_zero_velocity(&self) -> Result<(), arci::Error> {
         self.vel_client
             .send_velocity(&BaseVelocity::new(0.0, 0.0, 0.0))
     }
 
-    pub fn send_control_vel_from_pose_error(
+    pub fn send_control_velocity_from_pose_error(
         &self,
         pose_error: Isometry2<f64>,
     ) -> Result<(), arci::Error> {
@@ -127,7 +127,7 @@ mod tests {
 
         // Set control velocity
         local_move
-            .send_control_vel_from_pose_error(Isometry2::new(Vector2::new(1.0, -1.0), 1.0))
+            .send_control_velocity_from_pose_error(Isometry2::new(Vector2::new(1.0, -1.0), 1.0))
             .unwrap();
         let vel0 = local_move.vel_client.current_velocity().unwrap();
         assert_eq!(vel0.x, 1.0); // linear_gain = 1.0
@@ -135,7 +135,7 @@ mod tests {
         assert_eq!(vel0.theta, 1.0); // angular_gain = 1.0
 
         local_move
-            .send_control_vel_from_pose_error(Isometry2::new(Vector2::new(2.0, -2.0), 2.0))
+            .send_control_velocity_from_pose_error(Isometry2::new(Vector2::new(2.0, -2.0), 2.0))
             .unwrap(); // saturated case
         let vel1 = local_move.vel_client.current_velocity().unwrap();
         assert_eq!(vel1.x, 1.0); // max_linear_vel = 1.0
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(vel1.theta, 1.0); // max_angular_vel = 1.0
 
         // Set zero velocity
-        local_move.send_zero_vel().unwrap();
+        local_move.send_zero_velocity().unwrap();
         let vel2 = local_move.vel_client.current_velocity().unwrap();
         assert_eq!(vel2.x, 0.0);
         assert_eq!(vel2.y, 0.0);

--- a/openrr-client/src/clients/local_move.rs
+++ b/openrr-client/src/clients/local_move.rs
@@ -1,0 +1,152 @@
+use arci::{BaseVelocity, MoveBase, Navigation};
+use k::nalgebra as na;
+use na::Isometry2;
+use serde::{Deserialize, Serialize};
+
+use crate::Error;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LocalMoveConfig {
+    pub reach_distance_threshold: f64,
+    pub reach_angle_threshold: f64,
+    pub control_frequency: f64,
+    pub linear_gain: f64,
+    pub angular_gain: f64,
+    pub max_linear_vel: f64,
+    pub max_angular_vel: f64,
+}
+
+impl LocalMoveConfig {
+    pub fn try_new<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
+        let config: LocalMoveConfig = toml::from_str(
+            &std::fs::read_to_string(&path)
+                .map_err(|e| Error::NoFile(path.as_ref().to_owned(), e))?,
+        )
+        .map_err(|e| Error::TomlParseFailure(path.as_ref().to_owned(), e))?;
+        Ok(config)
+    }
+}
+
+pub struct LocalMove {
+    pub nav_client: Box<dyn Navigation>,
+    pub vel_client: Box<dyn MoveBase>,
+    pub config: LocalMoveConfig,
+}
+
+impl LocalMove {
+    pub fn new(
+        nav_client: Box<dyn Navigation>,
+        vel_client: Box<dyn MoveBase>,
+        config: LocalMoveConfig,
+    ) -> Self {
+        Self {
+            nav_client,
+            vel_client,
+            config,
+        }
+    }
+
+    pub fn is_reached(&self, pose_error: Isometry2<f64>) -> bool {
+        pose_error.translation.vector.norm() < self.config.reach_distance_threshold
+            && pose_error.rotation.angle().abs() < self.config.reach_angle_threshold
+    }
+
+    pub fn send_zero_vel(&self) -> Result<(), arci::Error> {
+        self.vel_client
+            .send_velocity(&BaseVelocity::new(0.0, 0.0, 0.0))
+    }
+
+    pub fn send_control_vel_from_pose_error(
+        &self,
+        pose_error: Isometry2<f64>,
+    ) -> Result<(), arci::Error> {
+        // Calculate control velocity
+        // NOTE: pose_error = pose_reference - pose_current
+        let vel_x = na::clamp(
+            self.config.linear_gain * pose_error.translation.vector[0],
+            -self.config.max_linear_vel,
+            self.config.max_linear_vel,
+        );
+        let vel_y = na::clamp(
+            self.config.linear_gain * pose_error.translation.vector[1],
+            -self.config.max_linear_vel,
+            self.config.max_linear_vel,
+        );
+        let vel_theta = na::clamp(
+            self.config.angular_gain * pose_error.rotation.angle(),
+            -self.config.max_angular_vel,
+            self.config.max_angular_vel,
+        );
+
+        self.vel_client
+            .send_velocity(&BaseVelocity::new(vel_x, vel_y, vel_theta))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arci::{DummyMoveBase, DummyNavigation};
+    use na::Vector2;
+    #[test]
+    fn test_config() {
+        let path = std::path::Path::new("tests/local_move_sample.toml");
+        let config = LocalMoveConfig::try_new(path).unwrap();
+        assert_eq!(config.reach_distance_threshold, 0.1);
+        assert_eq!(config.control_frequency, 10.0);
+        assert_eq!(config.linear_gain, 1.0);
+        assert_eq!(config.max_linear_vel, 1.0);
+    }
+
+    #[test]
+    fn test() {
+        let path = std::path::Path::new("tests/local_move_sample.toml");
+        let config = LocalMoveConfig::try_new(path).unwrap();
+        assert_eq!(config.linear_gain, 1.0);
+        let move_base = DummyMoveBase::new();
+        let nav = DummyNavigation::new();
+        let local_move = LocalMove::new(Box::new(nav), Box::new(move_base), config);
+
+        // Check convergence evaluations
+        assert_eq!(
+            local_move.is_reached(Isometry2::new(Vector2::new(0.0, 0.0), 0.0)),
+            true
+        );
+        assert_eq!(
+            local_move.is_reached(Isometry2::new(Vector2::new(0.05, 0.05), 0.05)),
+            true
+        );
+        assert_eq!(
+            local_move.is_reached(Isometry2::new(Vector2::new(0.11, 0.0), 0.0)),
+            false
+        ); // reach_distance_threshold = 0.1
+        assert_eq!(
+            local_move.is_reached(Isometry2::new(Vector2::new(0.0, 0.0), 0.11)),
+            false
+        ); // reach_angle_threshold = 0.1
+
+        // Set control velocity
+        local_move
+            .send_control_vel_from_pose_error(Isometry2::new(Vector2::new(1.0, -1.0), 1.0))
+            .unwrap();
+        let vel0 = local_move.vel_client.current_velocity().unwrap();
+        assert_eq!(vel0.x, 1.0); // linear_gain = 1.0
+        assert_eq!(vel0.y, -1.0); // linear_gain = 1.0
+        assert_eq!(vel0.theta, 1.0); // angular_gain = 1.0
+
+        local_move
+            .send_control_vel_from_pose_error(Isometry2::new(Vector2::new(2.0, -2.0), 2.0))
+            .unwrap(); // saturated case
+        let vel1 = local_move.vel_client.current_velocity().unwrap();
+        assert_eq!(vel1.x, 1.0); // max_linear_vel = 1.0
+        assert_eq!(vel1.y, -1.0); // max_linear_vel = 1.0
+        assert_eq!(vel1.theta, 1.0); // max_angular_vel = 1.0
+
+        // Set zero velocity
+        local_move.send_zero_vel().unwrap();
+        let vel2 = local_move.vel_client.current_velocity().unwrap();
+        assert_eq!(vel2.x, 0.0);
+        assert_eq!(vel2.y, 0.0);
+        assert_eq!(vel2.theta, 0.0);
+    }
+}

--- a/openrr-client/src/clients/local_move.rs
+++ b/openrr-client/src/clients/local_move.rs
@@ -27,18 +27,22 @@ impl LocalMoveConfig {
     }
 }
 
-pub struct LocalMove {
-    pub nav_client: Box<dyn Navigation>,
-    pub vel_client: Box<dyn MoveBase>,
+pub struct LocalMove<N, M>
+where
+    N: Navigation,
+    M: MoveBase,
+{
+    pub nav_client: N,
+    pub vel_client: M,
     pub config: LocalMoveConfig,
 }
 
-impl LocalMove {
-    pub fn new(
-        nav_client: Box<dyn Navigation>,
-        vel_client: Box<dyn MoveBase>,
-        config: LocalMoveConfig,
-    ) -> Self {
+impl<N, M> LocalMove<N, M>
+where
+    N: Navigation,
+    M: MoveBase,
+{
+    pub fn new(nav_client: N, vel_client: M, config: LocalMoveConfig) -> Self {
         Self {
             nav_client,
             vel_client,

--- a/openrr-client/src/error.rs
+++ b/openrr-client/src/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     Arci(#[from] arci::Error),
     #[error("openrr-client: MismatchedLength {} != {}.", .0, .1)]
     MismatchedLength(usize, usize),
+    #[error("openrr-client: No File {:?} is found ({}).", .0, .1)]
+    NoFile(PathBuf, #[source] std::io::Error),
     #[error("openrr-client: No IkClient={} is found.", .0)]
     NoIkClient(String),
     #[error("openrr-client: No Joint={} is found.", .0)]
@@ -21,6 +23,8 @@ pub enum Error {
     NoParentDirectory(PathBuf),
     #[error("openrr-client: No UrdfPath is specified.")]
     NoUrdfPath,
+    #[error("openrr-client: Failed to parse {:?} as toml ({}).", .0, .1)]
+    TomlParseFailure(PathBuf, #[source] toml::de::Error),
     #[error("openrr-client: urdf-rs: {:?}", .0)]
     UrdfRs(#[from] UrdfError),
 }

--- a/openrr-client/src/error.rs
+++ b/openrr-client/src/error.rs
@@ -5,22 +5,22 @@ use urdf_rs::UrdfError;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
-    #[error("openrr-client: No JointTrajectoryClient={} is found.", .0)]
-    NoJointTrajectoryClient(String),
+    #[error("openrr-client: arci: {:?}", .0)]
+    Arci(#[from] arci::Error),
+    #[error("openrr-client: MismatchedLength {} != {}.", .0, .1)]
+    MismatchedLength(usize, usize),
     #[error("openrr-client: No IkClient={} is found.", .0)]
     NoIkClient(String),
     #[error("openrr-client: No Joint={} is found.", .0)]
     NoJoint(String),
-    #[error("openrr-client: MismatchedLength {} != {}.", .0, .1)]
-    MismatchedLength(usize, usize),
-    #[error("openrr-client: No UrdfPath is specified.")]
-    NoUrdfPath,
     #[error("openrr-client: No JointsPose {} {} is found.", .0, .1)]
     NoJointsPose(String, String),
+    #[error("openrr-client: No JointTrajectoryClient={} is found.", .0)]
+    NoJointTrajectoryClient(String),
     #[error("openrr-client: No ParentDirectory {:?} is found.", .0)]
     NoParentDirectory(PathBuf),
-    #[error("openrr-client: arci: {:?}", .0)]
-    Arci(#[from] arci::Error),
+    #[error("openrr-client: No UrdfPath is specified.")]
+    NoUrdfPath,
     #[error("openrr-client: urdf-rs: {:?}", .0)]
     UrdfRs(#[from] UrdfError),
 }

--- a/openrr-client/tests/local_move_sample.toml
+++ b/openrr-client/tests/local_move_sample.toml
@@ -1,0 +1,7 @@
+reach_distance_threshold = 0.1
+reach_angle_threshold = 0.1
+control_frequency = 10.0
+linear_gain = 1.0
+angular_gain = 1.0
+max_linear_vel = 1.0
+max_angular_vel = 1.0


### PR DESCRIPTION
This PR adds a struct to move robots to a goal directly.

The placement of the sample configuration file named `local_move_sample.toml`, which is used for tests, should be discussed.