### PR TITLE
[openrr-planner] Get collision link names before resetting

### DIFF
--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -157,19 +157,23 @@ where
         let step_length = self.step_length;
         let max_try = self.max_try;
         let current_angles = using_joints.joint_positions();
+
         if !self.is_feasible(using_joints, start_angles, objects) {
+            let collision_link_names = self.colliding_link_names(objects);
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::Collision {
                 part: CollisionPart::Start,
-                collision_link_names: self.colliding_link_names(objects),
+                collision_link_names,
             });
         } else if !self.is_feasible(using_joints, goal_angles, objects) {
+            let collision_link_names = self.colliding_link_names(objects);
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::Collision {
                 part: CollisionPart::End,
-                collision_link_names: self.colliding_link_names(objects),
+                collision_link_names,
             });
         }
+
         let mut path = match rrt::dual_rrt_connect(
             start_angles,
             goal_angles,
@@ -211,19 +215,23 @@ where
         let step_length = self.step_length;
         let max_try = self.max_try;
         let current_angles = using_joints.joint_positions();
+
         if !self.is_feasible_with_self(using_joints, start_angles) {
+            let collision_link_names = self.colliding_link_names_with_self();
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::SelfCollision {
                 part: CollisionPart::Start,
-                collision_link_names: self.colliding_link_names_with_self(),
+                collision_link_names,
             });
         } else if !self.is_feasible_with_self(using_joints, goal_angles) {
+            let collision_link_names = self.colliding_link_names_with_self();
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::SelfCollision {
                 part: CollisionPart::End,
-                collision_link_names: self.colliding_link_names_with_self(),
+                collision_link_names,
             });
         }
+
         let mut path = match rrt::dual_rrt_connect(
             start_angles,
             goal_angles,


### PR DESCRIPTION
In current implementation, both `plan()` and `plan_avoid_self_collision()` functions never show which links will collide, since resetting joint angles runs before identify the link names.

This PR solves this problem just by inverting algorithms: first, get collision link names with reference joint angles; then, reset joint angles.