### PR TITLE
[workflows] Separate the dependency installation on linux into a script

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,9 +18,7 @@ jobs:
         with:
           toolchain: nightly
           override: true
-      - run: sudo apt-get update
-      # only for arci-gamepad-gilrs
-      - run: sudo apt-get install -y libudev-dev libasound2-dev
+      - run: ci/ubuntu-install-dependencies.sh
       # only for arci-ros test (roscore)
       - run: sudo apt-get install -y python-roslaunch python-rostopic
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,12 +58,11 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: sudo apt-get update
-      # only for arci-gamepad-gilrs
-      - run: sudo apt-get install -y libudev-dev libasound2-dev
+      - run: ci/ubuntu-install-dependencies.sh
       - uses: actions-rs/cargo@v1
         with:
           command: check
+
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -74,14 +73,13 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: sudo apt-get update
-      # only for arci-gamepad-gilrs
-      - run: sudo apt-get install -y libudev-dev libasound2-dev
+      - run: ci/ubuntu-install-dependencies.sh
       # testing arci-ros is done in ros1.yaml
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace --exclude arci-ros
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -97,6 +95,7 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -107,9 +106,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: sudo apt-get update
-      # only for arci-gamepad-gilrs
-      - run: sudo apt-get install -y libudev-dev libasound2-dev
+      - run: ci/ubuntu-install-dependencies.sh
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ros1.yaml
+++ b/.github/workflows/ros1.yaml
@@ -43,15 +43,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           apt-get update
-          apt-get -y install curl libasound2-dev
+          apt-get -y install curl
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - run: sudo apt-get update
-      # only for arci-gamepad-gilrs
-      - run: sudo apt-get install -y libudev-dev libasound2-dev
+      - run: ci/ubuntu-install-dependencies.sh
       - name: cargo test
         shell: bash -ieo pipefail {0}
         working-directory: openrr-apps

--- a/ci/ubuntu-install-dependencies.sh
+++ b/ci/ubuntu-install-dependencies.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+sudo apt-get update
+
+# libudev-dev is for arci-gamepad-gilrs
+# libasound2-dev is for arci-speak-audio
+sudo apt-get install -y \
+    libudev-dev libasound2-dev


### PR DESCRIPTION
If we forget to update the dependency installation command for the Linux environment, #206 will break easily. And it's hard to notice until the release process actually started.

This patch separates the dependency installation commands into scripts for easier management. Also, this makes workflows that aren't run regularly like #206 hard to break.