### PR TITLE
[arci-ros2] Allow arci-ros2 to be used as plugin

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -32,7 +32,8 @@ jobs:
           source /opt/ros/foxy/setup.bash
           # for test of arci-ros (roscore, rostopic)
           source /opt/ros/noetic/setup.bash
-          cargo tarpaulin --verbose --all-features --workspace --out Xml --timeout 60
+          # TODO: Currently, if we include arci-ros2, the build fails due to "Broken pipe (os error 32)" error.
+          cargo tarpaulin --verbose --all-features --workspace --exclude arci-ros2 --out Xml --timeout 60
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
         with:

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -10,13 +10,19 @@ categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
 documentation = "https://docs.rs/arci-ros2"
 
+[lib]
+crate-type = ["lib", "staticlib", "cdylib"]
+
 [dependencies]
+abi_stable = "0.9"
 anyhow = "1.0"
 arci = "0.0.5"
 async-trait = "0.1"
-thiserror = "1.0"
-r2r = { git = "https://github.com/sequenceplanner/r2r", optional = true}
+openrr-plugin = "0.0.5"
+r2r = { git = "https://github.com/sequenceplanner/r2r", optional = true }
 serde = { version = "1", features = ["derive"] }
+thiserror = "1.0"
+toml = "0.5"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/arci-ros2/src/cmd_vel_move_base.rs
+++ b/arci-ros2/src/cmd_vel_move_base.rs
@@ -37,6 +37,7 @@ impl MoveBase for Ros2CmdVelMoveBase {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Ros2CmdVelMoveBaseConfig {
     pub topic: String,
 }

--- a/arci-ros2/src/lib.rs
+++ b/arci-ros2/src/lib.rs
@@ -1,6 +1,10 @@
 //! [`arci`] implementation using ROS2.
+
 #[cfg(feature = "ros2")]
 mod cmd_vel_move_base;
+#[cfg(feature = "ros2")]
+mod plugin;
+
 #[cfg(feature = "ros2")]
 pub use cmd_vel_move_base::*;
 // re-export

--- a/arci-ros2/src/plugin.rs
+++ b/arci-ros2/src/plugin.rs
@@ -1,0 +1,43 @@
+use std::{
+    cell::RefCell,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use crate::{Ros2CmdVelMoveBase, Ros2CmdVelMoveBaseConfig};
+
+openrr_plugin::export_plugin!(Ros2Plugin {});
+
+struct Ros2Plugin {}
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+thread_local! {
+    // r2r::Node is not thread-safe, so create a node per thread.
+    static NODE: RefCell<r2r::Node> = {
+        let ctx = r2r::Context::create().unwrap();
+        // Name a different node name per thread. Note that this is not a unique
+        // name. If we need a really unique node name, we may need to include
+        // the process id as well.
+        // See also https://github.com/ros2/design/issues/187.
+        let name = format!("arci_ros2_plugin_node_{}", COUNTER.fetch_add(1, Ordering::Relaxed));
+        let node = r2r::Node::create(ctx, &name, "").unwrap();
+        RefCell::new(node)
+    }
+}
+
+impl openrr_plugin::Plugin for Ros2Plugin {
+    fn name(&self) -> String {
+        "arci-ros2-plugin".into()
+    }
+
+    fn new_move_base(&self, args: String) -> Result<Option<Box<dyn arci::MoveBase>>, arci::Error> {
+        let config: Ros2CmdVelMoveBaseConfig =
+            toml::from_str(&args).map_err(anyhow::Error::from)?;
+        Ok(Some(NODE.with(|node| {
+            Box::new(Ros2CmdVelMoveBase::new(
+                &mut *node.borrow_mut(),
+                &config.topic,
+            ))
+        })))
+    }
+}

--- a/openrr-apps/config/sample_robot_client_config_for_plugin.toml
+++ b/openrr-apps/config/sample_robot_client_config_for_plugin.toml
@@ -1,3 +1,5 @@
+move_base = "plugin1"
+
 [openrr_clients_config]
 urdf_path = "../../openrr-planner/sample.urdf"
 self_collision_check_pairs = ["l_shoulder_yaw:l_gripper_linear1"]
@@ -42,5 +44,20 @@ args = """
 """
 
 [[plugins.plugin1.instances]]
-name = "move_base"
+name = "plugin1"
 type = "MoveBase"
+
+[[plugins.plugin1.instances]]
+# If the instances are of different types, the names of the instances will not conflict.
+name = "plugin1"
+type = "Navigation"
+
+[plugins.arci_ros2]
+path = "../../target/debug/libarci_ros2"
+
+[[plugins.arci_ros2.instances]]
+name = "arci_ros2"
+type = "MoveBase"
+args = """
+topic = "/cmd_vel"
+"""


### PR DESCRIPTION
~~Depend on #319~~

### Examples

```sh
# build plugins
cargo build -p arci-ros2 --features ros2
cargo build -p openrr-plugin-example

# run gazebo
gazebo --verbose /opt/ros/foxy/share/gazebo_plugins/worlds/gazebo_ros_diff_drive_demo.world
# run openrr_apps_velocity_sender
cargo run -p openrr-apps --bin openrr_apps_velocity_sender -- \
    --config-path ./openrr-apps/config/sample_robot_client_config_for_plugin.toml \
    --config='move_base="arci_ros2";plugins.arci_ros2.instances[0].args="topic=\"/demo/cmd_demo\""'
```