### PR TITLE
[arci-urdf-viz] Add start_background method to mock server

### DIFF
--- a/arci-urdf-viz/tests/test_client.rs
+++ b/arci-urdf-viz/tests/test_client.rs
@@ -70,8 +70,7 @@ fn test_urdf_viz_web_client_config_clone() {
 fn test_create_joint_trajectory_clients() {
     const DEFAULT_PORT: u16 = 7777;
     let web_server = WebServer::new(DEFAULT_PORT);
-    std::thread::spawn(move || web_server.start());
-    std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
+    web_server.start_background();
     let configs = vec![
         UrdfVizWebClientConfig {
             name: "c1".to_owned(),
@@ -97,8 +96,7 @@ fn test_current_joint_positions() {
         names: vec!["j1".to_owned(), "j2".to_owned()],
         positions: vec![1.0, -1.0],
     }));
-    std::thread::spawn(move || web_server.start());
-    std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
+    web_server.start_background();
     let c = UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
         .unwrap();
     let v = c.current_joint_positions().unwrap();
@@ -110,8 +108,7 @@ fn test_current_joint_positions() {
 fn test_set_complete_condition() {
     const PORT: u16 = 7779;
     let web_server = WebServer::new(PORT);
-    std::thread::spawn(move || web_server.start());
-    std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
+    web_server.start_background();
     let mut client =
         UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
             .unwrap();
@@ -127,8 +124,7 @@ async fn test_send_joint_positions() {
         names: vec!["j1".to_owned()],
         positions: vec![0.0],
     }));
-    std::thread::spawn(move || web_server.start());
-    std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
+    web_server.start_background();
     let mut client =
         UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
             .unwrap();
@@ -147,8 +143,7 @@ async fn test_send_joint_trajectory() {
         names: vec!["j1".to_owned()],
         positions: vec![0.0],
     }));
-    std::thread::spawn(move || web_server.start());
-    std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
+    web_server.start_background();
     let mut client =
         UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
             .unwrap();

--- a/arci-urdf-viz/tests/test_web.rs
+++ b/arci-urdf-viz/tests/test_web.rs
@@ -9,8 +9,7 @@ use web_server::*;
 fn test_set_get_vel() {
     const PORT: u16 = 8888;
     let web_server = WebServer::new(PORT);
-    std::thread::spawn(move || web_server.start());
-    std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
+    web_server.start_background();
     let c = UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
         .unwrap();
     let v = c.current_velocity().unwrap();
@@ -29,8 +28,7 @@ fn test_set_get_vel() {
 fn test_set_get_pose() {
     const PORT: u16 = 8889;
     let web_server = WebServer::new(PORT);
-    std::thread::spawn(move || web_server.start());
-    std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
+    web_server.start_background();
     let c = UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
         .unwrap();
     let pose = c.current_pose("").unwrap();

--- a/arci-urdf-viz/tests/web_server.rs
+++ b/arci-urdf-viz/tests/web_server.rs
@@ -77,7 +77,7 @@ impl WebServer {
     }
 
     #[actix_web::main]
-    pub async fn start(self) -> io::Result<()> {
+    async fn start(self) -> io::Result<()> {
         let data = Data {
             target_joint_positions: self.target_joint_positions,
             current_joint_positions: self.current_joint_positions,
@@ -100,6 +100,11 @@ impl WebServer {
         .bind(("0.0.0.0", self.port))?
         .run()
         .await
+    }
+
+    pub fn start_background(self) {
+        std::thread::spawn(move || self.start().unwrap());
+        std::thread::sleep(std::time::Duration::from_secs(1)); // Wait for web server to start.
     }
 }
 


### PR DESCRIPTION
reduce boilerplate code

```diff
- std::thread::spawn(move || web_server.start());
- std::thread::sleep(std::time::Duration::from_secs(1));
+ web_server.start_background();
```