### PR TITLE
[openrr-client] impl Default for OpenrrClientsConfig

### DIFF
--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -410,7 +410,7 @@ pub struct JointTrajectoryClientsContainerConfig {
     pub clients_names: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct OpenrrClientsConfig {
     pub urdf_path: Option<String>,
     urdf_full_path: Option<PathBuf>,


### PR DESCRIPTION
I think it makes sense to implement Default, as all fields can be omitted when deserializing.