### PR TITLE
[openrr-teleop] Fix panic in switcher

### DIFF
--- a/arci-gamepad-gilrs/src/lib.rs
+++ b/arci-gamepad-gilrs/src/lib.rs
@@ -1,6 +1,9 @@
 //! [`arci::Gamepad`] implementation using [gilrs](https://gitlab.com/gilrs-project/gilrs).
 
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 use std::{
     collections::HashMap,

--- a/arci-gamepad-keyboard/src/lib.rs
+++ b/arci-gamepad-keyboard/src/lib.rs
@@ -39,6 +39,9 @@
 
 #![cfg(unix)]
 #![warn(missing_docs, rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 use std::{
     collections::HashMap,

--- a/arci-ros/src/lib.rs
+++ b/arci-ros/src/lib.rs
@@ -1,6 +1,9 @@
 //! [`arci`] implementation using ROS1.
 
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod cmd_vel_move_base;
 mod error;

--- a/arci-ros2/src/lib.rs
+++ b/arci-ros2/src/lib.rs
@@ -9,6 +9,9 @@
     unreachable_pub
 )]
 #![warn(clippy::default_trait_access, clippy::wildcard_imports)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod cmd_vel_move_base;
 mod navigation;

--- a/arci-speak-audio/src/lib.rs
+++ b/arci-speak-audio/src/lib.rs
@@ -1,6 +1,9 @@
 //! [`arci::Speaker`] implementation for playing audio files.
 
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 use std::{
     collections::HashMap,

--- a/arci-speak-cmd/src/lib.rs
+++ b/arci-speak-cmd/src/lib.rs
@@ -1,6 +1,9 @@
 //! [`arci::Speaker`] implementation using local command.
 
 #![warn(missing_docs, rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 use std::{io, process::Command};
 

--- a/arci-urdf-viz/src/lib.rs
+++ b/arci-urdf-viz/src/lib.rs
@@ -1,6 +1,9 @@
 //! [`arci`] implementation using [urdf-viz](https://github.com/openrr/urdf-viz).
 
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod client;
 mod utils;

--- a/arci/src/lib.rs
+++ b/arci/src/lib.rs
@@ -1,6 +1,9 @@
 //! Abstract Robot Control Interface.
 
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod clients;
 mod error;

--- a/openrr-apps/src/lib.rs
+++ b/openrr-apps/src/lib.rs
@@ -1,4 +1,7 @@
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod error;
 mod robot_config;

--- a/openrr-client/src/lib.rs
+++ b/openrr-client/src/lib.rs
@@ -1,4 +1,7 @@
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod clients;
 mod error;

--- a/openrr-command/src/lib.rs
+++ b/openrr-command/src/lib.rs
@@ -1,4 +1,7 @@
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod error;
 mod robot_command;

--- a/openrr-config/src/lib.rs
+++ b/openrr-config/src/lib.rs
@@ -1,6 +1,9 @@
 //! Utilities for modifying configuration files.
 
 #![warn(missing_docs, rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 use std::{iter, mem};
 

--- a/openrr-gui/src/lib.rs
+++ b/openrr-gui/src/lib.rs
@@ -1,4 +1,7 @@
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod error;
 mod joint_position_sender;

--- a/openrr-planner/src/lib.rs
+++ b/openrr-planner/src/lib.rs
@@ -20,6 +20,9 @@ limitations under the License.
 //!
 
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod errors;
 

--- a/openrr-plugin/src/lib.rs
+++ b/openrr-plugin/src/lib.rs
@@ -1,6 +1,9 @@
 //! Experimental plugin support for [`arci`].
 
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod proxy;
 

--- a/openrr-sleep/src/lib.rs
+++ b/openrr-sleep/src/lib.rs
@@ -1,4 +1,7 @@
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod scoped_sleep;
 

--- a/openrr-teleop/src/lib.rs
+++ b/openrr-teleop/src/lib.rs
@@ -1,4 +1,7 @@
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 mod control_node;
 mod control_nodes_config;

--- a/openrr/src/lib.rs
+++ b/openrr/src/lib.rs
@@ -1,4 +1,7 @@
 #![warn(rust_2018_idioms)]
+// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
+// https://github.com/rust-lang/rust-clippy/issues/4295
+#![allow(clippy::mutex_atomic)]
 
 pub mod apps {
     pub use openrr_apps::*;


### PR DESCRIPTION
In the current implementation, if the index is loaded while increment_mode is being processed, the index may point out of range.

I guess this is a bug introduced by clippy::mutex_atomic lint's false positive was misinterpreted as a correct warning. I think it is possible to write this using atomic, but it is more complicated because it requires a way like CAS loop.