### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
 documentation = "http://docs.rs/openrr-apps"
-readme = "README.md"
 
 [features]
 default = ["gui", "ros"]

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["pathplanning", "robotics", "robot"]
 categories = ["algorithms", "science::robotics"]
 repository = "https://github.com/openrr/openrr"
 documentation = "http://docs.rs/openrr-planner"
-readme = "README.md"
 
 [features]
 default = [ "assimp" ]


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field if readme is in the default location (`readme = "README.md"`).

