### PR TITLE
[openrr-apps] Use doc comments instead of #[structopt(about)]

### DIFF
--- a/openrr-apps/src/bin/robot_command.rs
+++ b/openrr-apps/src/bin/robot_command.rs
@@ -5,11 +5,9 @@ use openrr_command::{RobotCommand, RobotCommandExecutor};
 use structopt::StructOpt;
 use tracing::info;
 
+/// An openrr command line tool.
 #[derive(StructOpt, Debug)]
-#[structopt(
-    name = env!("CARGO_BIN_NAME"),
-    about = "An openrr command line tool."
-)]
+#[structopt(name = env!("CARGO_BIN_NAME"))]
 struct RobotCommandArgs {
     /// Path to the setting file.
     #[structopt(short, long, parse(from_os_str))]

--- a/openrr-apps/src/bin/robot_teleop.rs
+++ b/openrr-apps/src/bin/robot_teleop.rs
@@ -9,11 +9,9 @@ use openrr_teleop::ControlNodeSwitcher;
 use structopt::StructOpt;
 use tracing::info;
 
+/// An openrr teleoperation tool.
 #[derive(StructOpt, Debug)]
-#[structopt(
-    name = env!("CARGO_BIN_NAME"),
-    about = "An openrr teleoperation tool."
-)]
+#[structopt(name = env!("CARGO_BIN_NAME"))]
 pub struct RobotTeleopArgs {
     /// Path to the setting file.
     #[structopt(short, long, parse(from_os_str))]


### PR DESCRIPTION
structopt recognizes the doc comment and treats it as a help message.

