### PR TITLE
[planner & client] Correct DoF in collision check tests

### DIFF
--- a/openrr-client/src/clients/collision_check_client.rs
+++ b/openrr-client/src/clients/collision_check_client.rs
@@ -98,7 +98,7 @@ mod tests {
                 .collect(),
         );
         client
-            .send_joint_positions(vec![0.0; 9], std::time::Duration::new(0, 0))
+            .send_joint_positions(vec![0.0; 8], std::time::Duration::new(0, 0))
             .unwrap()
             .await
             .unwrap();
@@ -113,15 +113,15 @@ mod tests {
 
         assert_eq!(
             *collision_check_client.current_joint_positions().unwrap(),
-            vec![0.0; 9]
+            vec![0.0; 8]
         );
 
         assert!(collision_check_client
-            .send_joint_positions(vec![0.0; 9], std::time::Duration::new(1, 0),)
+            .send_joint_positions(vec![0.0; 8], std::time::Duration::new(1, 0),)
             .is_ok());
         assert!(collision_check_client
             .send_joint_positions(
-                vec![1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                vec![1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
                 std::time::Duration::new(1, 0),
             )
             .is_err());

--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -165,16 +165,12 @@ fn test_create_self_collision_checker() {
     );
 
     assert!(self_collision_checker
-        .check_joint_positions(
-            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            std::time::Duration::new(1, 0),
-        )
+        .check_joint_positions(&[0.0; 8], &[0.0; 8], std::time::Duration::new(1, 0),)
         .is_ok());
     assert!(self_collision_checker
         .check_joint_positions(
-            &[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            &[1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            &[0.0; 8],
+            &[1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
             std::time::Duration::new(1, 0),
         )
         .is_err());


### PR DESCRIPTION
A robot defined in `sample.urdf` has only 8 movable joints. This PR corrects mistakes I made in #396 and #407  .