### PR TITLE
[arci-urdf-viz] Fix leak

### DIFF
--- a/arci-urdf-viz/tests/test_web.rs
+++ b/arci-urdf-viz/tests/test_web.rs
@@ -12,6 +12,7 @@ fn test_set_get_vel() {
     web_server.start_background();
     let c = UrdfVizWebClient::try_new(Url::parse(&format!("http://127.0.0.1:{}", PORT)).unwrap())
         .unwrap();
+    c.run_send_velocity_thread();
     let v = c.current_velocity().unwrap();
     assert_approx_eq!(v.x, 0.0);
     assert_approx_eq!(v.y, 0.0);

--- a/openrr-apps/src/robot_config.rs
+++ b/openrr-apps/src/robot_config.rs
@@ -263,7 +263,7 @@ impl RobotConfig {
             Some(Box::new(arci::Lazy::new(move || {
                 debug!("create_move_base_without_ros: creating UrdfVizWebClient");
                 let urdf_viz_client = UrdfVizWebClient::default();
-                urdf_viz_client.run_thread();
+                urdf_viz_client.run_send_velocity_thread();
                 Ok(urdf_viz_client)
             })))
         } else {


### PR DESCRIPTION
The thread has a cloned `Arc`, so this drop will never be called and `is_dropping` flag will never set to `true`.

https://github.com/openrr/openrr/blob/36a3e59b2f6dcf9c8faa281fbd77783fd6531706/arci-urdf-viz/src/client.rs#L315-L319

And the thread will not terminate unless `is_dropping` flag is `true`.

https://github.com/openrr/openrr/blob/36a3e59b2f6dcf9c8faa281fbd77783fd6531706/arci-urdf-viz/src/client.rs#L244

Therefore, the thread and `Arc<UrdfVizWebClientInner>` will continue to live until the end of the program even if the client is dropped.