### PR TITLE
[openrr-apps] Add JSON schemas for config files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,18 @@ jobs:
         working-directory: openrr-apps
         run: cargo test --no-default-features --features gui
 
+  # TODO(taiki-e): Some configs use HashMap and the order of the default values
+  #                will change every time because HashMap order is not stable.
+  #                So we cannot enable this check until the uses of HashMap in
+  #                configs are removed.
+  # # When this job failed, run tools/update-schema.sh and commit result changes.
+  # schema:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: tools/update-schema.sh
+  #     - run: git diff --exit-code
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,17 @@ members = [
 
 [patch.crates-io]
 
-"arci-speak-cmd" = {path = "arci-speak-cmd"}
-"arci-speak-audio" = {path = "arci-speak-audio"}
-"arci" = {path = "arci"}
-"arci-gamepad-gilrs" = {path = "arci-gamepad-gilrs"}
-"arci-ros" = {path = "arci-ros"}
-"arci-urdf-viz" = {path = "arci-urdf-viz"}
-"openrr" = {path = "openrr"}
-"openrr-apps" = {path = "openrr-apps"}
-"openrr-client" = {path = "openrr-client"}
-"openrr-command" = {path = "openrr-command"}
-"openrr-gui" = {path = "openrr-gui"}
-"openrr-planner" = {path = "openrr-planner"}
-"openrr-sleep" = {path = "openrr-sleep"}
-"openrr-teleop" = {path = "openrr-teleop"}
+arci-speak-cmd = { path = "arci-speak-cmd" }
+arci-speak-audio = { path = "arci-speak-audio" }
+arci = { path = "arci" }
+arci-gamepad-gilrs = { path = "arci-gamepad-gilrs" }
+arci-ros = { path = "arci-ros" }
+arci-urdf-viz = { path = "arci-urdf-viz" }
+openrr = { path = "openrr" }
+openrr-apps = { path = "openrr-apps" }
+openrr-client = { path = "openrr-client" }
+openrr-command = { path = "openrr-command" }
+openrr-gui = { path = "openrr-gui" }
+openrr-planner = { path = "openrr-planner" }
+openrr-sleep = { path = "openrr-sleep" }
+openrr-teleop = { path = "openrr-teleop" }

--- a/arci-gamepad-gilrs/Cargo.toml
+++ b/arci-gamepad-gilrs/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "http://docs.rs/arci-gamepad-gilrs"
 arci = "0.0.5"
 flume = "0.10"
 gilrs = { version = "0.8.1", features = ["serde-serialize"] }
+schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.5"
 tracing = { version = "0.1", features = ["log"] }

--- a/arci-ros/Cargo.toml
+++ b/arci-ros/Cargo.toml
@@ -19,6 +19,7 @@ nalgebra = "0.26"
 paste = "1.0"
 ros-nalgebra = "0.0.5"
 rosrust = "0.9"
+schemars = "0.8.3"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/arci-ros/src/cmd_vel_move_base.rs
+++ b/arci-ros/src/cmd_vel_move_base.rs
@@ -1,4 +1,5 @@
 use arci::*;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{msg, rosrust_utils::wait_subscriber};
@@ -33,7 +34,7 @@ impl MoveBase for RosCmdVelMoveBase {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct RosCmdVelMoveBaseConfig {
     pub topic: String,
 }

--- a/arci-ros/src/ros_control_client.rs
+++ b/arci-ros/src/ros_control_client.rs
@@ -10,11 +10,12 @@ use msg::{
     control_msgs::JointTrajectoryControllerState,
     trajectory_msgs::{JointTrajectory, JointTrajectoryPoint},
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{error::Error, msg, SubscriberHandler};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct RosControlClientConfig {
     pub name: String,
     pub joint_names: Vec<String>,

--- a/arci-ros/src/ros_localization_client.rs
+++ b/arci-ros/src/ros_localization_client.rs
@@ -2,6 +2,7 @@ use std::borrow::Borrow;
 
 use arci::*;
 use nalgebra as na;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{msg, rosrust_utils::*};
@@ -13,7 +14,7 @@ rosrust::rosmsg_include! {
 const AMCL_POSE_TOPIC: &str = "/amcl_pose";
 const NO_MOTION_UPDATE_SERVICE: &str = "request_nomotion_update";
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct RosLocalizationClientConfig {
     pub request_final_nomotion_update_hack: bool,
 }

--- a/arci-ros/src/ros_nav_client.rs
+++ b/arci-ros/src/ros_nav_client.rs
@@ -2,6 +2,7 @@ use std::{sync::Arc, time};
 
 use arci::*;
 use nalgebra as na;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{define_action_client_internal, msg};
@@ -227,7 +228,7 @@ impl Navigation for RosNavClient {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct RosNavClientConfig {
     pub request_final_nomotion_update_hack: bool,
     pub clear_costmap_before_start: bool,

--- a/arci-ros/src/ros_speak_client.rs
+++ b/arci-ros/src/ros_speak_client.rs
@@ -1,4 +1,5 @@
 use arci::WaitFuture;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 mod msg {
@@ -9,7 +10,7 @@ pub struct RosEspeakClient {
     publisher: rosrust::Publisher<msg::std_msgs::String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct RosEspeakClientConfig {
     pub topic: String,
 }

--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -17,11 +17,12 @@ async-trait = "0.1"
 nalgebra = "0.26"
 openrr-planner = { version = "0.0.5", default-features = false }
 openrr-sleep = "0.0.5"
+schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = { version = "0.1", features = ["log"] }
-ureq = { version = "2", features = ["json"] }
 urdf-rs = "0.6"
+ureq = { version = "2", features = ["json"] }
 url = "2.0"
 
 [dev-dependencies]

--- a/arci-urdf-viz/src/client.rs
+++ b/arci-urdf-viz/src/client.rs
@@ -17,13 +17,14 @@ use arci::{
 };
 use nalgebra as na;
 use openrr_sleep::ScopedSleep;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 use url::Url;
 
 use crate::utils::*;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct UrdfVizWebClientConfig {
     pub name: String,
     pub joint_names: Vec<String>,

--- a/arci/Cargo.toml
+++ b/arci/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "0.1"
 auto_impl = "0.4"
 futures = "0.3"
 nalgebra = "0.26"
+schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["time"] }

--- a/arci/src/clients/joint_position_limiter.rs
+++ b/arci/src/clients/joint_position_limiter.rs
@@ -1,5 +1,6 @@
 use std::{f64, ops::RangeInclusive};
 
+use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tracing::debug;
 use urdf_rs::JointType;
@@ -236,6 +237,24 @@ impl Serialize for JointPositionLimit {
     }
 }
 
+impl JsonSchema for JointPositionLimit {
+    fn schema_name() -> String {
+        "JointPositionLimit".into()
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        // As workaround for https://github.com/tamasfe/taplo/issues/57,
+        // use struct with option value instead of enum.
+        #[allow(dead_code)]
+        #[derive(JsonSchema)]
+        struct JointPositionLimitRepr {
+            lower: Option<f64>,
+            upper: Option<f64>,
+        }
+
+        JointPositionLimitRepr::json_schema(gen)
+    }
+}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum JointPositionLimiterStrategy {

--- a/arci/src/traits/gamepad.rs
+++ b/arci/src/traits/gamepad.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
 use auto_impl::auto_impl;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub enum Button {
     South,
     East,
@@ -24,7 +25,7 @@ pub enum Button {
     Unknown,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub enum Axis {
     LeftStickX,
     LeftStickY,

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -32,7 +32,9 @@ openrr-client = "0.0.5"
 openrr-command = "0.0.5"
 openrr-teleop = "0.0.5"
 rand = "0.8.0"
+schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 structopt = "0.3.21"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
@@ -58,3 +60,7 @@ path = "src/bin/robot_teleop.rs"
 name = "openrr_apps_joint_position_sender"
 path = "src/bin/joint_position_sender.rs"
 required-features = ["gui"]
+
+[[bin]]
+name = "openrr_apps_config"
+path = "src/bin/config.rs"

--- a/openrr-apps/README.md
+++ b/openrr-apps/README.md
@@ -267,3 +267,26 @@ openrr_apps_joint_position_sender
 ```
 
 Do not forget to unset OPENRR_APPS_ROBOT_CONFIG_PATH before try other settings
+
+## Schemas for config files
+
+The `schema` directory contains the JSON schemas for the config files used by openrr, and when combined with an extension of the editor that supports completion using the JSON schema, completion can be enabled.
+
+### Visual Studio Code
+
+In VS Code, you can enable completion and validation by installing the [Even Better TOML] extension and using the `evenBetterToml.schema.associations` configuration object in `settings.json`.
+
+For example:
+
+```json
+{
+  "evenBetterToml.schema.associations": {
+    ".*robot_client_config.*\\.toml": "https://raw.githubusercontent.com/openrr/openrr/main/openrr-apps/schema/robot_config.json",
+    ".*teleop_config.*\\.toml": "https://raw.githubusercontent.com/openrr/openrr/main/openrr-apps/schema/robot_teleop_config.json",
+  },
+}
+```
+
+<img width="581" alt="" src="https://user-images.githubusercontent.com/43724913/116380268-c458c700-a84e-11eb-83d2-3fd33b74183c.png">
+
+[Even Better TOML]: https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml

--- a/openrr-apps/config/pr2_robot_client_config_for_ros.toml
+++ b/openrr-apps/config/pr2_robot_client_config_for_ros.toml
@@ -4,14 +4,30 @@ ros_cmd_vel_move_base_client_config.topic = "/base_controller/command"
 
 [[ros_clients_configs]]
 name = "l_arm"
-joint_names = ["l_shoulder_pan_joint", "l_shoulder_lift_joint", "l_upper_arm_roll_joint", "l_elbow_flex_joint", "l_forearm_roll_joint", "l_wrist_flex_joint", "l_wrist_roll_joint"]
+joint_names = [
+    "l_shoulder_pan_joint",
+    "l_shoulder_lift_joint",
+    "l_upper_arm_roll_joint",
+    "l_elbow_flex_joint",
+    "l_forearm_roll_joint",
+    "l_wrist_flex_joint",
+    "l_wrist_roll_joint",
+]
 complete_allowable_errors = [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
 controller_name = "l_arm_controller"
 state_topic_name = "l_arm_controller/openrr/state"
 
 [[ros_clients_configs]]
 name = "r_arm"
-joint_names = ["r_shoulder_pan_joint", "r_shoulder_lift_joint", "r_upper_arm_roll_joint", "r_elbow_flex_joint", "r_forearm_roll_joint", "r_wrist_flex_joint", "r_wrist_roll_joint"]
+joint_names = [
+    "r_shoulder_pan_joint",
+    "r_shoulder_lift_joint",
+    "r_upper_arm_roll_joint",
+    "r_elbow_flex_joint",
+    "r_forearm_roll_joint",
+    "r_wrist_flex_joint",
+    "r_wrist_roll_joint",
+]
 complete_allowable_errors = [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
 controller_name = "r_arm_controller"
 state_topic_name = "r_arm_controller/openrr/state"

--- a/openrr-apps/config/pr2_robot_client_config_for_urdf_viz.toml
+++ b/openrr-apps/config/pr2_robot_client_config_for_urdf_viz.toml
@@ -1,10 +1,26 @@
 [[urdf_viz_clients_configs]]
 name = "l_arm"
-joint_names = ["l_shoulder_pan_joint", "l_shoulder_lift_joint", "l_upper_arm_roll_joint", "l_elbow_flex_joint", "l_forearm_roll_joint", "l_wrist_flex_joint", "l_wrist_roll_joint"]
+joint_names = [
+    "l_shoulder_pan_joint",
+    "l_shoulder_lift_joint",
+    "l_upper_arm_roll_joint",
+    "l_elbow_flex_joint",
+    "l_forearm_roll_joint",
+    "l_wrist_flex_joint",
+    "l_wrist_roll_joint",
+]
 
 [[urdf_viz_clients_configs]]
 name = "r_arm"
-joint_names = ["r_shoulder_pan_joint", "r_shoulder_lift_joint", "r_upper_arm_roll_joint", "r_elbow_flex_joint", "r_forearm_roll_joint", "r_wrist_flex_joint", "r_wrist_roll_joint"]
+joint_names = [
+    "r_shoulder_pan_joint",
+    "r_shoulder_lift_joint",
+    "r_upper_arm_roll_joint",
+    "r_elbow_flex_joint",
+    "r_forearm_roll_joint",
+    "r_wrist_flex_joint",
+    "r_wrist_roll_joint",
+]
 
 [[urdf_viz_clients_configs]]
 name = "torso"

--- a/openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml
+++ b/openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml
@@ -12,12 +12,12 @@ wrap_with_joint_position_limiter = true
 # If joint_position_limits is not specified, limits will be got from URDF.
 # The following values are the same as if getting limits from URDF.
 joint_position_limits = [
-    { lower = -3, upper = 3 },
-    { lower = -2, upper = 1.5 },
-    { lower = -1.5, upper = 2 },
-    { lower = -2, upper = 1.5 },
-    { lower = -3, upper = 3 },
-    { lower = -2, upper = 2 },
+    { lower = -3.0, upper = 3.0 },
+    { lower = -2.0, upper = 1.5 },
+    { lower = -1.5, upper = 2.0 },
+    { lower = -2.0, upper = 1.5 },
+    { lower = -3.0, upper = 3.0 },
+    { lower = -2.0, upper = 2.0 },
 ]
 
 [openrr_clients_config]

--- a/openrr-apps/config/sample_robot_client_config_for_urdf_viz_with_multiple_speaker.toml
+++ b/openrr-apps/config/sample_robot_client_config_for_urdf_viz_with_multiple_speaker.toml
@@ -1,6 +1,13 @@
 [[urdf_viz_clients_configs]]
 name = "arm"
-joint_names = ["l_shoulder_yaw", "l_shoulder_pitch", "l_shoulder_roll", "l_elbow_pitch", "l_wrist_yaw", "l_wrist_pitch"]
+joint_names = [
+    "l_shoulder_yaw",
+    "l_shoulder_pitch",
+    "l_shoulder_roll",
+    "l_elbow_pitch",
+    "l_wrist_yaw",
+    "l_wrist_pitch",
+]
 
 [speak_configs."print"]
 type = "Print"

--- a/openrr-apps/config/ur10_robot_client_config_for_ros.toml
+++ b/openrr-apps/config/ur10_robot_client_config_for_ros.toml
@@ -3,7 +3,14 @@ use_navigation_urdf_viz_web_client = false
 
 [[ros_clients_configs]]
 name = "arm"
-joint_names = ["shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", "wrist_1_joint", "wrist_2_joint", "wrist_3_joint"]
+joint_names = [
+    "shoulder_pan_joint",
+    "shoulder_lift_joint",
+    "elbow_joint",
+    "wrist_1_joint",
+    "wrist_2_joint",
+    "wrist_3_joint",
+]
 complete_allowable_errors = [0.02, 0.02, 0.02, 0.02, 0.02, 0.02]
 controller_name = "arm_controller"
 

--- a/openrr-apps/config/ur10_robot_client_config_for_urdf_viz.toml
+++ b/openrr-apps/config/ur10_robot_client_config_for_urdf_viz.toml
@@ -1,6 +1,13 @@
 [[urdf_viz_clients_configs]]
 name = "arm"
-joint_names = ["shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint", "wrist_1_joint", "wrist_2_joint", "wrist_3_joint"]
+joint_names = [
+    "shoulder_pan_joint",
+    "shoulder_lift_joint",
+    "elbow_joint",
+    "wrist_1_joint",
+    "wrist_2_joint",
+    "wrist_3_joint",
+]
 
 [openrr_clients_config]
 urdf_path = "../../../universal_robot/ur_description/urdf/ur10_robot.urdf.xacro"

--- a/openrr-apps/config/ur10_teleop_config_urdf_viz.toml
+++ b/openrr-apps/config/ur10_teleop_config_urdf_viz.toml
@@ -17,5 +17,3 @@ client_name = "arm_collision_checked"
 
 [control_nodes_config.joy_joint_teleop_configs.config]
 mode = "arm"
-
-

--- a/openrr-apps/schema/robot_config.json
+++ b/openrr-apps/schema/robot_config.json
@@ -1,0 +1,594 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RobotConfig",
+  "type": "object",
+  "required": [
+    "openrr_clients_config"
+  ],
+  "properties": {
+    "openrr_clients_config": {
+      "$ref": "#/definitions/OpenrrClientsConfig"
+    },
+    "ros_clients_configs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/RosControlClientConfig"
+      }
+    },
+    "ros_cmd_vel_move_base_client_config": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RosCmdVelMoveBaseConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ros_localization_client_config": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RosLocalizationClientConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "ros_navigation_client_config": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RosNavClientConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "speak_configs": {
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/SpeakConfig"
+      }
+    },
+    "urdf_viz_clients_complete_timeout_sec": {
+      "default": 3.0,
+      "type": "number",
+      "format": "double"
+    },
+    "urdf_viz_clients_configs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/UrdfVizWebClientConfig"
+      }
+    },
+    "urdf_viz_clients_total_complete_allowable_error": {
+      "default": 0.02,
+      "type": "number",
+      "format": "double"
+    },
+    "use_localization_urdf_viz_web_client": {
+      "default": true,
+      "type": "boolean"
+    },
+    "use_move_base_urdf_viz_web_client": {
+      "default": true,
+      "type": "boolean"
+    },
+    "use_navigation_urdf_viz_web_client": {
+      "default": true,
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "CollisionCheckClientConfig": {
+      "type": "object",
+      "required": [
+        "client_name",
+        "name"
+      ],
+      "properties": {
+        "client_name": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "self_collision_checker_config": {
+          "default": {
+            "prediction": 0.001,
+            "time_interpolate_rate": 0.5
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SelfCollisionCheckerConfig"
+            }
+          ]
+        }
+      }
+    },
+    "IkClientConfig": {
+      "type": "object",
+      "required": [
+        "client_name",
+        "name",
+        "solver_name"
+      ],
+      "properties": {
+        "client_name": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "solver_name": {
+          "type": "string"
+        }
+      }
+    },
+    "IkSolverConfig": {
+      "type": "object",
+      "required": [
+        "ik_target"
+      ],
+      "properties": {
+        "allowable_angle_error_rad": {
+          "default": 0.005,
+          "type": "number",
+          "format": "double"
+        },
+        "allowable_position_error_m": {
+          "default": 0.005,
+          "type": "number",
+          "format": "double"
+        },
+        "constraints": {
+          "description": "A bundle of flags determining which coordinates are constrained for a target",
+          "default": {
+            "position_x": true,
+            "position_y": true,
+            "position_z": true,
+            "rotation_x": true,
+            "rotation_y": true,
+            "rotation_z": true
+          },
+          "type": "object",
+          "properties": {
+            "position_x": {
+              "description": "true means the constraint is used. The coordinates is the world, not the end of the arm.",
+              "default": true,
+              "type": "boolean"
+            },
+            "position_y": {
+              "default": true,
+              "type": "boolean"
+            },
+            "position_z": {
+              "default": true,
+              "type": "boolean"
+            },
+            "rotation_x": {
+              "default": true,
+              "type": "boolean"
+            },
+            "rotation_y": {
+              "default": true,
+              "type": "boolean"
+            },
+            "rotation_z": {
+              "default": true,
+              "type": "boolean"
+            }
+          }
+        },
+        "ik_target": {
+          "type": "string"
+        },
+        "jacobian_multiplier": {
+          "default": 0.1,
+          "type": "number",
+          "format": "double"
+        },
+        "num_max_try": {
+          "default": 300,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "root_node_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "use_random_ik": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "JointPositionLimit": {
+      "type": "object",
+      "properties": {
+        "lower": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "upper": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        }
+      }
+    },
+    "JointTrajectoryClientsContainerConfig": {
+      "type": "object",
+      "required": [
+        "clients_names",
+        "name"
+      ],
+      "properties": {
+        "clients_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "JointsPose": {
+      "type": "object",
+      "required": [
+        "client_name",
+        "pose_name",
+        "positions"
+      ],
+      "properties": {
+        "client_name": {
+          "type": "string"
+        },
+        "pose_name": {
+          "type": "string"
+        },
+        "positions": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      }
+    },
+    "OpenrrClientsConfig": {
+      "type": "object",
+      "properties": {
+        "collision_check_clients_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CollisionCheckClientConfig"
+          }
+        },
+        "ik_clients_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IkClientConfig"
+          }
+        },
+        "ik_solvers_configs": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/IkSolverConfig"
+          }
+        },
+        "joint_trajectory_clients_container_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JointTrajectoryClientsContainerConfig"
+          }
+        },
+        "joints_poses": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JointsPose"
+          }
+        },
+        "self_collision_check_pairs": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "urdf_full_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "urdf_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "RosCmdVelMoveBaseConfig": {
+      "type": "object",
+      "required": [
+        "topic"
+      ],
+      "properties": {
+        "topic": {
+          "type": "string"
+        }
+      }
+    },
+    "RosControlClientConfig": {
+      "type": "object",
+      "required": [
+        "complete_allowable_errors",
+        "controller_name",
+        "joint_names",
+        "name"
+      ],
+      "properties": {
+        "complete_allowable_errors": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "complete_timeout_sec": {
+          "default": 10.0,
+          "type": "number",
+          "format": "double"
+        },
+        "controller_name": {
+          "type": "string"
+        },
+        "joint_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "joint_position_limits": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/JointPositionLimit"
+          }
+        },
+        "joint_velocity_limits": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "send_partial_joints_goal": {
+          "default": false,
+          "type": "boolean"
+        },
+        "state_topic_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "wrap_with_joint_position_limiter": {
+          "default": false,
+          "type": "boolean"
+        },
+        "wrap_with_joint_velocity_limiter": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "RosEspeakClientConfig": {
+      "type": "object",
+      "required": [
+        "topic"
+      ],
+      "properties": {
+        "topic": {
+          "type": "string"
+        }
+      }
+    },
+    "RosLocalizationClientConfig": {
+      "type": "object",
+      "required": [
+        "request_final_nomotion_update_hack"
+      ],
+      "properties": {
+        "request_final_nomotion_update_hack": {
+          "type": "boolean"
+        }
+      }
+    },
+    "RosNavClientConfig": {
+      "type": "object",
+      "required": [
+        "clear_costmap_before_start",
+        "request_final_nomotion_update_hack"
+      ],
+      "properties": {
+        "clear_costmap_before_start": {
+          "type": "boolean"
+        },
+        "request_final_nomotion_update_hack": {
+          "type": "boolean"
+        }
+      }
+    },
+    "SelfCollisionCheckerConfig": {
+      "type": "object",
+      "properties": {
+        "prediction": {
+          "default": 0.001,
+          "type": "number",
+          "format": "double"
+        },
+        "time_interpolate_rate": {
+          "default": 0.5,
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "SpeakConfig": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Print"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Command"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "args",
+            "type"
+          ],
+          "properties": {
+            "args": {
+              "type": "object",
+              "required": [
+                "config"
+              ],
+              "properties": {
+                "config": {
+                  "$ref": "#/definitions/RosEspeakClientConfig"
+                }
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "RosEspeak"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "args",
+            "type"
+          ],
+          "properties": {
+            "args": {
+              "type": "object",
+              "required": [
+                "map"
+              ],
+              "properties": {
+                "map": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "Audio"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "UrdfVizWebClientConfig": {
+      "type": "object",
+      "required": [
+        "joint_names",
+        "name"
+      ],
+      "properties": {
+        "joint_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "joint_position_limits": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/JointPositionLimit"
+          }
+        },
+        "joint_velocity_limits": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "wrap_with_joint_position_limiter": {
+          "default": false,
+          "type": "boolean"
+        },
+        "wrap_with_joint_velocity_limiter": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/openrr-apps/schema/robot_teleop_config.json
+++ b/openrr-apps/schema/robot_teleop_config.json
@@ -1,0 +1,558 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RobotTeleopConfig",
+  "type": "object",
+  "required": [
+    "control_nodes_config",
+    "robot_config_path"
+  ],
+  "properties": {
+    "control_nodes_config": {
+      "$ref": "#/definitions/ControlNodesConfig"
+    },
+    "gil_gamepad_config": {
+      "default": {
+        "device_id": 0,
+        "map": {
+          "axis_map": [
+            [
+              "RightStickY",
+              "RightStickY"
+            ],
+            [
+              "DPadX",
+              "DPadX"
+            ],
+            [
+              "DPadY",
+              "DPadY"
+            ],
+            [
+              "RightStickX",
+              "RightStickX"
+            ],
+            [
+              "LeftStickX",
+              "LeftStickX"
+            ],
+            [
+              "LeftStickY",
+              "LeftStickY"
+            ]
+          ],
+          "axis_value_map": [
+            [
+              "LeftStickX",
+              -1.0
+            ],
+            [
+              "RightStickX",
+              -1.0
+            ]
+          ],
+          "button_map": [
+            [
+              "LeftTrigger2",
+              "LeftTrigger2"
+            ],
+            [
+              "Start",
+              "Start"
+            ],
+            [
+              "West",
+              "West"
+            ],
+            [
+              "RightTrigger2",
+              "RightTrigger2"
+            ],
+            [
+              "DPadRight",
+              "DPadRight"
+            ],
+            [
+              "Mode",
+              "Mode"
+            ],
+            [
+              "East",
+              "East"
+            ],
+            [
+              "Select",
+              "Select"
+            ],
+            [
+              "DPadLeft",
+              "DPadLeft"
+            ],
+            [
+              "RightTrigger",
+              "RightTrigger"
+            ],
+            [
+              "North",
+              "North"
+            ],
+            [
+              "LeftThumb",
+              "LeftThumb"
+            ],
+            [
+              "RightThumb",
+              "RightThumb"
+            ],
+            [
+              "DPadUp",
+              "DPadUp"
+            ],
+            [
+              "LeftTrigger",
+              "LeftTrigger"
+            ],
+            [
+              "South",
+              "South"
+            ],
+            [
+              "DPadDown",
+              "DPadDown"
+            ]
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GilGamepadConfig"
+        }
+      ]
+    },
+    "initial_mode": {
+      "default": "",
+      "type": "string"
+    },
+    "robot_config_full_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "robot_config_path": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "Axis": {
+      "type": "string",
+      "enum": [
+        "LeftStickX",
+        "LeftStickY",
+        "LeftTrigger",
+        "RightStickX",
+        "RightStickY",
+        "RightTrigger",
+        "DPadX",
+        "DPadY",
+        "Unknown"
+      ]
+    },
+    "Button": {
+      "type": "string",
+      "enum": [
+        "South",
+        "East",
+        "North",
+        "West",
+        "LeftTrigger",
+        "LeftTrigger2",
+        "RightTrigger",
+        "RightTrigger2",
+        "Select",
+        "Start",
+        "Mode",
+        "LeftThumb",
+        "RightThumb",
+        "DPadUp",
+        "DPadDown",
+        "DPadLeft",
+        "DPadRight",
+        "Unknown"
+      ]
+    },
+    "ControlNodesConfig": {
+      "type": "object",
+      "required": [
+        "ik_node_teleop_configs",
+        "joy_joint_teleop_configs"
+      ],
+      "properties": {
+        "ik_node_teleop_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IkNodeTeleopConfig"
+          }
+        },
+        "joints_pose_sender_config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/JointsPoseSenderConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "joy_joint_teleop_configs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/JoyJointTeleopConfig"
+          }
+        },
+        "move_base_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "GilGamepadConfig": {
+      "type": "object",
+      "properties": {
+        "device_id": {
+          "default": 0,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "map": {
+          "default": {
+            "axis_map": [
+              [
+                "LeftStickX",
+                "LeftStickX"
+              ],
+              [
+                "RightStickY",
+                "RightStickY"
+              ],
+              [
+                "DPadX",
+                "DPadX"
+              ],
+              [
+                "DPadY",
+                "DPadY"
+              ],
+              [
+                "LeftStickY",
+                "LeftStickY"
+              ],
+              [
+                "RightStickX",
+                "RightStickX"
+              ]
+            ],
+            "axis_value_map": [
+              [
+                "LeftStickX",
+                -1.0
+              ],
+              [
+                "RightStickX",
+                -1.0
+              ]
+            ],
+            "button_map": [
+              [
+                "DPadDown",
+                "DPadDown"
+              ],
+              [
+                "West",
+                "West"
+              ],
+              [
+                "LeftTrigger",
+                "LeftTrigger"
+              ],
+              [
+                "LeftTrigger2",
+                "LeftTrigger2"
+              ],
+              [
+                "North",
+                "North"
+              ],
+              [
+                "RightThumb",
+                "RightThumb"
+              ],
+              [
+                "Mode",
+                "Mode"
+              ],
+              [
+                "RightTrigger",
+                "RightTrigger"
+              ],
+              [
+                "DPadLeft",
+                "DPadLeft"
+              ],
+              [
+                "DPadUp",
+                "DPadUp"
+              ],
+              [
+                "South",
+                "South"
+              ],
+              [
+                "LeftThumb",
+                "LeftThumb"
+              ],
+              [
+                "Select",
+                "Select"
+              ],
+              [
+                "Start",
+                "Start"
+              ],
+              [
+                "DPadRight",
+                "DPadRight"
+              ],
+              [
+                "RightTrigger2",
+                "RightTrigger2"
+              ],
+              [
+                "East",
+                "East"
+              ]
+            ]
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Map"
+            }
+          ]
+        }
+      }
+    },
+    "GilrsAxis": {
+      "type": "string",
+      "enum": [
+        "LeftStickX",
+        "LeftStickY",
+        "LeftZ",
+        "RightStickX",
+        "RightStickY",
+        "RightZ",
+        "DPadX",
+        "DPadY",
+        "Unknown"
+      ]
+    },
+    "GilrsButton": {
+      "type": "string",
+      "enum": [
+        "South",
+        "East",
+        "North",
+        "West",
+        "C",
+        "Z",
+        "LeftTrigger",
+        "LeftTrigger2",
+        "RightTrigger",
+        "RightTrigger2",
+        "Select",
+        "Start",
+        "Mode",
+        "LeftThumb",
+        "RightThumb",
+        "DPadUp",
+        "DPadDown",
+        "DPadLeft",
+        "DPadRight",
+        "Unknown"
+      ]
+    },
+    "IkNodeConfig": {
+      "type": "object",
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "move_step_angular": {
+          "default": [
+            0.05,
+            0.05,
+            0.17
+          ],
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          },
+          "maxItems": 3,
+          "minItems": 3
+        },
+        "move_step_linear": {
+          "default": [
+            0.01,
+            0.01,
+            0.01
+          ],
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          },
+          "maxItems": 3,
+          "minItems": 3
+        },
+        "step_duration_secs": {
+          "default": 0.1,
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "IkNodeTeleopConfig": {
+      "type": "object",
+      "required": [
+        "config",
+        "joint_trajectory_client_name",
+        "solver_name"
+      ],
+      "properties": {
+        "config": {
+          "$ref": "#/definitions/IkNodeConfig"
+        },
+        "joint_trajectory_client_name": {
+          "type": "string"
+        },
+        "solver_name": {
+          "type": "string"
+        }
+      }
+    },
+    "JointsPoseSenderConfig": {
+      "type": "object",
+      "properties": {
+        "duration_secs": {
+          "default": 2.0,
+          "type": "number",
+          "format": "double"
+        },
+        "mode": {
+          "default": "pose",
+          "type": "string"
+        }
+      }
+    },
+    "JoyJointTeleopConfig": {
+      "type": "object",
+      "required": [
+        "client_name",
+        "config"
+      ],
+      "properties": {
+        "client_name": {
+          "type": "string"
+        },
+        "config": {
+          "$ref": "#/definitions/JoyJointTeleopNodeConfig"
+        }
+      }
+    },
+    "JoyJointTeleopNodeConfig": {
+      "type": "object",
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "joint_step": {
+          "default": 0.02,
+          "type": "number",
+          "format": "double"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "step_duration_secs": {
+          "default": 0.1,
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "Map": {
+      "type": "object",
+      "required": [
+        "axis_map",
+        "axis_value_map",
+        "button_map"
+      ],
+      "properties": {
+        "axis_map": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "$ref": "#/definitions/GilrsAxis"
+              },
+              {
+                "$ref": "#/definitions/Axis"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          }
+        },
+        "axis_value_map": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "$ref": "#/definitions/Axis"
+              },
+              {
+                "type": "number",
+                "format": "double"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          }
+        },
+        "button_map": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "$ref": "#/definitions/GilrsButton"
+              },
+              {
+                "$ref": "#/definitions/Button"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          }
+        }
+      }
+    }
+  }
+}

--- a/openrr-apps/src/bin/config.rs
+++ b/openrr-apps/src/bin/config.rs
@@ -1,0 +1,44 @@
+use schemars::schema_for;
+use structopt::{clap::arg_enum, StructOpt};
+use tracing::debug;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = env!("CARGO_BIN_NAME"))]
+struct Args {
+    #[structopt(subcommand)]
+    subcommand: Subcommand,
+}
+
+#[derive(Debug, StructOpt)]
+enum Subcommand {
+    /// Generate JSON schema for the specified config file.
+    Schema {
+        /// Kind of config file.
+        #[structopt(possible_values = &ConfigKind::variants(), case_insensitive = true)]
+        kind: ConfigKind,
+    },
+}
+
+arg_enum! {
+    #[derive(Debug)]
+    enum ConfigKind {
+        RobotConfig,
+        RobotTeleopConfig,
+    }
+}
+
+fn main() {
+    tracing_subscriber::fmt::init();
+    let args = Args::from_args();
+    debug!(?args);
+
+    match args.subcommand {
+        Subcommand::Schema { kind } => {
+            let schema = match kind {
+                ConfigKind::RobotConfig => schema_for!(openrr_apps::RobotConfig),
+                ConfigKind::RobotTeleopConfig => schema_for!(openrr_apps::RobotTeleopConfig),
+            };
+            println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+        }
+    }
+}

--- a/openrr-apps/src/robot_config.rs
+++ b/openrr-apps/src/robot_config.rs
@@ -15,12 +15,13 @@ use arci_speak_audio::AudioSpeaker;
 use arci_speak_cmd::LocalCommand;
 use arci_urdf_viz::{create_joint_trajectory_clients, UrdfVizWebClient, UrdfVizWebClientConfig};
 use openrr_client::{OpenrrClientsConfig, PrintSpeaker, RobotClient};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::Error;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(tag = "type", content = "args")]
 #[non_exhaustive] // The variants will increase depending on the feature flag.
 pub enum SpeakConfig {
@@ -36,6 +37,7 @@ pub enum SpeakConfig {
     #[cfg(not(feature = "ros"))]
     #[serde(rename = "RosEspeak")]
     __RosEspeak {
+        #[schemars(schema_with = "unimplemented_schema")]
         config: toml::Value,
     },
     Audio {
@@ -49,7 +51,7 @@ impl Default for SpeakConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[non_exhaustive] // The fields will increase depending on the feature flag.
 pub struct RobotConfig {
     // TOML format has a restriction that if a table itself contains tables,
@@ -73,6 +75,7 @@ pub struct RobotConfig {
     pub ros_clients_configs: Vec<RosControlClientConfig>,
     // A dummy field to catch that there is a config that requires the ros feature.
     #[cfg(not(feature = "ros"))]
+    #[schemars(schema_with = "unimplemented_schema")]
     ros_clients_configs: Option<toml::Value>,
     #[serde(default)]
     // https://github.com/alexcrichton/toml-rs/issues/258
@@ -86,18 +89,21 @@ pub struct RobotConfig {
     pub ros_cmd_vel_move_base_client_config: Option<RosCmdVelMoveBaseConfig>,
     // A dummy field to catch that there is a config that requires the ros feature.
     #[cfg(not(feature = "ros"))]
+    #[schemars(schema_with = "unimplemented_schema")]
     ros_cmd_vel_move_base_client_config: Option<toml::Value>,
 
     #[cfg(feature = "ros")]
     pub ros_navigation_client_config: Option<RosNavClientConfig>,
     // A dummy field to catch that there is a config that requires the ros feature.
     #[cfg(not(feature = "ros"))]
+    #[schemars(schema_with = "unimplemented_schema")]
     ros_navigation_client_config: Option<toml::Value>,
 
     #[cfg(feature = "ros")]
     pub ros_localization_client_config: Option<RosLocalizationClientConfig>,
     // A dummy field to catch that there is a config that requires the ros feature.
     #[cfg(not(feature = "ros"))]
+    #[schemars(schema_with = "unimplemented_schema")]
     ros_localization_client_config: Option<toml::Value>,
 
     pub openrr_clients_config: OpenrrClientsConfig,
@@ -133,6 +139,12 @@ fn default_urdf_viz_clients_complete_timeout_sec() -> f64 {
 
 fn default_true() -> bool {
     true
+}
+
+// Creates dummy schema for dummy fields.
+#[cfg(not(feature = "ros"))]
+fn unimplemented_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    unimplemented!()
 }
 
 impl RobotConfig {

--- a/openrr-apps/src/robot_teleop_config.rs
+++ b/openrr-apps/src/robot_teleop_config.rs
@@ -3,11 +3,12 @@ use std::path::PathBuf;
 use arci_gamepad_gilrs::GilGamepadConfig;
 use openrr_client::resolve_relative_path;
 use openrr_teleop::ControlNodesConfig;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::Error;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
 pub struct RobotTeleopConfig {
     pub robot_config_path: String,
     robot_config_full_path: Option<PathBuf>,

--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -16,6 +16,7 @@ arci = "0.0.5"
 async-trait = "0.1"
 k = { version = "0.24", features = ["serde-serialize"] }
 openrr-planner = "0.0.5"
+schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 toml = "0.5"

--- a/openrr-client/src/clients/collision_check_client.rs
+++ b/openrr-client/src/clients/collision_check_client.rs
@@ -2,6 +2,7 @@ use std::{path::Path, sync::Arc, time::Duration};
 
 use arci::{Error, JointTrajectoryClient, TrajectoryPoint, WaitFuture};
 use openrr_planner::{collision::parse_colon_separated_pairs, CollisionChecker};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -143,7 +144,7 @@ where
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct SelfCollisionCheckerConfig {
     #[serde(default = "default_prediction")]
     pub prediction: f64,

--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -10,6 +10,7 @@ use arci::{
     Localization, MoveBase, Navigation, Speaker, WaitFuture,
 };
 use k::{nalgebra::Isometry2, Chain, Isometry3};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -434,13 +435,13 @@ where
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct JointTrajectoryClientsContainerConfig {
     pub name: String,
     pub clients_names: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
 pub struct OpenrrClientsConfig {
     pub urdf_path: Option<String>,
     urdf_full_path: Option<PathBuf>,
@@ -502,13 +503,13 @@ impl OpenrrClientsConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct JointsPose {
     pub pose_name: String,
     pub client_name: String,
     pub positions: Vec<f64>,
 }
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct IkClientConfig {
     pub name: String,
     pub client_name: String,
@@ -533,7 +534,7 @@ pub fn create_ik_clients(
     clients
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct CollisionCheckClientConfig {
     pub name: String,
     pub client_name: String,

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "openrr-planner"
 version = "0.0.5"
 authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
-edition="2018"
+edition = "2018"
 license = "Apache-2.0"
 description = "Collision avoidance path planning for robotics"
 keywords = ["pathplanning", "robotics", "robot"]
@@ -11,7 +11,7 @@ repository = "https://github.com/openrr/openrr"
 documentation = "http://docs.rs/openrr-planner"
 
 [features]
-default = [ "assimp" ]
+default = ["assimp"]
 
 [dependencies]
 assimp = { version = "0.3", optional = true }

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "0.1"
 auto_impl = "0.4.1"
 k = "0.24"
 openrr-client = "0.0.5"
+schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }

--- a/openrr-teleop/src/control_nodes_config.rs
+++ b/openrr-teleop/src/control_nodes_config.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use arci::{JointTrajectoryClient, MoveBase, Speaker};
 use openrr_client::{IkSolverWithChain, JointsPose};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -9,20 +10,20 @@ use crate::{
     JoyJointTeleopNode, JoyJointTeleopNodeConfig, MoveBaseNode,
 };
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct JoyJointTeleopConfig {
     pub client_name: String,
     pub config: JoyJointTeleopNodeConfig,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct IkNodeTeleopConfig {
     pub solver_name: String,
     pub joint_trajectory_client_name: String,
     pub config: IkNodeConfig,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
 pub struct ControlNodesConfig {
     pub move_base_mode: Option<String>,
     pub joy_joint_teleop_configs: Vec<JoyJointTeleopConfig>,

--- a/openrr-teleop/src/ik.rs
+++ b/openrr-teleop/src/ik.rs
@@ -7,6 +7,7 @@ use arci::{
 use async_trait::async_trait;
 use k::{Translation3, Vector3};
 use openrr_client::IkSolverWithChain;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::control_node::ControlNode;
@@ -202,7 +203,7 @@ where
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct IkNodeConfig {
     pub mode: String,
     #[serde(default = "default_move_step_angular")]

--- a/openrr-teleop/src/joints.rs
+++ b/openrr-teleop/src/joints.rs
@@ -5,6 +5,7 @@ use arci::{
     JointTrajectoryClient, Speaker,
 };
 use async_trait::async_trait;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::control_node::ControlNode;
@@ -151,7 +152,7 @@ where
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct JoyJointTeleopNodeConfig {
     pub mode: String,
     #[serde(default = "default_joint_step")]

--- a/openrr-teleop/src/joints_pose_sender.rs
+++ b/openrr-teleop/src/joints_pose_sender.rs
@@ -6,6 +6,7 @@ use arci::{
 };
 use async_trait::async_trait;
 use openrr_client::JointsPose;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::ControlNode;
@@ -131,7 +132,7 @@ where
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct JointsPoseSenderConfig {
     #[serde(default = "default_mode")]
     pub mode: String,

--- a/tools/update-schema.sh
+++ b/tools/update-schema.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Update schemas for configs.
+#
+# Usage:
+#    ./tools/update-schema.sh
+
+set -euo pipefail
+IFS=$'\n\t'
+
+cd "$(cd "$(dirname "${0}")" && pwd)"/..
+
+cargo run -p openrr-apps --bin openrr_apps_config -- schema RobotConfig >openrr-apps/schema/robot_config.json
+cargo run -p openrr-apps --bin openrr_apps_config -- schema RobotTeleopConfig >openrr-apps/schema/robot_teleop_config.json


### PR DESCRIPTION
This adds JSON schemas for the config files used by openrr (`RobotConfig`, `RobotTeleopConfig`), and when combined with an extension of the editor that supports completion using the JSON schema, completion can be enabled.

cc https://github.com/openrr/openrr/issues/252

## Example

In VS Code, you can enable completion and validation by installing the [Even Better TOML] extension and using the `evenBetterToml.schema.associations` configuration object in `settings.json`.

For example:

```jsonc
{
  "evenBetterToml.schema.associations": {
    // NOTE: replace "taiki-e/schema" with "main" once this PR merged.
    ".*robot_client_config.*\\.toml": "https://raw.githubusercontent.com/openrr/openrr/taiki-e/schema/openrr-apps/schema/robot_config.json",
    ".*teleop_config.*\\.toml": "https://raw.githubusercontent.com/openrr/openrr/taiki-e/schema/openrr-apps/schema/robot_teleop_config.json",
  },
}
```

<img width="581" alt="" src="https://user-images.githubusercontent.com/43724913/116380268-c458c700-a84e-11eb-83d2-3fd33b74183c.png">

[Even Better TOML]: https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml

## `openrr_apps_config schema`

This also adds a helper command to openrr-apps. This command generates JSON schema for the specified config file.

Usage:
```console
$ openrr_apps_config schema --help
openrr_apps_config-schema 0.0.5
Generate JSON schema for specified config file

USAGE:
    openrr_apps_config schema <kind>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <kind>    Kind of config file [possible values: RobotConfig, RobotTeleopConfig]
```