### PR TITLE
[openrr-gui] Revert "Pin zerocopy to 0.3.0"

### DIFF
--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -18,6 +18,3 @@ rand = "0.8"
 thiserror = "1"
 tracing = { version = "0.1", features = ["log"] }
 urdf-rs = "0.6"
-
-# zerocopy 0.3.1 removed support for stable Rust.
-zerocopy = "=0.3.0"


### PR DESCRIPTION
This reverts commit 2d29c13ce25ef2897c828b011e3c441f27d71577 (#216).