### PR TITLE
Ignore dependabot update of nalgebra, ncollide3d, k, and urdf-viz

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,10 @@ updates:
       interval: daily
     commit-message:
       prefix: ''
+    ignore:
+      # These dependencies need to be updated at the same time.
+      - dependency-name: k
+      - dependency-name: nalgebra
+      - dependency-name: ncollide3d
+      - dependency-name: urdf-viz
     labels: []


### PR DESCRIPTION
These dependencies need to be updated at the same time.