### PR TITLE
[arci] Use WaitFuture::from in WaitFuture::new

### DIFF
--- a/arci/src/waits.rs
+++ b/arci/src/waits.rs
@@ -22,9 +22,7 @@ pub struct WaitFuture {
 impl WaitFuture {
     /// Waits until the `future` is complete.
     pub fn new(future: impl Future<Output = Result<(), Error>> + Send + 'static) -> Self {
-        Self {
-            future: future.boxed(),
-        }
+        Self::from(future.boxed())
     }
 
     /// Waits until the `stream` is complete.


### PR DESCRIPTION
Hopefully, this will make 100% test coverage for this file.
https://codecov.io/gh/openrr/openrr/src/main/arci/src/waits.rs