### PR TITLE
Make dependency on assimp and mio optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           command: build
           # rosrust is not supported on Windows
-          args: --manifest-path openrr-apps/Cargo.toml --no-default-features --features gui
+          args: --manifest-path openrr-apps/Cargo.toml --no-default-features --features gui,assimp
 
   macos:
     name: Build on MacOS
@@ -81,7 +81,7 @@ jobs:
           args: --workspace --exclude arci-ros
       - name: cargo test (openrr-apps without ros)
         working-directory: openrr-apps
-        run: cargo test --no-default-features --features gui
+        run: cargo test --no-default-features --features gui,assimp
 
   # TODO(taiki-e): Some configs use HashMap and the order of the default values
   #                will change every time because HashMap order is not stable.
@@ -94,6 +94,16 @@ jobs:
   #     - uses: actions/checkout@v2
   #     - run: tools/update-schema.sh
   #     - run: git diff --exit-code
+
+  # Check all feature combinations work properly.
+  features:
+    name: Check features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ci/ubuntu-install-dependencies.sh
+      - run: cargo install cargo-hack
+      - run: cargo hack check --all --feature-powerset --optional-deps
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/ros1.yaml
+++ b/.github/workflows/ros1.yaml
@@ -54,4 +54,4 @@ jobs:
         shell: bash -ieo pipefail {0}
         working-directory: openrr-apps
         run: |
-          cargo test --no-default-features --features ros
+          cargo test --no-default-features --features ros,assimp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "arci",
     "arci-gamepad-gilrs",

--- a/arci-speak-audio/Cargo.toml
+++ b/arci-speak-audio/Cargo.toml
@@ -15,8 +15,9 @@ arci = "0.0.5"
 rodio = "0.13.0"
 thiserror = "1.0"
 tracing = { version = "0.1", features = ["log"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 structopt = "0.3"
+tokio = { version = "1.0", features = ["full"] }
 tracing-subscriber = "0.2"

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -11,7 +11,12 @@ repository = "https://github.com/openrr/openrr"
 documentation = "https://docs.rs/openrr-apps"
 
 [features]
-default = ["gui", "ros"]
+default = ["assimp", "gui", "ros"]
+assimp = [
+    "openrr-client/assimp",
+    "openrr-command/assimp",
+    "openrr-teleop/assimp",
+]
 ros = ["arci-ros"]
 gui = ["openrr-gui"]
 # Enables the `iced_glow` renderer on GUI.
@@ -26,25 +31,26 @@ arci-speak-audio = "0.0.5"
 arci-speak-cmd = "0.0.5"
 arci-urdf-viz = "0.0.5"
 k = "0.24"
-openrr-client = "0.0.5"
-openrr-command = "0.0.5"
-openrr-teleop = "0.0.5"
+openrr-client = { version = "0.0.5", default-features = false }
+openrr-command = { version = "0.0.5", default-features = false }
+openrr-teleop = { version = "0.0.5", default-features = false }
 rand = "0.8.0"
 schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3.21"
 thiserror = "1.0"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 toml = "0.5"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = "0.2"
 urdf-rs = "0.6"
 
 arci-ros = { version = "0.0.5", optional = true }
-openrr-gui = { version = "0.0.5", optional = true }
+openrr-gui = { version = "0.0.5", optional = true, default-features = false }
 
 [dev-dependencies]
+tokio = { version = "1.0", features = ["full"] }
 
 [[bin]]
 name = "openrr_apps_robot_command"

--- a/openrr-apps/README.md
+++ b/openrr-apps/README.md
@@ -20,7 +20,7 @@ If you are Windows user, ROS is not supported.
 So remove it.
 
 ```bash
-cargo install openrr-apps --no-default-features --features gui
+cargo install openrr-apps --no-default-features --features gui,assimp
 ```
 
 ### Option: For UR10 sample

--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -10,11 +10,15 @@ categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
 documentation = "https://docs.rs/openrr-client"
 
+[features]
+default = ["assimp"]
+assimp = ["openrr-planner/assimp"]
+
 [dependencies]
 anyhow = "1.0"
 arci = "0.0.5"
 k = { version = "0.24", features = ["serde-serialize"] }
-openrr-planner = "0.0.5"
+openrr-planner = { version = "0.0.5", default-features = false }
 schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"

--- a/openrr-command/Cargo.toml
+++ b/openrr-command/Cargo.toml
@@ -10,11 +10,15 @@ categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
 documentation = "https://docs.rs/openrr-command"
 
+[features]
+default = ["assimp"]
+assimp = ["openrr-client/assimp"]
+
 [dependencies]
 arci = "0.0.5"
 async-recursion = "0.3"
 k = "0.24"
-openrr-client = "0.0.5"
+openrr-client = { version = "0.0.5", default-features = false }
 structopt = "0.3.21"
 thiserror = "1.0"
 tracing = { version = "0.1", features = ["log"] }

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/openrr/openrr"
 documentation = "https://docs.rs/openrr-gui"
 
 [features]
+default = ["assimp"]
+assimp = ["openrr-client/assimp"]
 # Enables the `iced_glow` renderer on GUI.
 # This might be useful if the default renderer doesn't work.
 glow = ["iced/glow"]
@@ -18,7 +20,7 @@ glow = ["iced/glow"]
 [dependencies]
 arci = "0.0.5"
 iced = "0.3"
-openrr-client = "0.0.5"
+openrr-client = { version = "0.0.5", default-features = false }
 rand = "0.8"
 thiserror = "1"
 tracing = { version = "0.1", features = ["log"] }

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -10,13 +10,20 @@ categories = ["algorithms", "science::robotics"]
 repository = "https://github.com/openrr/openrr"
 documentation = "https://docs.rs/openrr-teleop"
 
+[features]
+default = ["assimp"]
+assimp = ["openrr-client/assimp"]
+
 [dependencies]
 arci = "0.0.5"
 async-trait = "0.1"
 auto_impl = "0.4.1"
 k = "0.24"
-openrr-client = "0.0.5"
+openrr-client = { version = "0.0.5", default-features = false }
 schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "sync", "time"] }
 tracing = { version = "0.1", features = ["log"] }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["full"] }

--- a/openrr/Cargo.toml
+++ b/openrr/Cargo.toml
@@ -14,15 +14,21 @@ readme = "../README.md"
 
 [features]
 default = ["assimp"]
-assimp = ["openrr-planner/assimp"]
+assimp = [
+    "openrr-client/assimp",
+    "openrr-command/assimp",
+    "openrr-planner/assimp",
+    "openrr-teleop/assimp",
+    "openrr-apps/assimp",
+]
 ros = ["openrr-apps/ros"]
 
 [dependencies]
-openrr-client = "0.0.5"
-openrr-command = "0.0.5"
-openrr-planner = "0.0.5"
+openrr-client = { version = "0.0.5", default-features = false }
+openrr-command = { version = "0.0.5", default-features = false }
+openrr-planner = { version = "0.0.5", default-features = false }
 openrr-sleep = "0.0.5"
-openrr-teleop = "0.0.5"
+openrr-teleop = { version = "0.0.5", default-features = false }
 
 [dependencies.openrr-apps]
 version = "0.0.5"


### PR DESCRIPTION
Both or either is not available on some platforms, which can be a problem when working on support for platforms like WASM.

This PR makes both dependencies optional features.
This also adds a CI task that checks all feature combinations work properly.
