### PR TITLE
[openrr-apps] Create clients lazily

### DIFF
--- a/arci/Cargo.toml
+++ b/arci/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "0.1"
 auto_impl = "0.4"
 futures = "0.3"
 nalgebra = "0.26"
+once_cell = "1"
 schemars = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"

--- a/arci/src/clients.rs
+++ b/arci/src/clients.rs
@@ -6,6 +6,7 @@ mod dummy_trajectory_client;
 mod joint_position_limiter;
 mod joint_trajectory_clients_container;
 mod joint_velocity_limiter;
+mod lazy;
 mod partial_joint_trajectory_client;
 
 pub use dummy_localization::*;
@@ -16,4 +17,5 @@ pub use dummy_trajectory_client::*;
 pub use joint_position_limiter::*;
 pub use joint_trajectory_clients_container::*;
 pub use joint_velocity_limiter::*;
+pub use lazy::*;
 pub use partial_joint_trajectory_client::*;

--- a/arci/src/clients/lazy.rs
+++ b/arci/src/clients/lazy.rs
@@ -1,0 +1,158 @@
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use async_trait::async_trait;
+use nalgebra::{Isometry2, Isometry3};
+use tracing::error;
+
+use crate::{
+    error::Error,
+    gamepad::GamepadEvent,
+    traits::{
+        BaseVelocity, Gamepad, JointTrajectoryClient, Localization, MoveBase, Navigation, Speaker,
+        TrajectoryPoint, TransformResolver,
+    },
+    waits::WaitFuture,
+};
+
+#[allow(clippy::type_complexity)]
+pub struct Lazy<'a, T>(
+    once_cell::sync::Lazy<
+        Result<T, Arc<Error>>,
+        Box<dyn FnOnce() -> Result<T, Arc<Error>> + Send + Sync + 'a>,
+    >,
+);
+
+impl<'a, T> Lazy<'a, T> {
+    pub fn new(f: impl FnOnce() -> Result<T, Error> + Send + Sync + 'a) -> Self {
+        Self(once_cell::sync::Lazy::new(Box::new(|| {
+            f().map_err(Arc::new)
+        })))
+    }
+
+    pub fn get_ref(&self) -> Result<&T, Error> {
+        self.0.as_ref().map_err(|e| Error::Arc(e.clone()))
+    }
+}
+
+impl<T> JointTrajectoryClient for Lazy<'_, T>
+where
+    T: JointTrajectoryClient,
+{
+    fn joint_names(&self) -> Vec<String> {
+        match self.get_ref() {
+            Ok(this) => this.joint_names(),
+            Err(e) => {
+                error!("{}", e);
+                // TODO
+                vec![]
+            }
+        }
+    }
+
+    fn current_joint_positions(&self) -> Result<Vec<f64>, Error> {
+        self.get_ref()?.current_joint_positions()
+    }
+
+    fn send_joint_positions(
+        &self,
+        positions: Vec<f64>,
+        duration: Duration,
+    ) -> Result<WaitFuture, Error> {
+        self.get_ref()?.send_joint_positions(positions, duration)
+    }
+
+    fn send_joint_trajectory(&self, trajectory: Vec<TrajectoryPoint>) -> Result<WaitFuture, Error> {
+        self.get_ref()?.send_joint_trajectory(trajectory)
+    }
+}
+
+impl<T> Localization for Lazy<'_, T>
+where
+    T: Localization,
+{
+    fn current_pose(&self, frame_id: &str) -> Result<Isometry2<f64>, Error> {
+        self.get_ref()?.current_pose(frame_id)
+    }
+}
+
+impl<T> MoveBase for Lazy<'_, T>
+where
+    T: MoveBase,
+{
+    fn current_velocity(&self) -> Result<BaseVelocity, Error> {
+        self.get_ref()?.current_velocity()
+    }
+
+    fn send_velocity(&self, velocity: &BaseVelocity) -> Result<(), Error> {
+        self.get_ref()?.send_velocity(velocity)
+    }
+}
+
+impl<T> Navigation for Lazy<'_, T>
+where
+    T: Navigation,
+{
+    fn send_goal_pose(
+        &self,
+        goal: Isometry2<f64>,
+        frame_id: &str,
+        timeout: Duration,
+    ) -> Result<WaitFuture, Error> {
+        self.get_ref()?.send_goal_pose(goal, frame_id, timeout)
+    }
+
+    fn cancel(&self) -> Result<(), Error> {
+        self.get_ref()?.cancel()
+    }
+}
+
+impl<T> Speaker for Lazy<'_, T>
+where
+    T: Speaker,
+{
+    fn speak(&self, message: &str) -> Result<WaitFuture, Error> {
+        self.get_ref()?.speak(message)
+    }
+}
+
+impl<T> TransformResolver for Lazy<'_, T>
+where
+    T: TransformResolver,
+{
+    fn resolve_transformation(
+        &self,
+        from: &str,
+        to: &str,
+        time: SystemTime,
+    ) -> Result<Isometry3<f64>, Error> {
+        self.get_ref()?.resolve_transformation(from, to, time)
+    }
+}
+
+#[async_trait]
+impl<T> Gamepad for Lazy<'_, T>
+where
+    T: Gamepad,
+{
+    async fn next_event(&self) -> GamepadEvent {
+        match self.get_ref() {
+            Ok(this) => this.next_event().await,
+            Err(e) => {
+                error!("{}", e);
+                GamepadEvent::Unknown
+            }
+        }
+    }
+
+    fn stop(&self) {
+        match self.get_ref() {
+            Ok(this) => this.stop(),
+            Err(e) => {
+                error!("{}", e);
+            }
+        }
+    }
+}

--- a/arci/src/error.rs
+++ b/arci/src/error.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::{ops::RangeInclusive, sync::Arc};
 
 use thiserror::Error;
 
@@ -52,6 +52,8 @@ pub enum Error {
         position: f64,
         limit: RangeInclusive<f64>,
     },
+    #[error("{}", .0)]
+    Arc(Arc<Error>),
     #[error("arci: Other: {:?}", .0)]
     Other(#[from] anyhow::Error),
 }

--- a/arci/src/error.rs
+++ b/arci/src/error.rs
@@ -52,8 +52,8 @@ pub enum Error {
         position: f64,
         limit: RangeInclusive<f64>,
     },
-    #[error("{}", .0)]
-    Arc(Arc<Error>),
+    #[error("arci: Failed to construct instance: {}", .0)]
+    Lazy(Arc<Error>),
     #[error("arci: Other: {:?}", .0)]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
This makes the creation of clients except for arci-ros's JointTrajectoryClient lazy.

before:

```console
$ urdf-viz ./openrr-planner/sample.urdf &
$ RUST_LOG=openrr_apps=debug cargo run -p openrr-apps --bin openrr_apps_joint_position_sender -- --config-path ./openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml
May 21 17:10:58.516 DEBUG openrr_apps_joint_position_sender: opt: Opt { ... }
May 21 17:10:58.519 DEBUG openrr_apps::robot_config: RobotConfig { ... }
May 21 17:10:58.519 DEBUG openrr_apps::utils: init openrr_apps_joint_position_sender with RobotConfig { ... }
May 21 17:10:58.520 DEBUG create_print_speaker: openrr_apps::robot_config: creating PrintSpeaker
May 21 17:10:58.537 DEBUG create_localization_with_ros:create_localization_without_ros: openrr_apps::robot_config: creating UrdfVizWebClient
May 21 17:10:58.538 DEBUG create_move_base_with_ros:create_move_base_without_ros: openrr_apps::robot_config: creating UrdfVizWebClient
May 21 17:10:58.539 DEBUG create_navigation_with_ros:create_navigation_without_ros: openrr_apps::robot_config: creating UrdfVizWebClient
```


after:

```console
$ urdf-viz ./openrr-planner/sample.urdf &
$ RUST_LOG=openrr_apps=debug cargo run -p openrr-apps --bin openrr_apps_joint_position_sender -- --config-path ./openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml
May 21 17:13:33.790 DEBUG openrr_apps_joint_position_sender: opt: Opt { ... }
May 21 17:13:33.795 DEBUG openrr_apps::robot_config: RobotConfig { ... }
May 21 17:13:33.795 DEBUG openrr_apps::utils: init openrr_apps_joint_position_sender with RobotConfig { ... }
```