### PR TITLE
[openrr-gui, openrr-apps] Add glow feature

### DIFF
--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -15,6 +15,9 @@ readme = "README.md"
 default = ["gui", "ros"]
 ros = ["arci-ros"]
 gui = ["openrr-gui"]
+# Enables the `iced_glow` renderer on GUI.
+# This might be useful if the default renderer doesn't work.
+glow = ["openrr-gui/glow"]
 
 [dependencies]
 anyhow = "1.0"

--- a/openrr-apps/README.md
+++ b/openrr-apps/README.md
@@ -248,7 +248,11 @@ openrr_apps_joint_position_sender \
   --config-path ./openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml
 ```
 
-#### Environmental Variables
+### Troubleshooting
+
+See [openrr-gui](../openrr-gui/README.md#troubleshooting) crate for troubleshooting on GUI.
+
+## Environmental Variables
 
 If you set `export OPENRR_APPS_ROBOT_CONFIG_PATH=some_path_to_config.toml`, you can skip
 `--config-path`. If you give `--config-path` explicitly, the env var is ignored.
@@ -261,7 +265,3 @@ openrr_apps_joint_position_sender
 ```
 
 Do not forget to unset OPENRR_APPS_ROBOT_CONFIG_PATH before try other settings
-
-### Troubleshooting
-
-See [openrr-gui](../openrr-gui/README.md#troubleshooting) crate for troubleshooting.

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -10,6 +10,11 @@ categories = ["science::robotics", "gui"]
 repository = "https://github.com/openrr/openrr"
 documentation = "http://docs.rs/openrr-gui"
 
+[features]
+# Enables the `iced_glow` renderer on GUI.
+# This might be useful if the default renderer doesn't work.
+glow = ["iced/glow"]
+
 [dependencies]
 arci = "0.0.5"
 iced = "0.3"

--- a/openrr-gui/README.md
+++ b/openrr-gui/README.md
@@ -11,6 +11,6 @@
   A. There are several possibilities:
 
   - If the error is command-line arguments or IO related, it's likely that the argument is wrong.
-  - If you get the error that "GraphicsAdapterNotFound", try passing the "--features iced/glow" argument to `cargo build` or `cargo run`.
+  - If you get the error that "GraphicsAdapterNotFound", try enabling the `glow` feature of openrr-gui or openrr-apps.
   - If that doesn't fix the problem, try passing the `LIBGL_ALWAYS_SOFTWARE=1` environment variable.
   - On VM (e.g., VirtualBox), you may need to disable hardware acceleration.


### PR DESCRIPTION
[The troubleshooting doc](https://github.com/openrr/openrr/tree/main/openrr-gui#troubleshooting) mentions iced/glow feature, but its feature is not selectable when installing openrr-apps because iced is not a dependency of openrr-apps.