### PR TITLE
[openrr-apps] Emit log to stderr instead of stdout

### DIFF
--- a/openrr-apps/src/bin/config.rs
+++ b/openrr-apps/src/bin/config.rs
@@ -1,6 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use anyhow::Result;
+use openrr_apps::utils::init_tracing;
 use schemars::schema_for;
 use serde::Deserialize;
 use structopt::{clap::arg_enum, StructOpt};
@@ -47,7 +48,7 @@ enum Config {
 }
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    init_tracing();
     let args = Args::from_args();
     debug!(?args);
 

--- a/openrr-apps/src/bin/joint_position_sender.rs
+++ b/openrr-apps/src/bin/joint_position_sender.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use anyhow::Result;
-use openrr_apps::RobotConfig;
+use openrr_apps::{utils::init_tracing, RobotConfig};
 use openrr_client::BoxRobotClient;
 use openrr_gui::joint_position_sender;
 use structopt::StructOpt;
@@ -21,7 +21,7 @@ struct Opt {
 }
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    init_tracing();
     let opt = Opt::from_args();
     debug!("opt: {:?}", opt);
 

--- a/openrr-apps/src/bin/robot_command.rs
+++ b/openrr-apps/src/bin/robot_command.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use anyhow::Result;
-use openrr_apps::{Error, RobotConfig};
+use openrr_apps::{utils::init_tracing, Error, RobotConfig};
 use openrr_command::{RobotCommand, RobotCommandExecutor};
 use structopt::StructOpt;
 use tracing::info;
@@ -26,7 +26,7 @@ struct RobotCommandArgs {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    init_tracing();
     let args = RobotCommandArgs::from_args();
     info!("ParsedArgs {:?}", args);
 

--- a/openrr-apps/src/bin/robot_teleop.rs
+++ b/openrr-apps/src/bin/robot_teleop.rs
@@ -4,7 +4,9 @@ use std::{fs, path::PathBuf, sync::Arc};
 
 use anyhow::{format_err, Result};
 use arci_gamepad_gilrs::GilGamepad;
-use openrr_apps::{BuiltinGamepad, Error, GamepadKind, RobotConfig, RobotTeleopConfig};
+use openrr_apps::{
+    utils::init_tracing, BuiltinGamepad, Error, GamepadKind, RobotConfig, RobotTeleopConfig,
+};
 use openrr_client::ArcRobotClient;
 use openrr_plugin::PluginProxy;
 use openrr_teleop::ControlNodeSwitcher;
@@ -33,7 +35,7 @@ pub struct RobotTeleopArgs {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    init_tracing();
     let args = RobotTeleopArgs::from_args();
 
     if args.show_default_config {

--- a/openrr-apps/src/bin/velocity_sender.rs
+++ b/openrr-apps/src/bin/velocity_sender.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use anyhow::Result;
-use openrr_apps::RobotConfig;
+use openrr_apps::{utils::init_tracing, RobotConfig};
 use openrr_client::BoxRobotClient;
 use openrr_gui::velocity_sender;
 use structopt::StructOpt;
@@ -21,7 +21,7 @@ struct Opt {
 }
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    init_tracing();
     let opt = Opt::from_args();
     debug!("opt: {:?}", opt);
 

--- a/openrr-apps/src/utils.rs
+++ b/openrr-apps/src/utils.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{io, path::PathBuf};
 
 use rand::prelude::*;
 use tracing::{debug, warn};
@@ -61,4 +61,11 @@ pub fn init_with_anonymize(name: &str, config: &RobotConfig) {
     let suffix: u64 = rand::thread_rng().gen();
     let anon_name = format!("{}_{}", name, suffix);
     init(&anon_name, config);
+}
+
+pub fn init_tracing() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(io::stderr)
+        .init();
 }

--- a/tools/update-schema.sh
+++ b/tools/update-schema.sh
@@ -10,7 +10,5 @@ IFS=$'\n\t'
 
 cd "$(cd "$(dirname "${0}")" && pwd)"/..
 
-export RUST_LOG=error
-
 cargo run -p openrr-apps --bin openrr_apps_config -- schema RobotConfig >openrr-apps/schema/robot_config.json
 cargo run -p openrr-apps --bin openrr_apps_config -- schema RobotTeleopConfig >openrr-apps/schema/robot_teleop_config.json


### PR DESCRIPTION
openrr_apps_config uses stdout, so if we use stdout for output of log, it will conflicts.