### PR TITLE
[openrr-client] Return Option<&Path> instead of &Option<PathBuf> in OpenrrClientsConfig::urdf_full_path

### DIFF
--- a/openrr-apps/src/bin/joint_position_sender.rs
+++ b/openrr-apps/src/bin/joint_position_sender.rs
@@ -24,11 +24,7 @@ fn main() -> anyhow::Result<()> {
     let client: BoxRobotClient = config.create_robot_client()?;
     joint_position_sender(
         client,
-        config
-            .openrr_clients_config
-            .urdf_full_path()
-            .as_ref()
-            .unwrap(),
+        config.openrr_clients_config.urdf_full_path().unwrap(),
     )?;
     Ok(())
 }

--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -77,7 +77,7 @@ where
             ik_clients,
             self_collision_checkers,
             ik_solvers,
-        ) = if let Some(urdf_full_path) = config.urdf_full_path().as_ref() {
+        ) = if let Some(urdf_full_path) = config.urdf_full_path() {
             debug!("Loading {:?}", urdf_full_path);
             let full_chain_for_collision_checker =
                 Arc::new(Chain::from_urdf_file(&urdf_full_path)?);
@@ -467,8 +467,8 @@ impl OpenrrClientsConfig {
         }
         Ok(())
     }
-    pub fn urdf_full_path(&self) -> &Option<PathBuf> {
-        &self.urdf_full_path
+    pub fn urdf_full_path(&self) -> Option<&Path> {
+        self.urdf_full_path.as_deref()
     }
 }
 


### PR DESCRIPTION
Allow removing redundant `.as_ref()` in user side.