### PR TITLE
[openrr-apps,openrr-config] Support overwriting config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "openrr-apps",
     "openrr-client",
     "openrr-command",
+    "openrr-config",
     "openrr-gui",
     "openrr-planner",
     "openrr-plugin",
@@ -35,6 +36,7 @@ openrr = { path = "openrr" }
 openrr-apps = { path = "openrr-apps" }
 openrr-client = { path = "openrr-client" }
 openrr-command = { path = "openrr-command" }
+openrr-config = { path = "openrr-config" }
 openrr-gui = { path = "openrr-gui" }
 openrr-planner = { path = "openrr-planner" }
 openrr-plugin = { path = "openrr-plugin" }

--- a/arci-gamepad-gilrs/src/lib.rs
+++ b/arci-gamepad-gilrs/src/lib.rs
@@ -19,6 +19,7 @@ use tracing::{debug, error};
 
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Map {
     #[serde_as(as = "Vec<(_, _)>")]
     #[serde(default = "default_button_map")]
@@ -264,6 +265,7 @@ impl GilGamepad {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GilGamepadConfig {
     #[serde(default)]
     device_id: usize,

--- a/arci-ros/src/cmd_vel_move_base.rs
+++ b/arci-ros/src/cmd_vel_move_base.rs
@@ -35,6 +35,7 @@ impl MoveBase for RosCmdVelMoveBase {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RosCmdVelMoveBaseConfig {
     pub topic: String,
 }

--- a/arci-ros/src/ros_control_client.rs
+++ b/arci-ros/src/ros_control_client.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::{error::Error, msg, SubscriberHandler};
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RosControlClientConfig {
     pub name: String,
     pub joint_names: Vec<String>,

--- a/arci-ros/src/ros_localization_client.rs
+++ b/arci-ros/src/ros_localization_client.rs
@@ -15,6 +15,7 @@ const AMCL_POSE_TOPIC: &str = "/amcl_pose";
 const NO_MOTION_UPDATE_SERVICE: &str = "request_nomotion_update";
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RosLocalizationClientConfig {
     pub request_final_nomotion_update_hack: bool,
 }

--- a/arci-ros/src/ros_nav_client.rs
+++ b/arci-ros/src/ros_nav_client.rs
@@ -229,6 +229,7 @@ impl Navigation for RosNavClient {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RosNavClientConfig {
     pub request_final_nomotion_update_hack: bool,
     pub clear_costmap_before_start: bool,

--- a/arci-ros/src/ros_speak_client.rs
+++ b/arci-ros/src/ros_speak_client.rs
@@ -11,6 +11,7 @@ pub struct RosEspeakClient {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RosEspeakClientConfig {
     pub topic: String,
 }

--- a/arci-urdf-viz/src/client.rs
+++ b/arci-urdf-viz/src/client.rs
@@ -25,6 +25,7 @@ use url::Url;
 use crate::utils::*;
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct UrdfVizWebClientConfig {
     pub name: String,
     pub joint_names: Vec<String>,

--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -9,6 +9,7 @@ MEMBERS=(
     "arci"
     "openrr-sleep"
     "openrr-planner"
+    "openrr-config"
 
     # depend on arci
     "openrr-plugin"

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -33,6 +33,7 @@ arci-urdf-viz = "0.0.5"
 k = "0.24"
 openrr-client = { version = "0.0.5", default-features = false }
 openrr-command = { version = "0.0.5", default-features = false }
+openrr-config = "0.0.5"
 openrr-teleop = { version = "0.0.5", default-features = false }
 rand = "0.8.0"
 schemars = "0.8.3"

--- a/openrr-apps/README.md
+++ b/openrr-apps/README.md
@@ -299,6 +299,24 @@ openrr_apps_robot_teleop \
   --robot-config='urdf_viz_clients_configs[0].wrap_with_joint_position_limiter=false'
 ```
 
+To overwrite multiple configs, separate the scripts with a semicolon or a newline. For example:
+
+```bash
+# semicolon-separated
+openrr_apps_robot_teleop \
+  --config-path=./openrr-apps/config/sample_teleop_config_urdf_viz.toml \
+  --robot-config='urdf_viz_clients_configs[0].wrap_with_joint_position_limiter=false;openrr_clients_config.urdf_path="path/to/urdf"'
+
+# newline-separated
+{
+  echo 'urdf_viz_clients_configs[0].wrap_with_joint_position_limiter=false'
+  echo 'openrr_clients_config.urdf_path="path/to/urdf"'
+} > overwrite.txt
+openrr_apps_robot_teleop \
+  --config-path=./openrr-apps/config/sample_teleop_config_urdf_viz.toml \
+  --robot-config="$(cat ./overwrite.txt)"
+```
+
 ## Schemas for config files
 
 The `schema` directory contains the JSON schemas for the config files used by openrr, and when combined with an extension of the editor that supports completion using the JSON schema, completion can be enabled.

--- a/openrr-apps/README.md
+++ b/openrr-apps/README.md
@@ -268,6 +268,37 @@ openrr_apps_joint_position_sender
 
 Do not forget to unset OPENRR_APPS_ROBOT_CONFIG_PATH before try other settings
 
+## Overwrite configuration at startup
+
+By using `--config` flag, you can overwrite the configuration at startup.
+
+For example, to replace the urdf path:
+
+```bash
+openrr_apps_robot_command \
+  --config-path=./openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml \
+  --config='openrr_clients_config.urdf_path="path/to/urdf"' \
+  load_commands ./openrr-apps/command/sample_cmd_urdf_viz.txt
+```
+
+In `openrr_apps_robot_teleop`, there are two flags: `--robot-config` to overwrite robot config and `--teleop-config` to overwrite teleop config.
+
+For example, to run `openrr_apps_robot_teleop` with `arci-gamepad-keyboard`:
+
+```bash
+openrr_apps_robot_teleop \
+  --config-path=./openrr-apps/config/sample_teleop_config_urdf_viz.toml \
+  --teleop-config='gamepad="Keyboard"'
+```
+
+To disable joint_position_limiter:
+
+```bash
+openrr_apps_robot_teleop \
+  --config-path=./openrr-apps/config/sample_teleop_config_urdf_viz.toml \
+  --robot-config='urdf_viz_clients_configs[0].wrap_with_joint_position_limiter=false'
+```
+
 ## Schemas for config files
 
 The `schema` directory contains the JSON schemas for the config files used by openrr, and when combined with an extension of the editor that supports completion using the JSON schema, completion can be enabled.

--- a/openrr-apps/src/bin/config.rs
+++ b/openrr-apps/src/bin/config.rs
@@ -64,11 +64,10 @@ fn main() -> Result<()> {
             config: overwrite,
         } => {
             let s = &fs::read_to_string(&config_path)?;
-            // check if the input is valid config.
+            let s = &openrr_config::overwrite_str(s, &overwrite)?;
+            // check if the edited document is valid config.
             let _base: Config = toml::from_str(s)?;
-            let mut edit: toml::Value = toml::from_str(s)?;
-            openrr_config::overwrite(&mut edit, &overwrite)?;
-            println!("{}", toml::to_string(&edit)?);
+            println!("{}", s);
         }
     }
 

--- a/openrr-apps/src/bin/joint_position_sender.rs
+++ b/openrr-apps/src/bin/joint_position_sender.rs
@@ -1,5 +1,6 @@
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
+use anyhow::Result;
 use openrr_apps::RobotConfig;
 use openrr_client::BoxRobotClient;
 use openrr_gui::joint_position_sender;
@@ -13,14 +14,29 @@ struct Opt {
     /// Path to the setting file.
     #[structopt(short, long, parse(from_os_str))]
     config_path: Option<PathBuf>,
+    /// Set options from command line. These settings take priority over the
+    /// setting file specified by --config-path.
+    #[structopt(long)]
+    config: Option<String>,
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     let opt = Opt::from_args();
     debug!("opt: {:?}", opt);
+
     let config_path = openrr_apps::utils::get_apps_robot_config(opt.config_path).unwrap();
-    let config = RobotConfig::try_new(&config_path)?;
+    let config = if let Some(overwrite) = &opt.config {
+        let s = &fs::read_to_string(&config_path)?;
+        // check if the input is valid config.
+        let _base: RobotConfig = toml::from_str(s)?;
+        let mut edit: toml::Value = toml::from_str(s)?;
+        openrr_config::overwrite(&mut edit, overwrite)?;
+        RobotConfig::from_str(&toml::to_string(&edit)?, config_path)?
+    } else {
+        RobotConfig::try_new(config_path)?
+    };
+
     openrr_apps::utils::init(env!("CARGO_BIN_NAME"), &config);
     let client: BoxRobotClient = config.create_robot_client()?;
     let robot = urdf_rs::read_file(config.openrr_clients_config.urdf_full_path().unwrap())?;

--- a/openrr-apps/src/bin/joint_position_sender.rs
+++ b/openrr-apps/src/bin/joint_position_sender.rs
@@ -28,11 +28,8 @@ fn main() -> Result<()> {
     let config_path = openrr_apps::utils::get_apps_robot_config(opt.config_path).unwrap();
     let config = if let Some(overwrite) = &opt.config {
         let s = &fs::read_to_string(&config_path)?;
-        // check if the input is valid config.
-        let _base: RobotConfig = toml::from_str(s)?;
-        let mut edit: toml::Value = toml::from_str(s)?;
-        openrr_config::overwrite(&mut edit, overwrite)?;
-        RobotConfig::from_str(&toml::to_string(&edit)?, config_path)?
+        let s = &openrr_config::overwrite_str(s, overwrite)?;
+        RobotConfig::from_str(s, config_path)?
     } else {
         RobotConfig::try_new(config_path)?
     };

--- a/openrr-apps/src/bin/robot_command.rs
+++ b/openrr-apps/src/bin/robot_command.rs
@@ -40,11 +40,8 @@ async fn main() -> Result<()> {
     let command = args.command.ok_or(Error::NoCommand)?;
     let robot_config = if let Some(overwrite) = &args.config {
         let s = &fs::read_to_string(&config_path)?;
-        // check if the input is valid config.
-        let _base: RobotConfig = toml::from_str(s)?;
-        let mut edit: toml::Value = toml::from_str(s)?;
-        openrr_config::overwrite(&mut edit, overwrite)?;
-        RobotConfig::from_str(&toml::to_string(&edit)?, config_path)?
+        let s = &openrr_config::overwrite_str(s, overwrite)?;
+        RobotConfig::from_str(s, config_path)?
     } else {
         RobotConfig::try_new(config_path)?
     };

--- a/openrr-apps/src/bin/robot_teleop.rs
+++ b/openrr-apps/src/bin/robot_teleop.rs
@@ -46,22 +46,16 @@ async fn main() -> Result<()> {
     let teleop_config_path = args.config_path.ok_or(Error::NoConfigPath)?;
     let teleop_config = if let Some(overwrite) = &args.teleop_config {
         let s = &fs::read_to_string(&teleop_config_path)?;
-        // check if the input is valid config.
-        let _base: RobotTeleopConfig = toml::from_str(s)?;
-        let mut edit: toml::Value = toml::from_str(s)?;
-        openrr_config::overwrite(&mut edit, overwrite)?;
-        RobotTeleopConfig::from_str(&toml::to_string(&edit)?, &teleop_config_path)?
+        let s = &openrr_config::overwrite_str(s, overwrite)?;
+        RobotTeleopConfig::from_str(s, teleop_config_path)?
     } else {
         RobotTeleopConfig::try_new(teleop_config_path)?
     };
     let robot_config_path = teleop_config.robot_config_full_path().as_ref().unwrap();
     let robot_config = if let Some(overwrite) = &args.robot_config {
         let s = &fs::read_to_string(&robot_config_path)?;
-        // check if the input is valid config.
-        let _base: RobotConfig = toml::from_str(s)?;
-        let mut edit: toml::Value = toml::from_str(s)?;
-        openrr_config::overwrite(&mut edit, overwrite)?;
-        RobotConfig::from_str(&toml::to_string(&edit)?, robot_config_path)?
+        let s = &openrr_config::overwrite_str(s, overwrite)?;
+        RobotConfig::from_str(s, robot_config_path)?
     } else {
         RobotConfig::try_new(robot_config_path)?
     };

--- a/openrr-apps/src/robot_config.rs
+++ b/openrr-apps/src/robot_config.rs
@@ -23,6 +23,7 @@ use crate::Error;
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(tag = "type", content = "args")]
+#[serde(deny_unknown_fields)]
 #[non_exhaustive] // The variants will increase depending on the feature flag.
 pub enum SpeakConfig {
     Print,
@@ -52,6 +53,7 @@ impl Default for SpeakConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 #[non_exhaustive] // The fields will increase depending on the feature flag.
 pub struct RobotConfig {
     // TOML format has a restriction that if a table itself contains tables,

--- a/openrr-apps/src/robot_config.rs
+++ b/openrr-apps/src/robot_config.rs
@@ -397,11 +397,16 @@ mod test {
 
 impl RobotConfig {
     pub fn try_new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let mut config: RobotConfig = toml::from_str(
+        Self::from_str(
             &std::fs::read_to_string(&path)
                 .map_err(|e| Error::NoFile(path.as_ref().to_owned(), e))?,
+            &path,
         )
-        .map_err(|e| Error::TomlParseFailure(path.as_ref().to_owned(), e))?;
+    }
+
+    pub fn from_str<P: AsRef<Path>>(s: &str, path: P) -> Result<Self, Error> {
+        let mut config: RobotConfig =
+            toml::from_str(s).map_err(|e| Error::TomlParseFailure(path.as_ref().to_owned(), e))?;
 
         // Returns an error if a config requires ros feature but ros feature is disabled.
         #[cfg(not(feature = "ros"))]

--- a/openrr-apps/src/robot_teleop_config.rs
+++ b/openrr-apps/src/robot_teleop_config.rs
@@ -21,6 +21,7 @@ impl Default for GamepadKind {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RobotTeleopConfig {
     pub robot_config_path: String,
     robot_config_full_path: Option<PathBuf>,

--- a/openrr-apps/src/robot_teleop_config.rs
+++ b/openrr-apps/src/robot_teleop_config.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use arci_gamepad_gilrs::GilGamepadConfig;
 use openrr_client::resolve_relative_path;
@@ -35,12 +35,17 @@ pub struct RobotTeleopConfig {
 }
 
 impl RobotTeleopConfig {
-    pub fn try_new<P: AsRef<std::path::Path>>(path: P) -> Result<Self, Error> {
-        let mut config: RobotTeleopConfig = toml::from_str(
+    pub fn try_new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        Self::from_str(
             &std::fs::read_to_string(&path)
                 .map_err(|e| Error::NoFile(path.as_ref().to_owned(), e))?,
+            path,
         )
-        .map_err(|e| Error::TomlParseFailure(path.as_ref().to_owned(), e))?;
+    }
+
+    pub fn from_str<P: AsRef<Path>>(s: &str, path: P) -> Result<Self, Error> {
+        let mut config: RobotTeleopConfig =
+            toml::from_str(s).map_err(|e| Error::TomlParseFailure(path.as_ref().to_owned(), e))?;
         config.robot_config_full_path =
             Some(resolve_relative_path(path, &config.robot_config_path)?);
         Ok(config)

--- a/openrr-client/src/clients/collision_check_client.rs
+++ b/openrr-client/src/clients/collision_check_client.rs
@@ -145,6 +145,7 @@ where
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SelfCollisionCheckerConfig {
     #[serde(default = "default_prediction")]
     pub prediction: f64,

--- a/openrr-client/src/clients/ik_client.rs
+++ b/openrr-client/src/clients/ik_client.rs
@@ -299,6 +299,7 @@ where
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct IkSolverConfig {
     pub root_node_name: Option<String>,
     pub ik_target: String,

--- a/openrr-client/src/clients/local_move.rs
+++ b/openrr-client/src/clients/local_move.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::Error;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct LocalMoveConfig {
     pub reach_distance_threshold: f64,
     pub reach_angle_threshold: f64,

--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -436,12 +436,14 @@ where
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct JointTrajectoryClientsContainerConfig {
     pub name: String,
     pub clients_names: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct OpenrrClientsConfig {
     pub urdf_path: Option<String>,
     urdf_full_path: Option<PathBuf>,
@@ -504,12 +506,15 @@ impl OpenrrClientsConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct JointsPose {
     pub pose_name: String,
     pub client_name: String,
     pub positions: Vec<f64>,
 }
+
 #[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct IkClientConfig {
     pub name: String,
     pub client_name: String,
@@ -535,6 +540,7 @@ pub fn create_ik_clients(
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct CollisionCheckClientConfig {
     pub name: String,
     pub client_name: String,

--- a/openrr-config/Cargo.toml
+++ b/openrr-config/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "openrr-config"
+version = "0.0.5"
+authors = ["Taiki Endo <taiki@smilerobotics.com>"]
+edition = "2018"
+license = "Apache-2.0"
+description = "openrr config library"
+keywords = ["robotics", "robot"]
+categories = ["science::robotics", "gui"]
+repository = "https://github.com/openrr/openrr"
+documentation = "https://docs.rs/openrr-config"
+
+[dependencies]
+anyhow = "1"
+toml = "0.5"
+toml-query = "0.10"
+tracing = { version = "0.1", features = ["log"] }
+
+[dev-dependencies]
+assert_approx_eq = "1"

--- a/openrr-config/LICENSE
+++ b/openrr-config/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/openrr-config/README.md
+++ b/openrr-config/README.md
@@ -1,0 +1,3 @@
+# OpenRR Config
+
+[![crates.io](https://img.shields.io/crates/v/openrr-config.svg)](https://crates.io/crates/openrr-config) [![docs](https://docs.rs/openrr-config/badge.svg)](https://docs.rs/openrr-config)

--- a/openrr-config/src/lib.rs
+++ b/openrr-config/src/lib.rs
@@ -94,6 +94,16 @@ pub fn overwrite(doc: &mut Value, scripts: &str) -> Result<()> {
     Ok(())
 }
 
+/// Replaces the contents of the specified TOML document based on the specified scripts,
+/// returning edited document as string.
+///
+/// See [`overwrite`] for more.
+pub fn overwrite_str(doc: &str, scripts: &str) -> Result<String> {
+    let mut doc: toml::Value = toml::from_str(doc)?;
+    overwrite(&mut doc, scripts)?;
+    Ok(toml::to_string(&doc)?)
+}
+
 #[derive(Debug)]
 struct Script {
     line: usize,

--- a/openrr-config/src/lib.rs
+++ b/openrr-config/src/lib.rs
@@ -1,0 +1,484 @@
+#![warn(rust_2018_idioms)]
+
+use anyhow::{bail, Context, Result};
+use toml::{value, Value};
+use toml_query::{
+    delete::TomlValueDeleteExt, insert::TomlValueInsertExt, read::TomlValueReadExt,
+    set::TomlValueSetExt,
+};
+use tracing::debug;
+
+/// Replaces the contents of the specified TOML document based on the specified scripts.
+///
+/// You can specify multiple scripts at once (newline-separated).
+///
+/// # Set operation
+///
+/// Syntax:
+///
+/// ```text
+/// <key> = <value>
+/// ```
+///
+/// - If the specified key or array index exists, replace its value.
+/// - If the specified key does not exist, create the specified key and value.
+/// - If the specified array index does not exist, append the specified value to the array.
+/// - If the intermediate data structures do not exist, create them.
+///
+/// # Delete operation
+///
+/// Syntax:
+///
+/// ```text
+/// <key> =
+/// ```
+///
+/// - Deletes the specified key and its value or specified array element.
+/// - If the specified key or array index does not exist, it will be ignored.
+pub fn overwrite(doc: &mut Value, scripts: &str) -> Result<()> {
+    let scripts = parse_scripts(scripts)?;
+
+    for script in scripts {
+        let query = &script.query;
+        let line = script.line;
+        let old = doc.read_mut(query)?;
+        let exists = old.is_some();
+        let is_structure = matches!(&old, Some(r) if r.is_table() || r.is_array());
+        match script.operation {
+            Operation::Set(value) => {
+                if exists {
+                    debug!(?query, ?line, ?value, ?old, "executing set operation");
+                    doc.set(query, value)?;
+                    continue;
+                }
+
+                // TODO:
+                // - Workaround for toml-query bug: https://docs.rs/toml-query/0.10/toml_query/insert/trait.TomlValueInsertExt.html#known-bugs
+                // - Validate that the query points to a valid configuration.
+                debug!(?query, ?line, ?value, "executing insert operation");
+                doc.insert(query, value)?;
+            }
+            Operation::Delete => {
+                if !exists {
+                    debug!(
+                        ?query,
+                        ?line,
+                        "delete operation was not executed because value did not exist"
+                    );
+                    continue;
+                }
+
+                let old = old.unwrap();
+                // toml-query does not support deleting non-empty table/array.
+                // https://docs.rs/toml-query/0.10/toml_query/delete/trait.TomlValueDeleteExt.html#semantics
+                if is_structure {
+                    if old.is_array() {
+                        *old = Value::Array(vec![]);
+                    } else {
+                        *old = Value::Table(value::Map::new());
+                    }
+                }
+
+                debug!(
+                    ?query,
+                    ?line,
+                    ?is_structure,
+                    ?old,
+                    "executing delete operation"
+                );
+                doc.delete(query)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Script {
+    line: usize,
+    query: String,
+    operation: Operation,
+}
+
+#[derive(Debug)]
+enum Operation {
+    Set(Value),
+    Delete,
+}
+
+fn parse_scripts(s: &str) -> Result<Vec<Script>> {
+    let mut scripts = vec![];
+
+    let mut lines = s
+        .lines()
+        .map(str::trim)
+        .enumerate()
+        .filter(|(_, s)| !s.is_empty());
+    while let Some((i, line)) = lines.next() {
+        if !line.contains('=') {
+            bail!(
+                "invalid script syntax at line {}: not found `=`: {}",
+                i + 1,
+                line
+            );
+        }
+
+        let mut iter = line.splitn(2, '=');
+        let query = iter.next().unwrap().trim();
+        let mut value = iter.next().unwrap().trim().to_string();
+
+        if value.ends_with('[') {
+            let mut depth = 1;
+            for (_, l) in &mut lines {
+                value.push_str(l);
+                if l.starts_with(']') {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                if l.ends_with('[') {
+                    depth += 1;
+                }
+            }
+        }
+
+        let operation = if value.is_empty() {
+            Operation::Delete
+        } else {
+            let value: Value = toml::from_str(&format!(r#"a = {}"#, value))
+                .with_context(|| format!("invalid script syntax at line {}: {}", i + 1, value))?;
+            Operation::Set(value["a"].clone())
+        };
+
+        scripts.push(Script {
+            line: i + 1,
+            query: convert_query(query)?,
+            operation,
+        });
+    }
+
+    Ok(scripts)
+}
+
+fn convert_query(s: &str) -> Result<String> {
+    if s.contains('"') || s.contains('\'') {
+        // TODO
+        bail!("quote in query is not supported yet");
+    }
+
+    let mut out = String::with_capacity(s.len());
+    let mut pos = 0;
+    loop {
+        let next = s[pos..].find('[');
+        let n = match next {
+            Some(n) => n,
+            None => {
+                out.push_str(&s[pos..]);
+                break;
+            }
+        };
+
+        out.push_str(&s[pos..pos + n]);
+        out.push('.');
+        out.push('[');
+        pos += n + 1;
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    use assert_approx_eq::assert_approx_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_scripts() {
+        let f = |s: &str| parse_scripts(s).unwrap();
+        assert!(f("").is_empty());
+        assert!(f("\n").is_empty());
+        assert!(parse_scripts("a").is_err());
+        assert!(parse_scripts("a=b").is_err());
+        assert!(parse_scripts(r#"a="b"=0"#).is_err());
+        assert!(parse_scripts(r#"'a'=0"#).is_err()); // TODO
+        assert!(parse_scripts(r#""a"=0"#).is_err()); // TODO
+        assert!(parse_scripts(r#"'a=b'=0"#).is_err()); // TODO
+        assert!(parse_scripts(r#""a=b"=0"#).is_err()); // TODO
+        assert!(matches!(
+            &f(r#"a="b""#)[0],
+            Script { query, operation: Operation::Set(Value::String(s)), .. }
+            if query == "a" && s == "b"
+        ));
+        assert!(matches!(
+            &f(r#"a.b="c=d""#)[0],
+            Script { query, operation: Operation::Set(Value::String(s)), .. }
+            if query == "a.b" && s == "c=d"
+        ));
+        assert!(matches!(
+            &f(r#"a="""#)[0],
+            Script { query, operation: Operation::Set(Value::String(s)), .. }
+            if query == "a" && s.is_empty()
+        ));
+        assert!(matches!(
+            &f(r#"a="#)[0],
+            Script { query, operation: Operation::Delete, .. }
+            if query == "a"
+        ));
+        assert!(matches!(
+            &f(r#"a[0]="""#)[0],
+            Script { query, operation: Operation::Set(Value::String(s)), .. }
+            if query == "a.[0]" && s.is_empty()
+        ));
+        assert!(matches!(
+            &f(r#"a[0][1].b[2]="""#)[0],
+            Script { query, operation: Operation::Set(Value::String(s)), .. }
+            if query == "a.[0].[1].b.[2]" && s.is_empty()
+        ));
+    }
+
+    #[test]
+    fn test_overwrite() {
+        #[track_caller]
+        fn read<'a>(v: &'a Value, q: &str) -> Option<&'a Value> {
+            v.read(&convert_query(q).unwrap()).unwrap()
+        }
+
+        let mut root_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        root_dir.pop(); // openrr-config
+
+        let s = fs::read_to_string(
+            root_dir.join("openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml"),
+        )
+        .unwrap();
+        let v: &Value = &toml::from_str(&s).unwrap();
+
+        {
+            // set string
+            let v = &mut v.clone();
+            overwrite(v, r#"urdf_viz_clients_configs[0].name = "a""#).unwrap();
+            assert_eq!(
+                read(v, "urdf_viz_clients_configs[0].name")
+                    .unwrap()
+                    .as_str()
+                    .unwrap(),
+                "a"
+            )
+        }
+        {
+            // set string in array
+            let v = &mut v.clone();
+            overwrite(v, r#"urdf_viz_clients_configs[0].joint_names[0] = "b""#).unwrap();
+            assert_eq!(
+                read(v, "urdf_viz_clients_configs[0].joint_names[0]")
+                    .unwrap()
+                    .as_str()
+                    .unwrap(),
+                "b"
+            )
+        }
+        {
+            // set string in table in array
+            let v = &mut v.clone();
+            overwrite(
+                v,
+                r#"urdf_viz_clients_configs[0].joint_position_limits[0] = {}"#,
+            )
+            .unwrap();
+            assert!(
+                read(v, "urdf_viz_clients_configs[0].joint_position_limits[0]")
+                    .unwrap()
+                    .as_table()
+                    .unwrap()
+                    .is_empty(),
+            )
+        }
+        {
+            // set string in table in array
+            let v = &mut v.clone();
+            overwrite(
+                v,
+                r#"urdf_viz_clients_configs[0].joint_position_limits[1] = { lower = -3.0, upper = 3.0 }"#,
+            )
+            .unwrap();
+            let t = read(v, "urdf_viz_clients_configs[0].joint_position_limits[1]")
+                .unwrap()
+                .as_table()
+                .unwrap();
+            assert_approx_eq!(t["lower"].as_float().unwrap(), -3.0);
+            assert_approx_eq!(t["upper"].as_float().unwrap(), 3.0);
+        }
+        {
+            // set float
+            let v = &mut v.clone();
+            overwrite(
+                v,
+                "urdf_viz_clients_configs[0].joint_position_limits[2].lower = 0.0",
+            )
+            .unwrap();
+            assert_approx_eq!(
+                read(
+                    v,
+                    "urdf_viz_clients_configs[0].joint_position_limits[2].lower"
+                )
+                .unwrap()
+                .as_float()
+                .unwrap(),
+                0.0
+            );
+        }
+        {
+            // delete
+            let v = &mut v.clone();
+            overwrite(v, "urdf_viz_clients_configs[0].joint_position_limits =").unwrap();
+            assert!(read(v, "urdf_viz_clients_configs[0].joint_position_limits").is_none());
+        }
+        {
+            // delete
+            let v = &mut v.clone();
+            overwrite(
+                v,
+                "openrr_clients_config.ik_solvers_configs.arm_ik_solver =",
+            )
+            .unwrap();
+            assert!(read(v, "openrr_clients_config.ik_solvers_configs.arm_ik_solver").is_none());
+        }
+        {
+            // delete non exists key
+            let v = &mut v.clone();
+            overwrite(v, "a.b.c =").unwrap();
+        }
+        {
+            // set array multi-line
+            let v = &mut v.clone();
+            overwrite(v, "urdf_viz_clients_configs[0].joint_names = [\n\"a\"\n]").unwrap();
+            assert_eq!(
+                *read(v, "urdf_viz_clients_configs[0].joint_names")
+                    .unwrap()
+                    .as_array()
+                    .unwrap(),
+                vec![Value::String("a".into())]
+            )
+        }
+        {
+            // set array multi-line
+            let v = &mut v.clone();
+            overwrite(v, "urdf_viz_clients_configs[0].joint_names = [\n\"a\"]").unwrap();
+            assert_eq!(
+                *read(v, "urdf_viz_clients_configs[0].joint_names")
+                    .unwrap()
+                    .as_array()
+                    .unwrap(),
+                vec![Value::String("a".into())]
+            )
+        }
+        {
+            // TODO: this should not be error
+            // set array multi-line
+            let v = &mut v.clone();
+            overwrite(
+                v,
+                "urdf_viz_clients_configs[0].joint_names = [\n\"a\"]\ndummy=\"\"",
+            )
+            .unwrap_err();
+            // assert_eq!(
+            //     *read(v, "urdf_viz_clients_configs[0].joint_names")
+            //         .as_array()
+            //         .unwrap(),
+            //     vec![Value::String("a".into())]
+            // )
+        }
+        {
+            // TODO: toml-query bug: https://docs.rs/toml-query/0.10/toml_query/insert/trait.TomlValueInsertExt.html#known-bugs
+            let v = &mut v.clone();
+            overwrite(v, "a[0].b = 0").unwrap_err();
+            // assert_eq!(
+            //     *read(v, "a[0].b")
+            //         .as_integer()
+            //         .unwrap(),
+            //     vec![Value::Integer(0)]
+            // )
+        }
+        {
+            // insert
+            let v = &mut v.clone();
+            overwrite(
+                v,
+                "urdf_viz_clients_configs[0].wrap_with_joint_position_limiter =",
+            )
+            .unwrap();
+            assert!(v
+                .read("urdf_viz_clients_configs[0].wrap_with_joint_position_limiter")
+                .unwrap()
+                .is_none());
+            overwrite(
+                v,
+                "urdf_viz_clients_configs[0].wrap_with_joint_position_limiter = false",
+            )
+            .unwrap();
+            assert!(!read(
+                v,
+                "urdf_viz_clients_configs[0].wrap_with_joint_position_limiter"
+            )
+            .unwrap()
+            .as_bool()
+            .unwrap());
+        }
+
+        let s = r#"
+[gil_gamepad_config.map]
+axis_map = [
+    ["DPadX", "DPadX"],
+    ["LeftStickX", "LeftStickX"],
+    ["RightStickX", "RightStickX"],
+    ["RightStickY", "RightStickY"],
+    ["DPadY", "DPadY"],
+    ["LeftStickY", "LeftStickY"],
+]
+        "#;
+        let v: &Value = &toml::from_str(&s).unwrap();
+        {
+            let v = &mut v.clone();
+            overwrite(v, r#"gil_gamepad_config.map.axis_map[0][0] = "DPadN""#).unwrap();
+            assert_eq!(
+                read(v, "gil_gamepad_config.map.axis_map[0][0]")
+                    .unwrap()
+                    .as_str()
+                    .unwrap(),
+                "DPadN"
+            );
+            assert_eq!(
+                read(v, "gil_gamepad_config.map.axis_map[0][1]")
+                    .unwrap()
+                    .as_str()
+                    .unwrap(),
+                "DPadX"
+            );
+        }
+        {
+            let v = &mut v.clone();
+            overwrite(
+                v,
+                "gil_gamepad_config.map.axis_map = [\n[\n\"DPadN\"\n]\n]\n",
+            )
+            .unwrap();
+            assert_eq!(
+                read(v, "gil_gamepad_config.map.axis_map[0][0]")
+                    .unwrap()
+                    .as_str()
+                    .unwrap(),
+                "DPadN"
+            );
+            assert!(read(v, "gil_gamepad_config.map.axis_map[0]")
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .get(1)
+                .is_none());
+        }
+    }
+}

--- a/openrr-teleop/src/control_nodes_config.rs
+++ b/openrr-teleop/src/control_nodes_config.rs
@@ -11,12 +11,14 @@ use crate::{
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct JoyJointTeleopConfig {
     pub client_name: String,
     pub config: JoyJointTeleopNodeConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct IkNodeTeleopConfig {
     pub solver_name: String,
     pub joint_trajectory_client_name: String,
@@ -24,6 +26,7 @@ pub struct IkNodeTeleopConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ControlNodesConfig {
     pub move_base_mode: Option<String>,
     pub joy_joint_teleop_configs: Vec<JoyJointTeleopConfig>,

--- a/openrr-teleop/src/ik.rs
+++ b/openrr-teleop/src/ik.rs
@@ -204,6 +204,7 @@ where
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct IkNodeConfig {
     pub mode: String,
     #[serde(default = "default_move_step_angular")]

--- a/openrr-teleop/src/joints.rs
+++ b/openrr-teleop/src/joints.rs
@@ -153,6 +153,7 @@ where
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct JoyJointTeleopNodeConfig {
     pub mode: String,
     #[serde(default = "default_joint_step")]

--- a/openrr-teleop/src/joints_pose_sender.rs
+++ b/openrr-teleop/src/joints_pose_sender.rs
@@ -133,6 +133,7 @@ where
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct JointsPoseSenderConfig {
     #[serde(default = "default_mode")]
     pub mode: String,


### PR DESCRIPTION
Closes #78 Closes #165

- overwrite default values by argument (`--config` flag. `--teleop-config`/`--robot-config` flag  in openrr_apps_robot_teleop.)

- overwrite default values by another toml file (`openrr_apps_config merge`)

## Usage

### Overwrite configuration at startup

By using `--config` flag, you can overwrite the configuration at startup.

For example, to replace the urdf path:

```bash
openrr_apps_robot_command \
  --config-path=./openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml \
  --config='openrr_clients_config.urdf_path="path/to/urdf"' \
  load_commands ./openrr-apps/command/sample_cmd_urdf_viz.txt
```

In `openrr_apps_robot_teleop`, there are two flags: `--robot-config` to overwrite robot config and `--teleop-config` to overwrite teleop config.

For example, to run `openrr_apps_robot_teleop` with `arci-gamepad-keyboard`:

```bash
openrr_apps_robot_teleop \
  --config-path=./openrr-apps/config/sample_teleop_config_urdf_viz.toml \
  --teleop-config='gamepad="Keyboard"'
```

To disable joint_position_limiter:

```bash
openrr_apps_robot_teleop \
  --config-path=./openrr-apps/config/sample_teleop_config_urdf_viz.toml \
  --robot-config='urdf_viz_clients_configs[0].wrap_with_joint_position_limiter=false'
```

To overwrite multiple configs, separate the scripts with a semicolon or a newline. For example:

```bash
# semicolon-separated
openrr_apps_robot_teleop \
  --config-path=./openrr-apps/config/sample_teleop_config_urdf_viz.toml \
  --robot-config='urdf_viz_clients_configs[0].wrap_with_joint_position_limiter=false;openrr_clients_config.urdf_path="path/to/urdf"'

# newline-separated
{
  echo 'urdf_viz_clients_configs[0].wrap_with_joint_position_limiter=false'
  echo 'openrr_clients_config.urdf_path="path/to/urdf"'
} > overwrite.txt
openrr_apps_robot_teleop \
  --config-path=./openrr-apps/config/sample_teleop_config_urdf_viz.toml \
  --robot-config="$(cat ./overwrite.txt)"
```