### PR TITLE
Stop to use relative path for inside crates

### DIFF
--- a/arci-gamepad-gilrs/Cargo.toml
+++ b/arci-gamepad-gilrs/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-arci = {version = "0.0.1", path = "../arci"}
+arci = "0.0.1"
 crossbeam-channel = "0.5.0"
 gilrs = { version = "0.8", features = ["serde-serialize"] }
 log = "0.4"

--- a/arci-ros/Cargo.toml
+++ b/arci-ros/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
-arci = { path = "../arci" }
+arci = "0.0.1"
 async-trait = "0.1"
 crossbeam-channel = "0.5.0"
 nalgebra = "0.24"

--- a/arci-speak-cmd/Cargo.toml
+++ b/arci-speak-cmd/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-arci = { version = "0.0.1", path = "../arci" }
+arci = "0.0.1"
 log = "0.4"
 thiserror = "1.0"
 

--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -7,12 +7,12 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
-arci = { version = "0.0.1", path = "../arci" }
+arci = "0.0.1"
 async-trait = "0.1"
 log = "0.4"
 nalgebra = "0.24"
 openrr-planner = { version = "0.0.1", default-features = false }
-openrr-sleep = { version = "0.0.1", path = "../openrr-sleep" }
+openrr-sleep = "0.0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ureq = { version = "2", features = ["json"] }

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -12,17 +12,17 @@ gui = ["openrr-gui"]
 
 [dependencies]
 anyhow = "1.0"
-arci = { version = "0.0.1", path = "../arci" }
-arci-gamepad-gilrs = { version = "0.0.1", path = "../arci-gamepad-gilrs" }
-arci-urdf-viz = { version = "0.0.1", path = "../arci-urdf-viz" }
+arci = "0.0.1"
+arci-gamepad-gilrs = "0.0.1"
+arci-urdf-viz = "0.0.1"
 async-recursion = "0.3"
 async-trait = "0.1"
 env_logger = "0.8"
 k = "0.22"
 log = "0.4"
-openrr-client = { version = "0.0.1", path = "../openrr-client" }
-openrr-command = { version = "0.0.1", path = "../openrr-command" }
-openrr-teleop = { version = "0.0.1", path = "../openrr-teleop" }
+openrr-client = "0.0.1"
+openrr-command = "0.0.1"
+openrr-teleop = "0.0.1"
 serde = { version = "1.0", features = ["derive"] }
 structopt = "0.3.21"
 thiserror = "1.0"
@@ -31,7 +31,7 @@ toml = "0.5"
 urdf-rs = "0.6"
 
 arci-ros = { version = "0.0.1", optional = true }
-openrr-gui = { version = "0.0.1", path = "../openrr-gui", optional = true }
+openrr-gui = { version = "0.0.1", optional = true }
 rand = { version = "0.8.0", optional = true }
 rosrust = { version = "0.9", optional = true }
 

--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -7,11 +7,11 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0"
-arci = { version = "0.0.1", path = "../arci" }
+arci = "0.0.1"
 async-trait = "0.1"
 k = { version = "0.22", features = ["serde-serialize"] }
 log = "0.4"
-openrr-planner = { version = "0.0.1", path = "../openrr-planner" }
+openrr-planner = "0.0.1"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 urdf-rs = "0.6"

--- a/openrr-command/Cargo.toml
+++ b/openrr-command/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-arci = { version = "0.0.1", path = "../arci" }
+arci = "0.0.1"
 async-recursion = "0.3"
 k = "0.22"
 log = "0.4"
-openrr-client = { version = "0.0.1", path = "../openrr-client" }
+openrr-client = "0.0.1"
 structopt = "0.3.21"
 thiserror = "1.0"

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-arci = { version = "0.0.1", path = "../arci" }
+arci = "0.0.1"
 iced = "0.2"
 log = "0.4"
-openrr-client = { version = "0.0.1", path = "../openrr-client" }
+openrr-client = "0.0.1"
 rand = "0.8"
 thiserror = "1"
 urdf-rs = "0.6"

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -8,11 +8,11 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arci = {version="0.0.1", path="../arci"}
+arci = "0.0.1"
 async-trait = "0.1"
 auto_impl = "0.4.1"
 k = "0.22"
 log = "0.4"
-openrr-client = { version = "0.0.1", path = "../openrr-client"}
+openrr-client = "0.0.1"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/openrr/Cargo.toml
+++ b/openrr/Cargo.toml
@@ -14,9 +14,9 @@ assimp = ["openrr-planner/assimp"]
 ros = ["openrr-apps/ros"]
 
 [dependencies]
-openrr-apps = { path = "../openrr-apps", version = "0.0.1" }
-openrr-client = { path = "../openrr-client", version = "0.0.1" }
-openrr-command = { path = "../openrr-command", version = "0.0.1" }
-openrr-planner = { path = "../openrr-planner", version = "0.0.1" }
-openrr-sleep = { path = "../openrr-sleep", version = "0.0.1" }
-openrr-teleop = { path = "../openrr-teleop", version = "0.0.1" }
+openrr-apps = "0.0.1"
+openrr-client = "0.0.1"
+openrr-command = "0.0.1"
+openrr-planner = "0.0.1"
+openrr-sleep = "0.0.1"
+openrr-teleop = "0.0.1"


### PR DESCRIPTION
Because root Cargo.toml patches the paths, we don't need relative paths
Refs #137