### PR TITLE
[arci-urdf-viz] Fix default value of quaternion in web server

### DIFF
--- a/arci-urdf-viz/tests/web_server.rs
+++ b/arci-urdf-viz/tests/web_server.rs
@@ -19,10 +19,19 @@ pub struct JointNamesAndPositions {
     pub positions: Vec<f32>,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct RobotOrigin {
     pub position: [f32; 3],
     pub quaternion: [f32; 4],
+}
+
+impl Default for RobotOrigin {
+    fn default() -> Self {
+        Self {
+            position: Default::default(),
+            quaternion: [1.0, 0.0, 0.0, 0.0],
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]


### PR DESCRIPTION
Currently, the default value of `RobotOrigin::quaternion` is `[0.0,0.0,0.0,0.0]`.

https://github.com/openrr/openrr/blob/fe3494605ed2e9131d45741a8ad077588a54001a/arci-urdf-viz/tests/web_server.rs#L22-L26

However, if quaternion is `[0.0,0.0,0.0,0.0]`, this conversion will fail ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=9406215f3a35be566969900401cc1062)).

https://github.com/openrr/openrr/blob/fe3494605ed2e9131d45741a8ad077588a54001a/arci-urdf-viz/src/utils.rs#L88-L90

And this request will fail due to the conversion failure. (If the conversion fails, some values of the `pose` will be nan.)

https://github.com/openrr/openrr/blob/fe3494605ed2e9131d45741a8ad077588a54001a/arci-urdf-viz/src/client.rs#L254

`urdf_viz::Data` also uses the same default value, but [is replaced with `[1.0, 0.0, 0.0, 0.0]` (as far as I know) at startup](https://github.com/openrr/urdf-viz/blob/839c8761e174c964fc8f58e0777f4cefa8f3b416/src/app.rs#L456-L465).