### PR TITLE
[openrr-apps] Add flag to show the default setting as TOML

### DIFF
--- a/openrr-apps/src/bin/robot_command.rs
+++ b/openrr-apps/src/bin/robot_command.rs
@@ -1,4 +1,3 @@
-use crate::Error as OpenrrAppsError;
 use openrr_apps::{Error, RobotConfig};
 use openrr_command::{RobotCommand, RobotCommandExecutor};
 use std::path::PathBuf;
@@ -11,10 +10,14 @@ use tracing::info;
     about = "An openrr command line tool."
 )]
 struct RobotCommandArgs {
+    /// Path to the setting file.
     #[structopt(short, long, parse(from_os_str))]
     config_path: Option<PathBuf>,
     #[structopt(subcommand)]
-    command: RobotCommand,
+    command: Option<RobotCommand>,
+    /// Prints the default setting as TOML.
+    #[structopt(long)]
+    show_default_config: bool,
 }
 
 #[tokio::main]
@@ -22,13 +25,40 @@ async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt::init();
     let args = RobotCommandArgs::from_args();
     info!("ParsedArgs {:?}", args);
+
+    if args.show_default_config {
+        print!("{}", toml::to_string(&RobotConfig::default()).unwrap());
+        return Ok(());
+    }
+
     if let Some(config_path) = openrr_apps::utils::get_apps_robot_config(args.config_path) {
+        let command = args.command.ok_or(Error::NoCommand)?;
         let robot_config = RobotConfig::try_new(config_path)?;
         openrr_apps::utils::init_with_anonymize(env!("CARGO_BIN_NAME"), &robot_config);
         let client = robot_config.create_robot_client()?;
         let executor = RobotCommandExecutor {};
-        Ok(executor.execute(&client, &args.command).await?)
+        Ok(executor.execute(&client, &command).await?)
     } else {
-        Err(OpenrrAppsError::NoConfigPath)
+        Err(Error::NoConfigPath)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_args() {
+        let bin = env!("CARGO_BIN_NAME");
+        assert!(RobotCommandArgs::from_iter_safe(&[bin]).is_ok());
+        assert!(RobotCommandArgs::from_iter_safe(&[bin, "--show-default-config"]).is_ok());
+        assert!(RobotCommandArgs::from_iter_safe(&[bin, "--config-path", "path", "list"]).is_ok());
+        assert!(RobotCommandArgs::from_iter_safe(&[
+            bin,
+            "--show-default-config",
+            "--config-path",
+            "path"
+        ])
+        .is_ok());
     }
 }

--- a/openrr-apps/src/error.rs
+++ b/openrr-apps/src/error.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 pub enum Error {
     #[error("openrr-apps: No ConfigPath is specified.")]
     NoConfigPath,
+    #[error("openrr-apps: No command is specified.")]
+    NoCommand,
     #[error("openrr-apps: Failed to parse {:?} as toml ({}).", .0, .1)]
     TomlParseFailure(PathBuf, #[source] toml::de::Error),
     #[error("openrr-apps: No File {:?} is found ({}).", .0, .1)]


### PR DESCRIPTION
cc #252

```console
$ target/debug/openrr_apps_robot_command --show-default-config
urdf_viz_clients_total_complete_allowable_error = 0.02
urdf_viz_clients_complete_timeout_sec = 3.0
use_move_base_urdf_viz_web_client = true
use_navigation_urdf_viz_web_client = true
use_localization_urdf_viz_web_client = true

[speak_configs]

[openrr_clients_config]
self_collision_check_pairs = []

[openrr_clients_config.ik_solvers_configs]
```

```console
$ target/debug/openrr_apps_robot_teleop --show-default-config
robot_config_path = ""
initial_mode = ""

[control_nodes_config]
joy_joint_teleop_configs = []
ik_node_teleop_configs = []

[gil_gamepad_config]
device_id = 0

[gil_gamepad_config.map]
button_map = [["LeftTrigger2", "LeftTrigger2"], ["DPadUp", "DPadUp"], ["DPadLeft", "DPadLeft"], ["LeftTrigger", "LeftTrigger"], ["West", "West"], ["North", "North"], ["RightThumb", "RightThumb"], ["RightTrigger2", "RightTrigger2"], ["DPadRight", "DPadRight"], ["RightTrigger", "RightTrigger"], ["Mode", "Mode"], ["East", "East"], ["LeftThumb", "LeftThumb"], ["South", "South"], ["DPadDown", "DPadDown"], ["Start", "Start"], ["Select", "Select"]]
axis_map = [["DPadX", "DPadX"], ["LeftStickX", "LeftStickX"], ["RightStickX", "RightStickX"], ["RightStickY", "RightStickY"], ["DPadY", "DPadY"], ["LeftStickY", "LeftStickY"]]
axis_value_map = [["LeftStickX", -1.0], ["RightStickX", -1.0]]
```
