### PR TITLE
[openrr-planner,openrr-client] Fix clippy warnings added in 1.52

### DIFF
--- a/openrr-client/src/clients/collision_avoid_client.rs
+++ b/openrr-client/src/clients/collision_avoid_client.rs
@@ -40,8 +40,8 @@ where
     ) -> Self {
         Self {
             client,
-            collision_check_robot,
             using_joints,
+            collision_check_robot,
             planner,
         }
     }

--- a/openrr-client/src/clients/collision_check_client.rs
+++ b/openrr-client/src/clients/collision_check_client.rs
@@ -32,8 +32,8 @@ impl SelfCollisionChecker {
         let using_joints =
             k::Chain::<f64>::from_nodes(find_nodes(&joint_names, &collision_check_robot).unwrap());
         Self {
-            collision_check_robot,
             using_joints,
+            collision_check_robot,
             collision_checker,
             collision_pairs,
             time_interpolate_rate,

--- a/openrr-planner/src/collision/collision_checker.rs
+++ b/openrr-planner/src/collision/collision_checker.rs
@@ -365,14 +365,12 @@ impl FromUrdf for Compound<f64> {
                 l.collision
                     .iter()
                     .map(|collision| {
-                        match urdf_geometry_to_shape_handle(&collision.geometry, None) {
-                            Some(col) => Some((k::urdf::isometry_from(&collision.origin), col)),
-                            None => None,
-                        }
+                        urdf_geometry_to_shape_handle(&collision.geometry, None)
+                            .map(|col| (k::urdf::isometry_from(&collision.origin), col))
                     })
                     .collect::<Vec<_>>()
             })
-            .filter_map(|col_tuple| col_tuple)
+            .flatten()
             .collect::<Vec<_>>();
         Compound::new(compound_data)
     }


### PR DESCRIPTION
This fixes new clippy warnings added in the latest stable (1.52).

- Fix clippy::filter_map_identity warning
- Fix clippy::manual_map warning
- Fix clippy::inconsistent_struct_constructor warning

```text
error: called `filter_map(|x| x)` on an `Iterator`
   --> openrr-planner/src/collision/collision_checker.rs:375:14
    |
375 |             .filter_map(|col_tuple| col_tuple)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `flatten()`
    |
    = note: `-D clippy::filter-map-identity` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#filter_map_identity

error: manual implementation of `Option::map`
   --> openrr-planner/src/collision/collision_checker.rs:368:25
    |
368 | /                         match urdf_geometry_to_shape_handle(&collision.geometry, None) {
369 | |                             Some(col) => Some((k::urdf::isometry_from(&collision.origin), col)),
370 | |                             None => None,
371 | |                         }
    | |_________________________^ help: try this: `urdf_geometry_to_shape_handle(&collision.geometry, None).map(|col| (k::urdf::isometry_from(&collision.origin), col))`
    |
    = note: `-D clippy::manual-map` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
```
```text
error: inconsistent struct constructor
  --> openrr-client/src/clients/collision_avoid_client.rs:41:9
   |
41 | /         Self {
42 | |             client,
43 | |             collision_check_robot,
44 | |             using_joints,
45 | |             planner,
46 | |         }
   | |_________^ help: try: `Self { client, using_joints, collision_check_robot, planner }`
   |
   = note: `-D clippy::inconsistent-struct-constructor` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor

error: inconsistent struct constructor
  --> openrr-client/src/clients/collision_check_client.rs:34:9
   |
34 | /         Self {
35 | |             collision_check_robot,
36 | |             using_joints,
37 | |             collision_checker,
38 | |             collision_pairs,
39 | |             time_interpolate_rate,
40 | |         }
   | |_________^ help: try: `Self { using_joints, collision_check_robot, collision_checker, collision_pairs, time_interpolate_rate }`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor
```