### PR TITLE
Remove outdated comment in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
 
-# arci-ros is excluded to make it independent from ROS
-
 members = [
     "arci",
     "arci-gamepad-gilrs",


### PR DESCRIPTION
arci-ros is included in root workspace since https://github.com/openrr/openrr/commit/08187e454496af17e005a0aa2617c1135519a686.