### PR TITLE
[openrr-gui] Pin zerocopy to 0.3.0

### DIFF
--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -18,3 +18,6 @@ rand = "0.8"
 thiserror = "1"
 tracing = { version = "0.1", features = ["log"] }
 urdf-rs = "0.6"
+
+# zerocopy 0.3.1 removed support for stable Rust.
+zerocopy = "=0.3.0"


### PR DESCRIPTION
zerocopy 0.3.1 removed support for stable Rust. We want to use stable, so pin zerocopy to 0.3.0. 

### details

zerocopy 0.3.1 depends on min_const_generics that requires 1.51.0 (the current beta, [it will be released as stable in 2021-03-25](https://github.com/rust-lang/rust/blob/relnotes-1.51.0/RELEASES.md#version-1510-2021-03-25)).
Therefore, it cannot be used in the current stable (1.50.0). 

https://github.com/openrr/openrr/runs/2036728847?check_suite_focus=true

> ```
> error[E0658]: const generics are unstable
>    --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/zerocopy-0.3.1/src/lib.rs:71:38
>     |
> 71  |         unsafe impl<T: $trait, const N: usize> $trait for [T; N] {
>     |                                      ^
> ...
> 263 | impl_for_composite_types!(FromBytes);
>     | ------------------------------------- in this macro invocation
>     |
>     = note: see issue #74878 <https://github.com/rust-lang/rust/issues/74878> for more information
>     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
> ```

cc @joshlf Is this intentional? If so, it would be nice to have a note that warns us about stable Rust support is not guaranteed.
