### PR TITLE
Change Navigation::move_to to send_goal_pose

### DIFF
--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -29,4 +29,3 @@ actix-web = "3"
 assert_approx_eq = "1.1"
 serde_derive = "1.0"
 tokio = { version = "1.0", features = ["full"] }
-tokio-test = "0.4"

--- a/arci-urdf-viz/src/client.rs
+++ b/arci-urdf-viz/src/client.rs
@@ -3,7 +3,6 @@ use arci::{
     BaseVelocity, CompleteCondition, JointTrajectoryClient, JointVelocityLimiter, Localization,
     MoveBase, Navigation, SetCompleteCondition, TotalJointDiffCondition, WaitFuture,
 };
-use async_trait::async_trait;
 use futures::stream::FuturesOrdered;
 use nalgebra as na;
 use openrr_sleep::ScopedSleep;
@@ -274,14 +273,13 @@ impl Localization for UrdfVizWebClient {
     }
 }
 
-#[async_trait]
 impl Navigation for UrdfVizWebClient {
-    async fn move_to(
+    fn send_goal_pose(
         &self,
         goal: na::Isometry2<f64>,
         _frame_id: &str,
         _timeout: Duration,
-    ) -> Result<(), arci::Error> {
+    ) -> Result<WaitFuture, arci::Error> {
         // JUMP!
         let re = send_robot_origin(&self.base_url, goal.into()).map_err(|e| {
             arci::Error::Connection {
@@ -292,7 +290,7 @@ impl Navigation for UrdfVizWebClient {
             return Err(arci::Error::Connection { message: re.reason });
         }
 
-        Ok(())
+        Ok(WaitFuture::ready())
     }
 
     fn cancel(&self) -> Result<(), arci::Error> {

--- a/arci-urdf-viz/tests/test_web.rs
+++ b/arci-urdf-viz/tests/test_web.rs
@@ -44,9 +44,9 @@ async fn test_set_get_pose() {
     .await
     .unwrap();
     let pose = c.current_pose("").unwrap();
-    assert_approx_eq!(pose.translation.x, 0.0);
-    assert_approx_eq!(pose.translation.y, 0.0);
-    assert_approx_eq!(pose.rotation.angle(), 0.0);
+    assert_approx_eq!(pose.translation.x, 1.0);
+    assert_approx_eq!(pose.translation.y, 2.0);
+    assert_approx_eq!(pose.rotation.angle(), 3.0);
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn test_set_get_pose_no_wait() {
         )
         .unwrap();
     let pose = c.current_pose("").unwrap();
-    assert_approx_eq!(pose.translation.x, 0.0);
-    assert_approx_eq!(pose.translation.y, 0.0);
-    assert_approx_eq!(pose.rotation.angle(), 0.0);
+    assert_approx_eq!(pose.translation.x, 1.0);
+    assert_approx_eq!(pose.translation.y, 2.0);
+    assert_approx_eq!(pose.rotation.angle(), 3.0);
 }

--- a/arci-urdf-viz/tests/test_web.rs
+++ b/arci-urdf-viz/tests/test_web.rs
@@ -24,8 +24,8 @@ fn test_set_get_vel() {
     assert_approx_eq!(v.theta, 3.0);
 }
 
-#[test]
-fn test_set_get_pose() {
+#[tokio::test]
+async fn test_set_get_pose() {
     const PORT: u16 = 8889;
     let web_server = WebServer::new(PORT);
     web_server.start_background();
@@ -35,12 +35,38 @@ fn test_set_get_pose() {
     assert_approx_eq!(pose.translation.x, 0.0);
     assert_approx_eq!(pose.translation.y, 0.0);
     assert_approx_eq!(pose.rotation.angle(), 0.0);
-    tokio_test::block_on(c.move_to(
+    c.send_goal_pose(
         nalgebra::Isometry2::new(nalgebra::Vector2::new(1.0, 2.0), 3.0),
         "",
         std::time::Duration::from_secs(0),
-    ))
+    )
+    .unwrap()
+    .await
     .unwrap();
+    let pose = c.current_pose("").unwrap();
+    assert_approx_eq!(pose.translation.x, 0.0);
+    assert_approx_eq!(pose.translation.y, 0.0);
+    assert_approx_eq!(pose.rotation.angle(), 0.0);
+}
+
+#[test]
+fn test_set_get_pose_no_wait() {
+    const PORT: u16 = 8890;
+    let web_server = WebServer::new(PORT);
+    web_server.start_background();
+    let c = UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
+        .unwrap();
+    let pose = c.current_pose("").unwrap();
+    assert_approx_eq!(pose.translation.x, 0.0);
+    assert_approx_eq!(pose.translation.y, 0.0);
+    assert_approx_eq!(pose.rotation.angle(), 0.0);
+    let _ = c
+        .send_goal_pose(
+            nalgebra::Isometry2::new(nalgebra::Vector2::new(1.0, 2.0), 3.0),
+            "",
+            std::time::Duration::from_secs(0),
+        )
+        .unwrap();
     let pose = c.current_pose("").unwrap();
     assert_approx_eq!(pose.translation.x, 0.0);
     assert_approx_eq!(pose.translation.y, 0.0);

--- a/arci-urdf-viz/tests/web_server.rs
+++ b/arci-urdf-viz/tests/web_server.rs
@@ -1,4 +1,4 @@
-// This is copy of urdf-viz/web_server.rs
+// This is based on urdf-viz/web_server.rs
 // version = "0.25.0"
 // https://github.com/OpenRR/urdf-viz/blob/v0.25.0/src/web_server.rs
 // It is difficult to test with urdf-viz with `RUSTFLAGS=-Cpanic=abort`
@@ -18,22 +18,10 @@ pub struct JointNamesAndPositions {
     pub positions: Vec<f32>,
 }
 
-#[derive(Debug, Clone)]
-pub struct JointNamesAndPositionsRequest {
-    pub joint_positions: JointNamesAndPositions,
-    pub requested: bool,
-}
-
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct RobotOrigin {
     pub position: [f32; 3],
     pub quaternion: [f32; 4],
-}
-
-#[derive(Debug, Clone)]
-pub struct RobotOriginRequest {
-    pub origin: RobotOrigin,
-    pub requested: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -45,17 +33,13 @@ struct ResultResponse {
 #[derive(Debug)]
 pub struct WebServer {
     pub port: u16,
-    pub target_joint_positions: Arc<Mutex<JointNamesAndPositionsRequest>>,
     pub current_joint_positions: Arc<Mutex<JointNamesAndPositions>>,
-    pub target_robot_origin: Arc<Mutex<RobotOriginRequest>>,
     pub current_robot_origin: Arc<Mutex<RobotOrigin>>,
 }
 
 #[derive(Debug, Clone)]
 struct Data {
-    target_joint_positions: Arc<Mutex<JointNamesAndPositionsRequest>>,
     current_joint_positions: Arc<Mutex<JointNamesAndPositions>>,
-    target_robot_origin: Arc<Mutex<RobotOriginRequest>>,
     current_robot_origin: Arc<Mutex<RobotOrigin>>,
 }
 
@@ -63,15 +47,7 @@ impl WebServer {
     pub fn new(port: u16) -> Self {
         Self {
             port,
-            target_joint_positions: Arc::new(Mutex::new(JointNamesAndPositionsRequest {
-                joint_positions: JointNamesAndPositions::default(),
-                requested: false,
-            })),
             current_joint_positions: Arc::new(Mutex::new(JointNamesAndPositions::default())),
-            target_robot_origin: Arc::new(Mutex::new(RobotOriginRequest {
-                origin: RobotOrigin::default(),
-                requested: false,
-            })),
             current_robot_origin: Arc::new(Mutex::new(RobotOrigin::default())),
         }
     }
@@ -79,9 +55,7 @@ impl WebServer {
     #[actix_web::main]
     async fn start(self) -> io::Result<()> {
         let data = Data {
-            target_joint_positions: self.target_joint_positions,
             current_joint_positions: self.current_joint_positions,
-            target_robot_origin: self.target_robot_origin,
             current_robot_origin: self.current_robot_origin,
         };
 
@@ -113,9 +87,9 @@ async fn set_joint_positions(
     json: web::Json<JointNamesAndPositions>,
     data: web::Data<Data>,
 ) -> HttpResponse {
-    let mut jp_request = data.target_joint_positions.lock().unwrap();
-    jp_request.joint_positions = json.into_inner();
-    let jp = jp_request.joint_positions.clone();
+    let mut joint_positions = data.current_joint_positions.lock().unwrap();
+    *joint_positions = json.into_inner();
+    let jp = joint_positions.clone();
     if jp.names.len() != jp.positions.len() {
         HttpResponse::Ok().json(&ResultResponse {
             is_ok: false,
@@ -126,7 +100,6 @@ async fn set_joint_positions(
             ),
         })
     } else {
-        jp_request.requested = true;
         HttpResponse::Ok().json(&ResultResponse {
             is_ok: true,
             reason: "".to_string(),
@@ -136,9 +109,8 @@ async fn set_joint_positions(
 
 #[post("set_robot_origin")]
 async fn set_robot_origin(json: web::Json<RobotOrigin>, data: web::Data<Data>) -> HttpResponse {
-    let mut pose_request = data.target_robot_origin.lock().unwrap();
-    pose_request.origin = json.into_inner();
-    pose_request.requested = true;
+    let mut robot_origin = data.current_robot_origin.lock().unwrap();
+    *robot_origin = json.into_inner();
     HttpResponse::Ok().json(&ResultResponse {
         is_ok: true,
         reason: "".to_string(),

--- a/arci/src/traits/navigation.rs
+++ b/arci/src/traits/navigation.rs
@@ -1,17 +1,15 @@
 use crate::error::Error;
-use crate::Isometry2;
-use async_trait::async_trait;
+use crate::{Isometry2, WaitFuture};
 use auto_impl::auto_impl;
 
-#[async_trait]
 #[auto_impl(Box, Arc)]
 pub trait Navigation: Send + Sync {
-    async fn move_to(
+    fn send_goal_pose(
         &self,
         goal: Isometry2<f64>,
         frame_id: &str,
         timeout: std::time::Duration,
-    ) -> Result<(), Error>;
+    ) -> Result<WaitFuture, Error>;
 
     fn cancel(&self) -> Result<(), Error>;
 }

--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -6,7 +6,6 @@ use arci::{
     BaseVelocity, Error as ArciError, JointTrajectoryClient, JointTrajectoryClientsContainer,
     Localization, MoveBase, Navigation, Speaker, WaitFuture,
 };
-use async_trait::async_trait;
 use k::{nalgebra::Isometry2, Chain, Isometry3};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path, path::PathBuf, sync::Arc, time::Duration};
@@ -369,25 +368,22 @@ where
     }
 }
 
-#[async_trait]
 impl<L, M, N> Navigation for RobotClient<L, M, N>
 where
     L: Localization,
     M: MoveBase,
     N: Navigation,
 {
-    async fn move_to(
+    fn send_goal_pose(
         &self,
         goal: Isometry2<f64>,
         frame_id: &str,
         timeout: std::time::Duration,
-    ) -> Result<(), ArciError> {
-        Ok(self
-            .navigation
+    ) -> Result<WaitFuture, ArciError> {
+        self.navigation
             .as_ref()
             .unwrap()
-            .move_to(goal, frame_id, timeout)
-            .await?)
+            .send_goal_pose(goal, frame_id, timeout)
     }
 
     fn cancel(&self) -> Result<(), ArciError> {

--- a/openrr-command/src/robot_command.rs
+++ b/openrr-command/src/robot_command.rs
@@ -323,11 +323,11 @@ impl RobotCommandExecutor {
                 timeout_secs,
             } => {
                 client
-                    .move_to(
+                    .send_goal_pose(
                         Isometry2::new(Vector2::new(*x, *y), *yaw),
                         frame_id,
                         Duration::from_secs_f64(*timeout_secs),
-                    )
+                    )?
                     .await?;
             }
             RobotCommand::CancelNavigationGoal => {


### PR DESCRIPTION
- Change async method `Navigation::move_to` to normal method `send_goal_pose` that return future.

cc #172