### PR TITLE
[openrr-apps, openrr-gui] Move the application part of openrr-gui to openrr-apps

### DIFF
--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [features]
+default = ["gui"]
 ros = ["arci-ros", "rand"]
 gui = ["openrr-gui"]
 

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -7,8 +7,10 @@ license = "Apache-2.0"
 
 [features]
 ros = ["arci-ros", "rand"]
+gui = ["openrr-gui"]
 
 [dependencies]
+anyhow = "1.0"
 arci = { version = "0.0.1", path = "../arci" }
 arci-gamepad-gilrs = { version = "0.0.1", path = "../arci-gamepad-gilrs" }
 arci-urdf-viz = { version = "0.0.1", path = "../arci-urdf-viz" }
@@ -28,6 +30,7 @@ toml = "0.5"
 urdf-rs = "0.6"
 
 arci-ros = {version="0.0.1", optional = true}
+openrr-gui = { version = "0.0.1", path = "../openrr-gui", optional = true }
 rand = {version="0.8.0", optional = true}
 
 [dev-dependencies]
@@ -39,3 +42,8 @@ path = "src/bin/robot_command.rs"
 [[bin]]
 name = "openrr_apps_robot_teleop"
 path = "src/bin/robot_teleop.rs"
+
+[[bin]]
+name = "openrr_apps_joint_position_sender"
+path = "src/bin/joint_position_sender.rs"
+required-features = ["gui"]

--- a/openrr-apps/README.md
+++ b/openrr-apps/README.md
@@ -23,6 +23,13 @@ cd openrr-apps
 cargo build --release --features ros
 ```
 
+- With GUI
+
+```bash
+cd openrr-apps
+cargo build --release --features gui
+```
+
 ### For UR10 sample
 
 Install [Universal Robot software](https://github.com/ros-industrial/universal_robot).
@@ -228,3 +235,25 @@ Change urdf path and joystick settings (see [here](#joystick)) in [the setting f
 ./target/release/openrr_apps_robot_teleop \
   --config-path=./openrr-apps/config/pr2_teleop_config_ros.toml \
 ```
+
+## How to run openrr_apps_joint_position_sender
+
+### Sample robot
+
+- Launch urdf-viz.
+
+```bash
+urdf-viz ./openrr-planner/sample.urdf
+```
+
+- Launch openrr_apps_joint_position_sender.
+
+```bash
+./target/release/openrr_apps_joint_position_sender \
+  ./openrr-apps/config/sample_robot_client_config_for_command_urdf_viz.toml \
+  ./openrr-planner/sample.urdf
+```
+
+### Troubleshooting
+
+See [openrr-gui](../openrr-gui/README.md#troubleshooting) crate for troubleshooting.

--- a/openrr-apps/README.md
+++ b/openrr-apps/README.md
@@ -23,11 +23,11 @@ cd openrr-apps
 cargo build --release --features ros
 ```
 
-- With GUI
+- Without GUI
 
 ```bash
 cd openrr-apps
-cargo build --release --features gui
+cargo build --release --no-default-features
 ```
 
 ### For UR10 sample

--- a/openrr-apps/src/bin/joint_position_sender.rs
+++ b/openrr-apps/src/bin/joint_position_sender.rs
@@ -1,14 +1,16 @@
-// TODO: move to openrr-apps?
-
 use log::debug;
 use openrr_apps::RobotConfig;
 use openrr_client::BoxRobotClient;
 use openrr_gui::joint_position_sender;
 use structopt::StructOpt;
 
+/// An openrr GUI tool.
 #[derive(StructOpt, Debug)]
+#[structopt(name = env!("CARGO_BIN_NAME"))]
 struct Opt {
+    /// Path to the setting file.
     config_path: String,
+    /// Path to the URDF file.
     urdf_path: String,
 }
 

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -13,9 +13,3 @@ openrr-client = { version = "0.0.1", path = "../openrr-client" }
 rand = "0.8"
 thiserror = "1"
 urdf-rs = "0.6"
-
-[dev-dependencies]
-anyhow = "1"
-env_logger = "0.8"
-openrr-apps = { version = "0.0.1", path = "../openrr-apps" }
-structopt = "0.3.21"

--- a/openrr-gui/README.md
+++ b/openrr-gui/README.md
@@ -1,32 +1,5 @@
 # OpenRR GUI
 
-## Examples
-
-### Sample robot
-
-- Launch urdf-viz.
-
-  ```bash
-  urdf-viz ./openrr-planner/sample.urdf
-  ```
-
-- Launch joint_position_sender.
-
-  ```bash
-  cargo run -p openrr-gui --example joint_position_sender -- \
-    ./openrr-apps/config/sample_robot_client_config_for_command_urdf_viz.toml \
-    ./openrr-planner/sample.urdf
-  ```
-
-  or
-
-  ```bash
-  cargo build --release -p openrr-gui --example joint_position_sender
-  ./target/release/examples/joint_position_sender \
-    ./openrr-apps/config/sample_robot_client_config_for_command_urdf_viz.toml \
-    ./openrr-planner/sample.urdf
-  ```
-
 ## Troubleshooting
 
 - Q. Fails to compile.


### PR DESCRIPTION
This moves the application part of `openrr-gui` to `openrr-apps` as `openrr_apps_joint_position_sender` under the `gui` feature (enabled by default).

Closes #102

## How to run openrr_apps_joint_position_sender

### Sample robot

- Launch urdf-viz.

```bash
urdf-viz ./openrr-planner/sample.urdf
```

- Launch openrr_apps_joint_position_sender.

```bash
./target/release/openrr_apps_joint_position_sender \
  ./openrr-apps/config/sample_robot_client_config_for_command_urdf_viz.toml \
  ./openrr-planner/sample.urdf
```