### PR TITLE
[arci-ros] Stop to use parent() -> arci-ros to search msg files

### DIFF
--- a/arci-ros/build.rs
+++ b/arci-ros/build.rs
@@ -3,9 +3,6 @@ use std::{env, path::PathBuf};
 fn main() {
     let msg_path =
         PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("failed to get manifest root"))
-            .parent()
-            .expect("failed to get parent")
-            .join("arci-ros") // this works for workspace only. It can be improved.
             .join("ros_msgs");
     println!(
         "cargo:rustc-env=ROSRUST_MSG_PATH={}",


### PR DESCRIPTION
This old hack causes error on cargo install.