### PR TITLE
call update before collision check

### DIFF
--- a/openrr-planner/src/collision/collision_checker.rs
+++ b/openrr-planner/src/collision/collision_checker.rs
@@ -271,6 +271,7 @@ where
         target_shape: &'a dyn Shape<T>,
         target_pose: &'a na::Isometry3<T>,
     ) -> EnvCollisionNames<T> {
+        robot.update_transforms();
         EnvCollisionNames::new(self, robot, target_shape, target_pose)
     }
 
@@ -283,6 +284,7 @@ where
         collision_check_robot: &'a k::Chain<T>,
         self_collision_pairs: &'a [(String, String)],
     ) -> SelfCollisionPairs<T> {
+        collision_check_robot.update_transforms();
         SelfCollisionPairs::new(self, collision_check_robot, self_collision_pairs)
     }
 }


### PR DESCRIPTION
k::Chain is thread same, and sometimes bellow error happens.
I hope this improve the situation.

thread '<unnamed>' panicked at 'cache must exist', /Users/ogura/.cargo/registry/src/github.com-1ecc6299db9ec823/k-0.22.1/src/chain.rs:383:70
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', /Users/ogura/rust/openrr/openrr-planner/src/collision/collision_checker.rs:177:54
