### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,3 @@ members = [
 "openrr-planner" = {path = "openrr-planner"}
 "openrr-sleep" = {path = "openrr-sleep"}
 "openrr-teleop" = {path = "openrr-teleop"}
-
-# https://github.com/sebcrozet/kiss3d/issues/262
-kiss3d = { git = "https://github.com/sebcrozet/kiss3d", rev = "6274d50" }

--- a/arci-ros/Cargo.toml
+++ b/arci-ros/Cargo.toml
@@ -10,16 +10,16 @@ anyhow = "1.0"
 arci = { path = "../arci" }
 async-trait = "0.1"
 crossbeam-channel = "0.5.0"
-nalgebra = "0.23"
+nalgebra = "0.24"
 paste = "1.0"
-ros-nalgebra = "0.0.3"
+ros-nalgebra = "0.0.4"
 rosrust = "0.9"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-k = "0.21"
+k = "0.22"
 
 # for tests/utils (using same version of rosrust 0.9.5)
 

--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 arci = { version = "0.0.1", path = "../arci" }
 async-trait = "0.1"
 log = "0.4"
-nalgebra = "0.23"
+nalgebra = "0.24"
 openrr-planner = { version = "0.0.1", default-features = false }
 openrr-sleep = { version = "0.0.1", path = "../openrr-sleep" }
 serde = { version = "1.0", features = ["derive"] }
@@ -20,7 +20,7 @@ url = "2.0"
 
 [dev-dependencies]
 assert_approx_eq = "1.1"
-rouille = "2.1.0"
+rouille = "3.0"
 serde_derive = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 tokio-test = "0.4"

--- a/arci/Cargo.toml
+++ b/arci/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1"
 auto_impl = "0.4"
 futures = "0.3"
 log = "0.4"
-nalgebra = "0.23"
+nalgebra = "0.24"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -14,8 +14,8 @@ arci-gamepad-gilrs = { version = "0.0.1", path = "../arci-gamepad-gilrs" }
 arci-urdf-viz = { version = "0.0.1", path = "../arci-urdf-viz" }
 async-recursion = "0.3"
 async-trait = "0.1"
-env_logger = "0.7"
-k = "0.21"
+env_logger = "0.8"
+k = "0.22"
 log = "0.4"
 openrr-client = { version = "0.0.1", path = "../openrr-client" }
 openrr-command = { version = "0.0.1", path = "../openrr-command" }
@@ -25,7 +25,7 @@ structopt = "0.3.21"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 toml = "0.5"
-urdf-rs = "0.4.2"
+urdf-rs = "0.6"
 
 arci-ros = {version="0.0.1", optional = true}
 rand = {version="0.8.0", optional = true}

--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 anyhow = "1.0"
 arci = { version = "0.0.1", path = "../arci" }
 async-trait = "0.1"
-k = { version = "0.21", features = ["serde-serialize"] }
+k = { version = "0.22", features = ["serde-serialize"] }
 log = "0.4"
 openrr-planner = { version = "0.0.1", path = "../openrr-planner" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-urdf-rs = "0.4"
+urdf-rs = "0.6"
 
 [dev-dependencies]
 assert_approx_eq = "1.1"

--- a/openrr-client/src/clients/ik_client.rs
+++ b/openrr-client/src/clients/ik_client.rs
@@ -21,8 +21,8 @@ pub struct IkSolverParameters {
     pub num_max_try: usize,
 }
 
-pub fn create_jacobian_ik_solver(parameters: &IkSolverParameters) -> k::JacobianIKSolver<f64> {
-    k::JacobianIKSolver::new(
+pub fn create_jacobian_ik_solver(parameters: &IkSolverParameters) -> k::JacobianIkSolver<f64> {
+    k::JacobianIkSolver::new(
         parameters.allowable_position_error,
         parameters.allowable_angle_error,
         parameters.jacobian_multiplier,
@@ -32,7 +32,7 @@ pub fn create_jacobian_ik_solver(parameters: &IkSolverParameters) -> k::Jacobian
 
 pub fn create_random_jacobian_ik_solver(
     parameters: &IkSolverParameters,
-) -> openrr_planner::RandomInitializeIKSolver<f64, k::JacobianIKSolver<f64>> {
+) -> openrr_planner::RandomInitializeIKSolver<f64, k::JacobianIkSolver<f64>> {
     openrr_planner::RandomInitializeIKSolver::new(
         create_jacobian_ik_solver(parameters),
         parameters.num_max_try,

--- a/openrr-command/Cargo.toml
+++ b/openrr-command/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 arci = { version = "0.0.1", path = "../arci" }
 async-recursion = "0.3"
-k = "0.21"
+k = "0.22"
 log = "0.4"
 openrr-client = { version = "0.0.1", path = "../openrr-client" }
 structopt = "0.3.21"

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -12,7 +12,7 @@ log = "0.4"
 openrr-client = { version = "0.0.1", path = "../openrr-client" }
 rand = "0.8"
 thiserror = "1"
-urdf-rs = "0.4"
+urdf-rs = "0.6"
 
 [dev-dependencies]
 anyhow = "1"

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -15,18 +15,18 @@ default = [ "assimp" ]
 
 [dependencies]
 assimp = { version = "0.3", optional = true }
-k = "0.21"
+k = "0.22"
 log = "0.4"
-ncollide3d = "0.26"
+ncollide3d = "0.27"
 num-traits = "0.2"
-rand = "0.3.0"
+rand = "0.8"
 rrt = "0.4.0"
 thiserror = "1.0"
 trajectory = "0.0.1"
-urdf-rs = "0.4"
+urdf-rs = "0.6"
 
 [dev-dependencies]
-env_logger = "0.7"
-kiss3d = "0.28"
+env_logger = "0.8"
+kiss3d = "0.29"
 structopt = "0.3"
-urdf-viz = "0.22"
+urdf-viz = "0.23"

--- a/openrr-planner/README.md
+++ b/openrr-planner/README.md
@@ -22,7 +22,7 @@ fn main() {
         .collision_check_margin(0.01)
         .finalize();
     // Create inverse kinematics solver
-    let solver = openrr_planner::JacobianIKSolverBuilder::<f64>::new()
+    let solver = openrr_planner::JacobianIkSolverBuilder::<f64>::new()
         .num_max_try(1000)
         .allowable_target_distance(0.01)
         .move_epsilon(0.0001)

--- a/openrr-planner/examples/minimum.rs
+++ b/openrr-planner/examples/minimum.rs
@@ -26,7 +26,7 @@ fn main() {
         .collision_check_margin(0.01)
         .finalize();
     // Create inverse kinematics solver
-    let solver = openrr_planner::JacobianIKSolver::default();
+    let solver = openrr_planner::JacobianIkSolver::default();
     let solver = openrr_planner::RandomInitializeIKSolver::new(solver, 100);
     // Create path planner with IK solver
     let mut planner = openrr_planner::JointPathPlannerWithIK::new(planner, solver);

--- a/openrr-planner/examples/reach.rs
+++ b/openrr-planner/examples/reach.rs
@@ -23,7 +23,7 @@ use structopt::StructOpt;
 struct CollisionAvoidApp {
     planner: openrr_planner::JointPathPlannerWithIK<
         f64,
-        openrr_planner::RandomInitializeIKSolver<f64, openrr_planner::JacobianIKSolver<f64>>,
+        openrr_planner::RandomInitializeIKSolver<f64, openrr_planner::JacobianIkSolver<f64>>,
     >,
     obstacles: Compound<f64>,
     ik_target_pose: na::Isometry3<f64>,
@@ -51,7 +51,7 @@ impl CollisionAvoidApp {
             .unwrap()
             .collision_check_margin(0.01f64)
             .finalize();
-        let solver = openrr_planner::JacobianIKSolver::new(0.001f64, 0.005, 0.2, 100);
+        let solver = openrr_planner::JacobianIkSolver::new(0.001f64, 0.005, 0.2, 100);
         let solver = openrr_planner::RandomInitializeIKSolver::new(solver, 100);
         let planner = openrr_planner::JointPathPlannerWithIK::new(planner, solver);
         let mut viewer = urdf_viz::Viewer::new("openrr_planner: example reach");

--- a/openrr-planner/src/collision/urdf.rs
+++ b/openrr-planner/src/collision/urdf.rs
@@ -48,6 +48,9 @@ where
                 tri_mesh.uvs,
             )))
         }
+        urdf_rs::Geometry::Capsule { .. } => {
+            todo!()
+        }
         urdf_rs::Geometry::Sphere { radius } => {
             Some(ShapeHandle::new(Ball::new(na::convert(radius))))
         }
@@ -55,6 +58,7 @@ where
             ref filename,
             scale,
         } => {
+            let scale = scale.unwrap_or(DEFAULT_MESH_SCALE);
             let replaced_filename = urdf_rs::utils::expand_package_path(filename, base_dir);
             let path = Path::new(&replaced_filename);
             if !path.exists() {
@@ -71,3 +75,6 @@ where
         }
     }
 }
+
+// https://github.com/openrr/urdf-rs/pull/3/files#diff-0fb2eeea3273a4c9b3de69ee949567f546dc8c06b1e190336870d00b54ea0979L36-L38
+const DEFAULT_MESH_SCALE: [f64; 3] = [1.0f64; 3];

--- a/openrr-planner/src/ik.rs
+++ b/openrr-planner/src/ik.rs
@@ -148,7 +148,7 @@ mod tests {
         let target = target_link.world_transform().unwrap();
         println!("{:?}", target.translation);
         // Create IK solver with default settings
-        let solver = k::JacobianIKSolver::default();
+        let solver = k::JacobianIkSolver::default();
 
         // Create a set of joints from end joint
         let arm = k::SerialChain::from_end(target_link);

--- a/openrr-planner/src/lib.rs
+++ b/openrr-planner/src/lib.rs
@@ -34,4 +34,4 @@ mod planner;
 pub use planner::*;
 
 // re-export k::IK modules
-pub use k::{InverseKinematicsSolver, JacobianIKSolver};
+pub use k::{InverseKinematicsSolver, JacobianIkSolver};

--- a/openrr-planner/src/planner/ik_planner.rs
+++ b/openrr-planner/src/planner/ik_planner.rs
@@ -51,7 +51,7 @@ where
     ///     .collision_check_margin(0.01)
     ///     .finalize();
     /// // Create inverse kinematics solver
-    /// let solver = openrr_planner::JacobianIKSolver::default();
+    /// let solver = openrr_planner::JacobianIkSolver::default();
     /// // Create path planner with IK solver
     /// let _planner = openrr_planner::JointPathPlannerWithIK::new(planner, solver);
     /// ```

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 arci = {version="0.0.1", path="../arci"}
 async-trait = "0.1"
 auto_impl = "0.4.1"
-k = "0.21"
+k = "0.22"
 log = "0.4"
 openrr-client = { version = "0.0.1", path = "../openrr-client"}
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Closes #104

Blocked on:

- [x] urdf-rs: release v0.6; openrr/urdf-rs#12
- [x] k: update urdf-rs to 0.6; openrr/k#29
- [x] k: release v0.22; openrr/k#31
- [x] urdf-viz: update dependencies; openrr/urdf-viz#36
- [x] urdf-viz: release v0.23; openrr/urdf-viz#41
- [x] ros-nalgebra: update nalgebra to v0.24; openrr/ros-nalgebra#2
- [x] ros-nalgebra: release v0.0.4; openrr/ros-nalgebra#3
