### PR TITLE
[openrr-gui] Take urdf_rs::Robot instead of Path in joint_position_sender

### DIFF
--- a/openrr-apps/src/bin/joint_position_sender.rs
+++ b/openrr-apps/src/bin/joint_position_sender.rs
@@ -23,9 +23,7 @@ fn main() -> anyhow::Result<()> {
     let config = RobotConfig::try_new(&config_path)?;
     openrr_apps::utils::init(env!("CARGO_BIN_NAME"), &config);
     let client: BoxRobotClient = config.create_robot_client()?;
-    joint_position_sender(
-        client,
-        config.openrr_clients_config.urdf_full_path().unwrap(),
-    )?;
+    let robot = urdf_rs::read_file(config.openrr_clients_config.urdf_full_path().unwrap())?;
+    joint_position_sender(client, robot)?;
     Ok(())
 }

--- a/openrr-gui/src/error.rs
+++ b/openrr-gui/src/error.rs
@@ -3,10 +3,10 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    #[error("iced: {:?}", .0)]
+    #[error("openrr-gui: iced: {}", .0)]
     Iced(#[from] iced::Error),
-    #[error("urdf: {:?}", .0)]
-    Urdf(#[from] urdf_rs::UrdfError),
-    #[error("arci: {:?}", .0)]
+    #[error("openrr-gui: arci: {}", .0)]
     Arci(#[from] arci::Error),
+    #[error("openrr-gui: other: {}", .0)]
+    Other(String),
 }


### PR DESCRIPTION
This is useful if the user has not managed urdf as a file. For example, when used in an environment where cannot be access to local files (like wasm), or when urdf is embedded in another file.

~~This PR is marked as a draft because based on #280.~~
See the second and third commit for actual changes in this PR.