### PR TITLE
[arci-speak-cmd] v0.1.0 -> v0.0.3

### DIFF
--- a/arci-speak-cmd/Cargo.toml
+++ b/arci-speak-cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arci-speak-cmd"
-version = "0.1.0"
+version = "0.0.3"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
It should have been 0.0.1, but v0.1.0 is released.
When we release v0.1.0, we have to skip v0.1.0
for arci-speak-cmd.