### PR TITLE
[ci] Run `cargo clean` before `cargo publish`

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -39,6 +39,7 @@ set -x
 for i in "${!MEMBERS[@]}"; do
     (
         cd "${MEMBERS[${i}]}"
+        cargo clean
         cargo publish
     )
     if [[ $((i + 1)) != "${#MEMBERS[@]}" ]]; then


### PR DESCRIPTION
Fixes release workflow.

https://github.com/openrr/openrr/runs/2216239543?check_suite_focus=true

> No space left on device