### PR TITLE
[arci] Add JointVelocityLimiter::from_urdf

### DIFF
--- a/arci-ros/src/ros_control_client.rs
+++ b/arci-ros/src/ros_control_client.rs
@@ -22,8 +22,7 @@ pub struct RosControlClientConfig {
     pub wrap_with_joint_position_limiter: bool,
     #[serde(default)]
     pub wrap_with_joint_velocity_limiter: bool,
-    #[serde(default)]
-    pub joint_velocity_limits: Vec<f64>,
+    pub joint_velocity_limits: Option<Vec<f64>>,
 
     pub controller_name: String,
     pub state_topic_name: Option<String>,
@@ -97,38 +96,58 @@ pub fn create_joint_trajectory_clients(
         )));
         let client: Arc<dyn JointTrajectoryClient> = if config.wrap_with_joint_velocity_limiter {
             if config.wrap_with_joint_position_limiter {
-                if let Some(limits) = config.joint_position_limits {
-                    Arc::new(JointPositionLimiter::new(
-                        JointVelocityLimiter::new(client, config.joint_velocity_limits),
-                        limits,
-                    ))
-                } else {
-                    Arc::new(JointPositionLimiter::from_urdf(
-                        JointVelocityLimiter::new(client, config.joint_velocity_limits),
-                        &urdf_robot.unwrap().joints,
-                    )?)
-                }
+                Arc::new(new_joint_position_limiter(
+                    new_joint_velocity_limiter(client, config.joint_velocity_limits, urdf_robot)?,
+                    config.joint_position_limits,
+                    urdf_robot,
+                )?)
             } else {
-                Arc::new(JointVelocityLimiter::new(
+                Arc::new(new_joint_velocity_limiter(
                     client,
                     config.joint_velocity_limits,
-                ))
-            }
-        } else if config.wrap_with_joint_position_limiter {
-            if let Some(limits) = config.joint_position_limits {
-                Arc::new(JointPositionLimiter::new(client, limits))
-            } else {
-                Arc::new(JointPositionLimiter::from_urdf(
-                    client,
-                    &urdf_robot.unwrap().joints,
+                    urdf_robot,
                 )?)
             }
+        } else if config.wrap_with_joint_position_limiter {
+            Arc::new(new_joint_position_limiter(
+                client,
+                config.joint_position_limits,
+                urdf_robot,
+            )?)
         } else {
             Arc::new(client)
         };
         clients.insert(config.name, client);
     }
     Ok(clients)
+}
+
+fn new_joint_position_limiter<C>(
+    client: C,
+    position_limits: Option<Vec<JointPositionLimit>>,
+    urdf_robot: Option<&urdf_rs::Robot>,
+) -> Result<JointPositionLimiter<C>, arci::Error>
+where
+    C: JointTrajectoryClient,
+{
+    match position_limits {
+        Some(position_limits) => Ok(JointPositionLimiter::new(client, position_limits)),
+        None => JointPositionLimiter::from_urdf(client, &urdf_robot.unwrap().joints),
+    }
+}
+
+fn new_joint_velocity_limiter<C>(
+    client: C,
+    velocity_limits: Option<Vec<f64>>,
+    urdf_robot: Option<&urdf_rs::Robot>,
+) -> Result<JointVelocityLimiter<C>, arci::Error>
+where
+    C: JointTrajectoryClient,
+{
+    match velocity_limits {
+        Some(velocity_limits) => Ok(JointVelocityLimiter::new(client, velocity_limits)),
+        None => JointVelocityLimiter::from_urdf(client, &urdf_robot.unwrap().joints),
+    }
 }
 
 pub fn create_joint_trajectory_message_for_send_joint_positions(

--- a/arci-urdf-viz/tests/test_client.rs
+++ b/arci-urdf-viz/tests/test_client.rs
@@ -24,7 +24,7 @@ fn test_urdf_viz_web_client_config_accessor() {
         wrap_with_joint_position_limiter: true,
         joint_position_limits: None,
         wrap_with_joint_velocity_limiter: true,
-        joint_velocity_limits: vec![1.0, 2.0],
+        joint_velocity_limits: Some(vec![1.0, 2.0]),
     };
     assert_eq!(config.name, "test");
     assert_eq!(config.joint_names[0], "j1");
@@ -32,22 +32,22 @@ fn test_urdf_viz_web_client_config_accessor() {
     assert_eq!(config.wrap_with_joint_position_limiter, true);
     assert!(config.joint_position_limits.is_none());
     assert_eq!(config.wrap_with_joint_velocity_limiter, true);
-    assert_approx_eq!(config.joint_velocity_limits[0], 1.0);
-    assert_approx_eq!(config.joint_velocity_limits[1], 2.0);
+    assert_approx_eq!(config.joint_velocity_limits.as_ref().unwrap()[0], 1.0);
+    assert_approx_eq!(config.joint_velocity_limits.unwrap()[1], 2.0);
     config.name = "arm".to_owned();
     config.joint_names = vec!["shoulder_pan_joint".to_owned(), "elbow_joint".to_owned()];
     config.wrap_with_joint_position_limiter = false;
     config.joint_position_limits = Some(vec![]);
     config.wrap_with_joint_velocity_limiter = false;
-    config.joint_velocity_limits = vec![0.0, 0.0];
+    config.joint_velocity_limits = Some(vec![0.0, 0.0]);
     assert_eq!(config.name, "arm");
     assert_eq!(config.joint_names[0], "shoulder_pan_joint");
     assert_eq!(config.joint_names[1], "elbow_joint");
     assert_eq!(config.wrap_with_joint_position_limiter, false);
     assert!(config.joint_position_limits.unwrap().is_empty());
     assert_eq!(config.wrap_with_joint_velocity_limiter, false);
-    assert_approx_eq!(config.joint_velocity_limits[0], 0.0);
-    assert_approx_eq!(config.joint_velocity_limits[1], 0.0);
+    assert_approx_eq!(config.joint_velocity_limits.as_ref().unwrap()[0], 0.0);
+    assert_approx_eq!(config.joint_velocity_limits.unwrap()[1], 0.0);
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn test_urdf_viz_web_client_config_debug() {
         wrap_with_joint_position_limiter: true,
         joint_position_limits: None,
         wrap_with_joint_velocity_limiter: true,
-        joint_velocity_limits: vec![1.0, 2.0],
+        joint_velocity_limits: Some(vec![1.0, 2.0]),
     };
     assert_eq!(
         format!("{:?}", config),
@@ -66,7 +66,7 @@ fn test_urdf_viz_web_client_config_debug() {
             joint_names: [\"j1\", \"j2\"], \
             wrap_with_joint_position_limiter: true, \
             wrap_with_joint_velocity_limiter: true, \
-            joint_velocity_limits: [1.0, 2.0], \
+            joint_velocity_limits: Some([1.0, 2.0]), \
             joint_position_limits: None \
         }"
     )
@@ -81,7 +81,7 @@ fn test_urdf_viz_web_client_config_clone() {
         wrap_with_joint_position_limiter: true,
         joint_position_limits: None,
         wrap_with_joint_velocity_limiter: true,
-        joint_velocity_limits: vec![1.0, 2.0],
+        joint_velocity_limits: Some(vec![1.0, 2.0]),
     };
     let config2 = config1.clone();
     assert_eq!(config2.name, "test");
@@ -90,8 +90,8 @@ fn test_urdf_viz_web_client_config_clone() {
     assert_eq!(config2.wrap_with_joint_position_limiter, true);
     assert!(config2.joint_position_limits.is_none());
     assert_eq!(config2.wrap_with_joint_velocity_limiter, true);
-    assert_approx_eq!(config2.joint_velocity_limits[0], 1.0);
-    assert_approx_eq!(config2.joint_velocity_limits[1], 2.0);
+    assert_approx_eq!(config2.joint_velocity_limits.as_ref().unwrap()[0], 1.0);
+    assert_approx_eq!(config2.joint_velocity_limits.unwrap()[1], 2.0);
 }
 
 #[test]
@@ -106,7 +106,7 @@ fn test_create_joint_trajectory_clients() {
             wrap_with_joint_position_limiter: false,
             joint_position_limits: None,
             wrap_with_joint_velocity_limiter: true,
-            joint_velocity_limits: vec![1.0, 1.0],
+            joint_velocity_limits: Some(vec![1.0, 1.0]),
         },
         UrdfVizWebClientConfig {
             name: "c2".to_owned(),
@@ -114,7 +114,7 @@ fn test_create_joint_trajectory_clients() {
             wrap_with_joint_position_limiter: false,
             joint_position_limits: None,
             wrap_with_joint_velocity_limiter: false,
-            joint_velocity_limits: vec![],
+            joint_velocity_limits: None,
         },
     ];
     let _clients = arci_urdf_viz::create_joint_trajectory_clients(configs, 0.1, 0.1, None).unwrap();


### PR DESCRIPTION
This adds `JointVelocityLimiter::from_urdf` method that creates a new `JointVelocityLimiter` with the velocity limits defined in URDF.