### PR TITLE
[arci-ros2] Store Node globally

### DIFF
--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -18,6 +18,7 @@ abi_stable = "0.9"
 anyhow = "1.0"
 arci = "0.0.5"
 async-trait = "0.1"
+once_cell = "1"
 openrr-plugin = "0.0.5"
 r2r = { git = "https://github.com/sequenceplanner/r2r", optional = true }
 serde = { version = "1", features = ["derive"] }

--- a/arci-ros2/src/plugin.rs
+++ b/arci-ros2/src/plugin.rs
@@ -1,7 +1,6 @@
-use std::{
-    cell::RefCell,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
 
 use crate::{Ros2CmdVelMoveBase, Ros2CmdVelMoveBaseConfig};
 
@@ -9,21 +8,14 @@ openrr_plugin::export_plugin!(Ros2Plugin {});
 
 struct Ros2Plugin {}
 
-static COUNTER: AtomicUsize = AtomicUsize::new(0);
-
-thread_local! {
-    // r2r::Node is not thread-safe, so create a node per thread.
-    static NODE: RefCell<r2r::Node> = {
-        let ctx = r2r::Context::create().unwrap();
-        // Name a different node name per thread. Note that this is not a unique
-        // name. If we need a really unique node name, we may need to include
-        // the process id as well.
-        // See also https://github.com/ros2/design/issues/187.
-        let name = format!("arci_ros2_plugin_node_{}", COUNTER.fetch_add(1, Ordering::Relaxed));
-        let node = r2r::Node::create(ctx, &name, "").unwrap();
-        RefCell::new(node)
-    }
-}
+static NODE: Lazy<Mutex<r2r::Node>> = Lazy::new(|| {
+    let ctx = r2r::Context::create().unwrap();
+    // Note that this is not a unique name. If we need a really unique node
+    // name, we may need to include the process id as well.
+    // See also https://github.com/ros2/design/issues/187.
+    let node = r2r::Node::create(ctx, "arci_ros2_plugin_node", "").unwrap();
+    Mutex::new(node)
+});
 
 impl openrr_plugin::Plugin for Ros2Plugin {
     fn name(&self) -> String {
@@ -33,11 +25,10 @@ impl openrr_plugin::Plugin for Ros2Plugin {
     fn new_move_base(&self, args: String) -> Result<Option<Box<dyn arci::MoveBase>>, arci::Error> {
         let config: Ros2CmdVelMoveBaseConfig =
             toml::from_str(&args).map_err(anyhow::Error::from)?;
-        Ok(Some(NODE.with(|node| {
-            Box::new(Ros2CmdVelMoveBase::new(
-                &mut *node.borrow_mut(),
-                &config.topic,
-            ))
-        })))
+        let mut node = NODE.lock().unwrap();
+        Ok(Some(Box::new(Ros2CmdVelMoveBase::new(
+            &mut *node,
+            &config.topic,
+        ))))
     }
 }


### PR DESCRIPTION
`r2r::Node` is now `Send`. https://github.com/sequenceplanner/r2r/commit/5ab5ab5e3f5f0f137886fd98654b6e7cc99ea3b1