### PR TITLE
Support urdf-viz client without config

### DIFF
--- a/arci/src/error.rs
+++ b/arci/src/error.rs
@@ -65,6 +65,8 @@ pub enum Error {
     },
     #[error("arci: Failed to construct instance: {}", .0)]
     Lazy(Arc<Error>),
+    #[error("arci: urdf: {:?}", .0)]
+    Urdf(#[from] urdf_rs::UrdfError),
     #[error("arci: Other: {:?}", .0)]
     Other(#[from] anyhow::Error),
 }

--- a/openrr-apps/config/sample_robot_client_config_for_urdf_viz_minimal.toml
+++ b/openrr-apps/config/sample_robot_client_config_for_urdf_viz_minimal.toml
@@ -1,6 +1,0 @@
-[[urdf_viz_clients_configs]]
-name = "arm"
-wrap_with_joint_position_limiter = true
-
-[openrr_clients_config]
-urdf_path = "../../openrr-planner/sample.urdf"

--- a/openrr-apps/src/bin/robot_command.rs
+++ b/openrr-apps/src/bin/robot_command.rs
@@ -36,15 +36,34 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let config_path =
-        openrr_apps::utils::get_apps_robot_config(args.config_path).ok_or(Error::NoConfigPath)?;
+    let config_path = openrr_apps::utils::get_apps_robot_config(args.config_path);
     let command = args.command.ok_or(Error::NoCommand)?;
-    let robot_config = if let Some(overwrite) = &args.config {
-        let s = &fs::read_to_string(&config_path)?;
-        let s = &openrr_config::overwrite_str(s, overwrite)?;
-        RobotConfig::from_str(s, config_path)?
-    } else {
-        RobotConfig::new(config_path)?
+    let robot_config = match (&config_path, &args.config) {
+        (Some(config_path), Some(overwrite)) => {
+            let s = &fs::read_to_string(&config_path)?;
+            let s = &openrr_config::overwrite_str(s, overwrite)?;
+            RobotConfig::from_str(s, config_path)?
+        }
+        (Some(config_path), None) => RobotConfig::new(config_path)?,
+        (None, overwrite) => {
+            let mut config = RobotConfig::default();
+            config
+                .urdf_viz_clients_configs
+                .push(arci_urdf_viz::UrdfVizWebClientConfig {
+                    name: "all".into(),
+                    joint_names: None,
+                    wrap_with_joint_position_limiter: false,
+                    wrap_with_joint_velocity_limiter: false,
+                    joint_velocity_limits: None,
+                    joint_position_limits: None,
+                });
+            if let Some(overwrite) = overwrite {
+                let s = &toml::to_string(&config)?;
+                let s = &openrr_config::overwrite_str(s, overwrite)?;
+                config = toml::from_str(s)?;
+            }
+            config
+        }
     };
 
     openrr_apps::utils::init_with_anonymize(env!("CARGO_BIN_NAME"), &robot_config);

--- a/openrr-apps/src/bin/robot_teleop.rs
+++ b/openrr-apps/src/bin/robot_teleop.rs
@@ -54,13 +54,33 @@ async fn main() -> Result<()> {
     } else {
         RobotTeleopConfig::new(teleop_config_path.clone())?
     };
-    let robot_config_path = teleop_config.robot_config_full_path().as_ref().unwrap();
-    let robot_config = if let Some(overwrite) = &args.robot_config {
-        let s = &fs::read_to_string(&robot_config_path)?;
-        let s = &openrr_config::overwrite_str(s, overwrite)?;
-        RobotConfig::from_str(s, robot_config_path)?
-    } else {
-        RobotConfig::new(robot_config_path)?
+    let robot_config_path = teleop_config.robot_config_full_path();
+    let robot_config = match (robot_config_path, &args.robot_config) {
+        (Some(config_path), Some(overwrite)) => {
+            let s = &fs::read_to_string(&config_path)?;
+            let s = &openrr_config::overwrite_str(s, overwrite)?;
+            RobotConfig::from_str(s, config_path)?
+        }
+        (Some(config_path), None) => RobotConfig::new(config_path)?,
+        (None, overwrite) => {
+            let mut config = RobotConfig::default();
+            config
+                .urdf_viz_clients_configs
+                .push(arci_urdf_viz::UrdfVizWebClientConfig {
+                    name: "all".into(),
+                    joint_names: None,
+                    wrap_with_joint_position_limiter: false,
+                    wrap_with_joint_velocity_limiter: false,
+                    joint_velocity_limits: None,
+                    joint_position_limits: None,
+                });
+            if let Some(overwrite) = overwrite {
+                let s = &toml::to_string(&config)?;
+                let s = &openrr_config::overwrite_str(s, overwrite)?;
+                config = toml::from_str(s)?;
+            }
+            config
+        }
     };
 
     openrr_apps::utils::init(env!("CARGO_BIN_NAME"), &robot_config);

--- a/openrr-apps/src/bin/velocity_sender.rs
+++ b/openrr-apps/src/bin/velocity_sender.rs
@@ -25,13 +25,33 @@ fn main() -> Result<()> {
     let opt = Opt::from_args();
     debug!("opt: {:?}", opt);
 
-    let config_path = openrr_apps::utils::get_apps_robot_config(opt.config_path).unwrap();
-    let config = if let Some(overwrite) = &opt.config {
-        let s = &fs::read_to_string(&config_path)?;
-        let s = &openrr_config::overwrite_str(s, overwrite)?;
-        RobotConfig::from_str(s, config_path)?
-    } else {
-        RobotConfig::new(config_path)?
+    let config_path = openrr_apps::utils::get_apps_robot_config(opt.config_path);
+    let config = match (&config_path, &opt.config) {
+        (Some(config_path), Some(overwrite)) => {
+            let s = &fs::read_to_string(&config_path)?;
+            let s = &openrr_config::overwrite_str(s, overwrite)?;
+            RobotConfig::from_str(s, config_path)?
+        }
+        (Some(config_path), None) => RobotConfig::new(config_path)?,
+        (None, overwrite) => {
+            let mut config = RobotConfig::default();
+            config
+                .urdf_viz_clients_configs
+                .push(arci_urdf_viz::UrdfVizWebClientConfig {
+                    name: "all".into(),
+                    joint_names: None,
+                    wrap_with_joint_position_limiter: false,
+                    wrap_with_joint_velocity_limiter: false,
+                    joint_velocity_limits: None,
+                    joint_position_limits: None,
+                });
+            if let Some(overwrite) = overwrite {
+                let s = &toml::to_string(&config)?;
+                let s = &openrr_config::overwrite_str(s, overwrite)?;
+                config = toml::from_str(s)?;
+            }
+            config
+        }
     };
 
     openrr_apps::utils::init(env!("CARGO_BIN_NAME"), &config);

--- a/openrr-apps/src/error.rs
+++ b/openrr-apps/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
     DuplicateInstance(String),
     #[error("openrr-apps: Config {:?} requires ros feature.", .0)]
     ConfigRequireRos(String),
-    #[error("openrr-apps: arci: {:?}", .0)]
+    #[error("openrr-apps: urdf: {:?}", .0)]
     Urdf(#[from] urdf_rs::UrdfError),
     #[error("openrr-apps: arci: {:?}", .0)]
     Arci(#[from] arci::Error),

--- a/openrr-teleop/src/control_nodes_config.rs
+++ b/openrr-teleop/src/control_nodes_config.rs
@@ -49,7 +49,7 @@ impl ControlNodesConfig {
     #[allow(clippy::too_many_arguments)]
     pub fn create_control_nodes(
         &self,
-        base_path: PathBuf,
+        base_path: Option<PathBuf>,
         robot_client: Arc<ArcRobotClient>,
         speaker: Arc<dyn Speaker>,
         joint_trajectory_client_map: &HashMap<String, Arc<dyn JointTrajectoryClient>>,
@@ -103,13 +103,15 @@ impl ControlNodesConfig {
         }
 
         if !self.command_configs.is_empty() {
-            if let Some(e) = RobotCommandExecutor::new(
-                base_path,
-                self.command_configs.clone(),
-                robot_client,
-                speaker.clone(),
-            ) {
-                nodes.push(Box::new(e));
+            if let Some(base_path) = base_path {
+                if let Some(e) = RobotCommandExecutor::new(
+                    base_path,
+                    self.command_configs.clone(),
+                    robot_client,
+                    speaker.clone(),
+                ) {
+                    nodes.push(Box::new(e));
+                }
             }
         }
 


### PR DESCRIPTION
Depend on https://github.com/openrr/urdf-viz/pull/96.

```sh
cargo run --manifest-path ../urdf-viz/Cargo.toml -- ./openrr-planner/sample.urdf &

# openrr_apps_joint_position_sender
cargo run -p openrr-apps --bin openrr_apps_joint_position_sender

# openrr_apps_robot_teleop
cargo run -p openrr-apps --bin openrr_apps_robot_teleop
```

### TODO

- [x] polish & merge https://github.com/openrr/urdf-viz/pull/96
- [x] openrr_apps_joint_position_sender
- [x] openrr_apps_velocity_sender
- [x] openrr_apps_robot_command
- [x] openrr_apps_robot_teleop ~~(Note: teleop config is still needed)~~
- [x] support overwriting default config even if config-path is not specified
