### PR TITLE
[arci-ros2] Add arci-ros2 (only MoveBase trait)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,7 +17,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     container:
-      image: docker://openrr/openrr-coverage-ci:0
+      image: docker://openrr/openrr-coverage-ci:ros2
       options: --security-opt seccomp=unconfined
     env:
       HOME: /root
@@ -27,7 +27,9 @@ jobs:
       - name: Generate code coverage
         run: |
           # for test of arci-ros (roscore, rostopic)
-          source /opt/ros/melodic/setup.bash
+          source /opt/ros/noetic/setup.bash
+          # for test of arci-ros2
+          source /opt/ros/foxy/setup.bash
           cargo +nightly-2021-03-04 tarpaulin --verbose --all-features --workspace --out Xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -26,11 +26,11 @@ jobs:
       - run: ci/ubuntu-install-dependencies.sh
       - name: Generate code coverage
         run: |
-          # for test of arci-ros (roscore, rostopic)
-          source /opt/ros/noetic/setup.bash
           # for test of arci-ros2
           source /opt/ros/foxy/setup.bash
-          cargo +nightly-2021-03-04 tarpaulin --verbose --all-features --workspace --out Xml
+          # for test of arci-ros (roscore, rostopic)
+          source /opt/ros/noetic/setup.bash
+          cargo +nightly-2021-03-04 tarpaulin --verbose --all-features --workspace --out Xml --timeout 60
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: ci/ubuntu-install-dependencies.sh
       - run: cargo install cargo-hack
-      - run: cargo hack check --all --feature-powerset --optional-deps
+      - run: cargo hack check --all --feature-powerset --optional-deps --exclude arci-ros2
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,11 +74,11 @@ jobs:
           toolchain: stable
           override: true
       - run: ci/ubuntu-install-dependencies.sh
-      # testing arci-ros is done in ros1.yaml
+      # testing arci-ros/arci-ros2 is done in ros1.yaml, ros2.yaml
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --exclude arci-ros
+          args: --workspace --exclude arci-ros --exclude arci-ros2
       - name: cargo test (openrr-apps without ros)
         working-directory: openrr-apps
         run: cargo test --no-default-features --features gui,assimp

--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -1,0 +1,38 @@
+name: ros2
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ros2_arci_ros2:
+    runs-on: ubuntu-20.04
+    container:
+      image: docker://ros:foxy
+    env:
+      HOME: /root
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          apt-get update
+          apt-get -y install curl
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: cargo build
+        shell: bash -ieo pipefail {0}
+        working-directory: arci-ros2
+        run: |
+          source /opt/ros/foxy/setup.bash
+          cargo build --examples
+      - name: cargo test
+        shell: bash -ieo pipefail {0}
+        working-directory: arci-ros2
+        run: |
+          source /opt/ros/foxy/setup.bash
+          cargo test
+

--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           apt-get update
-          apt-get -y install curl
+          apt-get -y install curl libclang-dev
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/ros2.yaml
+++ b/.github/workflows/ros2.yaml
@@ -28,11 +28,10 @@ jobs:
         working-directory: arci-ros2
         run: |
           source /opt/ros/foxy/setup.bash
-          cargo build --examples
+          cargo build --features ros2 --examples
       - name: cargo test
         shell: bash -ieo pipefail {0}
         working-directory: arci-ros2
         run: |
           source /opt/ros/foxy/setup.bash
-          cargo test
-
+          cargo test --features ros2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "arci",
     "arci-gamepad-gilrs",
     "arci-ros",
+    "arci-ros2",
     "arci-speak-cmd",
     "arci-speak-audio",
     "arci-urdf-viz",
@@ -24,6 +25,7 @@ arci-speak-audio = { path = "arci-speak-audio" }
 arci = { path = "arci" }
 arci-gamepad-gilrs = { path = "arci-gamepad-gilrs" }
 arci-ros = { path = "arci-ros" }
+arci-ros2 = { path = "arci-ros2" }
 arci-urdf-viz = { path = "arci-urdf-viz" }
 openrr = { path = "openrr" }
 openrr-apps = { path = "openrr-apps" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "arci",
     "arci-gamepad-gilrs",
     "arci-ros",
+    "arci-ros2",
     "arci-speak-cmd",
     "arci-speak-audio",
     "arci-urdf-viz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ members = [
     "arci",
     "arci-gamepad-gilrs",
     "arci-ros",
-    "arci-ros2",
     "arci-speak-cmd",
     "arci-speak-audio",
     "arci-urdf-viz",

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -19,5 +19,6 @@ r2r = { git = "https://github.com/sequenceplanner/r2r" }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
+assert_approx_eq = "1.1"
 
 [workspace]

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -15,10 +15,11 @@ anyhow = "1.0"
 arci = "0.0.5"
 async-trait = "0.1"
 thiserror = "1.0"
-r2r = { git = "https://github.com/sequenceplanner/r2r" }
+r2r = { git = "https://github.com/sequenceplanner/r2r", optional = true}
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
 assert_approx_eq = "1.1"
 
-[workspace]
+[features]
+ros2 = ["r2r"]

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "arci-ros2"
+version = "0.0.5"
+authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
+edition = "2018"
+license = "Apache-2.0"
+description = "arci implementation using ROS2"
+keywords = ["robotics", "robot"]
+categories = ["science::robotics"]
+repository = "https://github.com/openrr/openrr"
+documentation = "http://docs.rs/arci-ros2"
+
+[dependencies]
+anyhow = "1.0"
+arci = "0.0.5"
+async-trait = "0.1"
+thiserror = "1.0"
+r2r = { git = "https://github.com/sequenceplanner/r2r" }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["full"] }

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -8,7 +8,7 @@ description = "arci implementation using ROS2"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "http://docs.rs/arci-ros2"
+documentation = "https://docs.rs/arci-ros2"
 
 [dependencies]
 anyhow = "1.0"

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -19,3 +19,5 @@ r2r = { git = "https://github.com/sequenceplanner/r2r" }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
+
+[workspace]

--- a/arci-ros2/LICENSE
+++ b/arci-ros2/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/arci-ros2/README.md
+++ b/arci-ros2/README.md
@@ -1,0 +1,9 @@
+# arci-ros2
+
+[![crates.io](https://img.shields.io/crates/v/arci-ros2.svg)](https://crates.io/crates/arci-ros2) [![docs](https://docs.rs/arci-ros2/badge.svg)](https://docs.rs/arci-ros2)
+
+ROS2 implementation for arci.
+
+## Dependencies
+
+* [r2r](https://github.com/sequenceplanner/r2r)

--- a/arci-ros2/README.md
+++ b/arci-ros2/README.md
@@ -6,4 +6,6 @@ ROS2 implementation for arci.
 
 ## Dependencies
 
+* ROS2 Foxy
 * [r2r](https://github.com/sequenceplanner/r2r)
+  * libclang-dev

--- a/arci-ros2/examples/cmd_vel.rs
+++ b/arci-ros2/examples/cmd_vel.rs
@@ -1,9 +1,11 @@
 use anyhow::Error;
-use arci::{BaseVelocity, MoveBase};
-use arci_ros2::{r2r, Ros2CmdVelMoveBase};
 
+#[cfg(feature = "ros2")]
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    use arci::{BaseVelocity, MoveBase};
+    use arci_ros2::{r2r, Ros2CmdVelMoveBase};
+
     let ctx = r2r::Context::create().unwrap();
     let mut node = r2r::Node::create(ctx, "example_cmd_vel_node", "").unwrap();
     let c = Ros2CmdVelMoveBase::new(&mut node, "/cmd_vel");
@@ -23,5 +25,10 @@ async fn main() -> Result<(), Error> {
         count -= 1;
         println!("{}, {:?}", count, vel);
     }
+    Ok(())
+}
+
+#[cfg(not(feature = "ros2"))]
+fn main() -> Result<(), Error> {
     Ok(())
 }

--- a/arci-ros2/examples/cmd_vel.rs
+++ b/arci-ros2/examples/cmd_vel.rs
@@ -1,0 +1,27 @@
+use anyhow::Error;
+use arci::{BaseVelocity, MoveBase};
+use arci_ros2::{r2r, Ros2CmdVelMoveBase};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let ctx = r2r::Context::create().unwrap();
+    let mut node = r2r::Node::create(ctx, "example_cmd_vel_node", "").unwrap();
+    let c = Ros2CmdVelMoveBase::new(&mut node, "/cmd_vel");
+    let mut count = 0;
+    let mut vel = BaseVelocity::default();
+    while count < 100 {
+        vel.x = 0.001 * (count as f64);
+        c.send_velocity(&vel)?;
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        count += 1;
+        println!("{}, {:?}", count, vel);
+    }
+    while count >= 0 {
+        vel.x = 0.001 * (count as f64);
+        c.send_velocity(&vel)?;
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        count -= 1;
+        println!("{}, {:?}", count, vel);
+    }
+    Ok(())
+}

--- a/arci-ros2/examples/cmd_vel.rs
+++ b/arci-ros2/examples/cmd_vel.rs
@@ -1,8 +1,7 @@
-use anyhow::Error;
-
 #[cfg(feature = "ros2")]
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    use anyhow::Error;
     use arci::{BaseVelocity, MoveBase};
     use arci_ros2::{r2r, Ros2CmdVelMoveBase};
 
@@ -29,6 +28,4 @@ async fn main() -> Result<(), Error> {
 }
 
 #[cfg(not(feature = "ros2"))]
-fn main() -> Result<(), Error> {
-    Ok(())
-}
+fn main() {}

--- a/arci-ros2/examples/cmd_vel.rs
+++ b/arci-ros2/examples/cmd_vel.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "ros2")]
 #[tokio::main]
-async fn main() -> Result<(), Error> {
-    use anyhow::Error;
+async fn main() -> Result<(), anyhow::Error> {
     use arci::{BaseVelocity, MoveBase};
     use arci_ros2::{r2r, Ros2CmdVelMoveBase};
 

--- a/arci-ros2/src/cmd_vel_move_base.rs
+++ b/arci-ros2/src/cmd_vel_move_base.rs
@@ -31,7 +31,7 @@ impl MoveBase for Ros2CmdVelMoveBase {
     }
 
     fn current_velocity(&self) -> Result<BaseVelocity, Error> {
-        panic!("not implemented yet");
+        unimplemented!("Read from /odom in the future?");
     }
 }
 

--- a/arci-ros2/src/cmd_vel_move_base.rs
+++ b/arci-ros2/src/cmd_vel_move_base.rs
@@ -1,0 +1,41 @@
+use arci::*;
+use r2r::geometry_msgs::msg::Twist;
+
+#[derive(Debug)]
+pub struct Ros2CmdVelMoveBase {
+    vel_publisher: r2r::Publisher<Twist>,
+}
+
+impl Ros2CmdVelMoveBase {
+    pub fn new(node: &mut r2r::Node, cmd_topic_name: &str) -> Self {
+        Self {
+            vel_publisher: node.create_publisher(cmd_topic_name).unwrap(),
+        }
+    }
+}
+
+unsafe impl Send for Ros2CmdVelMoveBase {}
+unsafe impl Sync for Ros2CmdVelMoveBase {}
+
+impl MoveBase for Ros2CmdVelMoveBase {
+    fn send_velocity(&self, velocity: &BaseVelocity) -> Result<(), Error> {
+        let mut twist_msg = Twist::default();
+        twist_msg.linear.x = velocity.x;
+        twist_msg.linear.y = velocity.y;
+        twist_msg.angular.z = velocity.theta;
+        self.vel_publisher
+            .publish(&twist_msg)
+            .map_err(|e| arci::Error::Connection {
+                message: format!("r2r publish error: {:?}", e),
+            })
+    }
+
+    fn current_velocity(&self) -> Result<BaseVelocity, Error> {
+        panic!("not implemented yet");
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Ros2CmdVelMoveBaseConfig {
+    pub topic: String,
+}

--- a/arci-ros2/src/lib.rs
+++ b/arci-ros2/src/lib.rs
@@ -1,7 +1,8 @@
 //! [`arci`] implementation using ROS1.
-
+#[cfg(feature = "ros2")]
 mod cmd_vel_move_base;
-
+#[cfg(feature = "ros2")]
 pub use cmd_vel_move_base::*;
 // re-export
+#[cfg(feature = "ros2")]
 pub use r2r;

--- a/arci-ros2/src/lib.rs
+++ b/arci-ros2/src/lib.rs
@@ -1,4 +1,4 @@
-//! [`arci`] implementation using ROS1.
+//! [`arci`] implementation using ROS2.
 #[cfg(feature = "ros2")]
 mod cmd_vel_move_base;
 #[cfg(feature = "ros2")]

--- a/arci-ros2/src/lib.rs
+++ b/arci-ros2/src/lib.rs
@@ -1,0 +1,7 @@
+//! [`arci`] implementation using ROS1.
+
+mod cmd_vel_move_base;
+
+pub use cmd_vel_move_base::*;
+// re-export
+pub use r2r;

--- a/arci-ros2/tests/test_cmd_vel.rs
+++ b/arci-ros2/tests/test_cmd_vel.rs
@@ -1,12 +1,12 @@
-use std::sync::mpsc;
-
-use arci::{BaseVelocity, MoveBase};
-use arci_ros2::{r2r, Ros2CmdVelMoveBase};
-use assert_approx_eq::assert_approx_eq;
-use r2r::geometry_msgs::msg::Twist;
-
+#[cfg(feature = "ros2")]
 #[tokio::test]
 async fn test_pub() {
+    use arci::{BaseVelocity, MoveBase};
+    use arci_ros2::{r2r, Ros2CmdVelMoveBase};
+    use assert_approx_eq::assert_approx_eq;
+    use r2r::geometry_msgs::msg::Twist;
+    use std::sync::mpsc;
+
     let ctx = r2r::Context::create().unwrap();
     let mut node = r2r::Node::create(ctx, "example_cmd_vel_node", "").unwrap();
     let c = Ros2CmdVelMoveBase::new(&mut node, "/cmd_vel_test");

--- a/arci-ros2/tests/test_cmd_vel.rs
+++ b/arci-ros2/tests/test_cmd_vel.rs
@@ -1,11 +1,12 @@
 #[cfg(feature = "ros2")]
 #[tokio::test]
 async fn test_pub() {
+    use std::sync::mpsc;
+
     use arci::{BaseVelocity, MoveBase};
     use arci_ros2::{r2r, Ros2CmdVelMoveBase};
     use assert_approx_eq::assert_approx_eq;
     use r2r::geometry_msgs::msg::Twist;
-    use std::sync::mpsc;
 
     let ctx = r2r::Context::create().unwrap();
     let mut node = r2r::Node::create(ctx, "example_cmd_vel_node", "").unwrap();

--- a/arci-ros2/tests/test_cmd_vel.rs
+++ b/arci-ros2/tests/test_cmd_vel.rs
@@ -1,4 +1,5 @@
-#[cfg(feature = "ros2")]
+#![cfg(feature = "ros2")]
+
 #[tokio::test]
 async fn test_pub() {
     use std::sync::mpsc;

--- a/arci-ros2/tests/test_cmd_vel.rs
+++ b/arci-ros2/tests/test_cmd_vel.rs
@@ -4,7 +4,6 @@ use assert_approx_eq::assert_approx_eq;
 use r2r::geometry_msgs::msg::Twist;
 use std::sync::mpsc;
 
-#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn test_pub() {
     let ctx = r2r::Context::create().unwrap();
@@ -21,10 +20,10 @@ async fn test_pub() {
 
     let mut count = 0;
     let mut vel = BaseVelocity::default();
-    while count < 100 {
+    while count < 10 {
         vel.x = 0.001 * (count as f64);
         c.send_velocity(&vel).unwrap();
-        node.spin_once(std::time::Duration::from_millis(1));
+        node.spin_once(std::time::Duration::from_millis(10));
         let v = rx.recv().unwrap();
         assert_approx_eq!(v.linear.x, vel.x);
         assert_approx_eq!(v.linear.y, vel.y);
@@ -41,7 +40,7 @@ async fn test_pub() {
         vel.y = 0.002 * (count as f64);
         vel.theta = -0.003 * (count as f64);
         c.send_velocity(&vel).unwrap();
-        node.spin_once(std::time::Duration::from_millis(1));
+        node.spin_once(std::time::Duration::from_millis(10));
         let v = rx.recv().unwrap();
         assert_approx_eq!(v.linear.x, vel.x);
         assert_approx_eq!(v.linear.y, vel.y);

--- a/arci-ros2/tests/test_cmd_vel.rs
+++ b/arci-ros2/tests/test_cmd_vel.rs
@@ -1,0 +1,56 @@
+use arci::{BaseVelocity, MoveBase};
+use arci_ros2::{r2r, Ros2CmdVelMoveBase};
+use assert_approx_eq::assert_approx_eq;
+use r2r::geometry_msgs::msg::Twist;
+use std::sync::mpsc;
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn test_pub() {
+    let ctx = r2r::Context::create().unwrap();
+    let mut node = r2r::Node::create(ctx, "example_cmd_vel_node", "").unwrap();
+    let c = Ros2CmdVelMoveBase::new(&mut node, "/cmd_vel_test");
+    let (tx, rx) = mpsc::channel::<Twist>();
+
+    let _sub = node.subscribe(
+        "/cmd_vel_test",
+        Box::new(move |v: Twist| {
+            tx.send(v).unwrap();
+        }),
+    );
+
+    let mut count = 0;
+    let mut vel = BaseVelocity::default();
+    while count < 100 {
+        vel.x = 0.001 * (count as f64);
+        c.send_velocity(&vel).unwrap();
+        node.spin_once(std::time::Duration::from_millis(1));
+        let v = rx.recv().unwrap();
+        assert_approx_eq!(v.linear.x, vel.x);
+        assert_approx_eq!(v.linear.y, vel.y);
+        assert_approx_eq!(v.linear.z, 0.0);
+        assert_approx_eq!(v.angular.x, 0.0);
+        assert_approx_eq!(v.angular.y, 0.0);
+        assert_approx_eq!(v.angular.z, vel.theta);
+
+        count += 1;
+        println!("{}, {:?}", count, vel);
+    }
+    while count >= 0 {
+        vel.x = 0.001 * (count as f64);
+        vel.y = 0.002 * (count as f64);
+        vel.theta = -0.003 * (count as f64);
+        c.send_velocity(&vel).unwrap();
+        node.spin_once(std::time::Duration::from_millis(1));
+        let v = rx.recv().unwrap();
+        assert_approx_eq!(v.linear.x, vel.x);
+        assert_approx_eq!(v.linear.y, vel.y);
+        assert_approx_eq!(v.linear.z, 0.0);
+        assert_approx_eq!(v.angular.x, 0.0);
+        assert_approx_eq!(v.angular.y, 0.0);
+        assert_approx_eq!(v.angular.z, vel.theta);
+
+        count -= 1;
+        println!("{}, {:?}", count, vel);
+    }
+}

--- a/arci-ros2/tests/test_cmd_vel.rs
+++ b/arci-ros2/tests/test_cmd_vel.rs
@@ -1,8 +1,9 @@
+use std::sync::mpsc;
+
 use arci::{BaseVelocity, MoveBase};
 use arci_ros2::{r2r, Ros2CmdVelMoveBase};
 use assert_approx_eq::assert_approx_eq;
 use r2r::geometry_msgs::msg::Twist;
-use std::sync::mpsc;
 
 #[tokio::test]
 async fn test_pub() {


### PR DESCRIPTION
It requires ROS2 Foxy (Ubuntu 20.04).

* r2r is not published to crates.io yet.
* It requires ROS2 foxy is installed.