### PR TITLE
[workflows] Automate release process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,8 @@ jobs:
         with:
           command: build
 
-  check:
-    name: Check
+  build:
+    name: Build on Linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -61,7 +61,7 @@ jobs:
       - run: ci/ubuntu-install-dependencies.sh
       - uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: build
 
   test:
     name: Test Suite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags: [ 'v[0-9]+.*' ]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  create-release:
+    if: github.repository_owner == 'openrr'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ci/ubuntu-install-dependencies.sh
+      - run: cargo build
+      - uses: taiki-e/create-gh-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: ci/publish.sh
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# A list of paths to the crate to be published.
+# It will be published in the order listed.
+MEMBERS=(
+    "arci"
+    "openrr-sleep"
+    "openrr-planner"
+
+    # depend on arci and openrr-planner
+    "openrr-client"
+
+    # depend on arci and openrr-client
+    "openrr-command"
+    "openrr-gui"
+    "openrr-teleop"
+
+    # depend on arci and some openrr-* crates
+    "arci-gamepad-gilrs"
+    "arci-ros"
+    "arci-speak-audio"
+    "arci-speak-cmd"
+    "arci-urdf-viz"
+
+    # depend on all arci-* crates
+    "openrr-apps"
+
+    # depend on all openrr-* crates
+    "openrr"
+)
+
+cd "$(cd "$(dirname "${0}")" && pwd)"/..
+
+set -x
+
+for i in "${!MEMBERS[@]}"; do
+    (
+        cd "${MEMBERS[${i}]}"
+        cargo publish
+    )
+    if [[ $((i + 1)) != "${#MEMBERS[@]}" ]]; then
+        sleep 30
+    fi
+done


### PR DESCRIPTION
The workflow added by this patch launches when the tag is pushed and does the following:

- Creates a GitHub release.
- Publishes the crates listed in ci/publish.sh to crates.io.

See openrr/urdf-viz#44 for more.


Closes #154