### PR TITLE
[planner] Use generics in SelfCollisionChecker refering to JointPathPlanner

### DIFF
--- a/openrr-client/src/clients/collision_check_client.rs
+++ b/openrr-client/src/clients/collision_check_client.rs
@@ -10,14 +10,14 @@ where
     T: JointTrajectoryClient,
 {
     pub client: T,
-    pub collision_checker: Arc<SelfCollisionChecker>,
+    pub collision_checker: Arc<SelfCollisionChecker<f64>>,
 }
 
 impl<T> CollisionCheckClient<T>
 where
     T: JointTrajectoryClient,
 {
-    pub fn new(client: T, collision_checker: Arc<SelfCollisionChecker>) -> Self {
+    pub fn new(client: T, collision_checker: Arc<SelfCollisionChecker<f64>>) -> Self {
         Self {
             client,
             collision_checker,

--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -40,7 +40,7 @@ where
     collision_check_clients:
         HashMap<String, Arc<CollisionCheckClient<Arc<dyn JointTrajectoryClient>>>>,
     ik_clients: HashMap<String, ArcIkClient>,
-    self_collision_checkers: HashMap<String, Arc<SelfCollisionChecker>>,
+    self_collision_checkers: HashMap<String, Arc<SelfCollisionChecker<f64>>>,
     ik_solvers: HashMap<String, Arc<IkSolverWithChain>>,
     speakers: HashMap<String, Arc<dyn Speaker>>,
     localization: Option<L>,
@@ -236,7 +236,7 @@ where
         &self.all_joint_trajectory_clients
     }
 
-    pub fn self_collision_checkers(&self) -> &HashMap<String, Arc<SelfCollisionChecker>> {
+    pub fn self_collision_checkers(&self) -> &HashMap<String, Arc<SelfCollisionChecker<f64>>> {
         &self.self_collision_checkers
     }
 

--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -61,11 +61,11 @@ where
         positions: &[N],
         duration: std::time::Duration,
     ) -> Result<()> {
+        let duration_f64 = num_traits::NumCast::from::<f64>(duration.as_secs_f64()).unwrap();
         match interpolate(
             &[current.to_vec(), positions.to_vec()],
-            num_traits::NumCast::from::<f64>(duration.as_secs_f64()).unwrap(),
-            self.time_interpolate_rate
-                .mul(num_traits::NumCast::from::<f64>(duration.as_secs_f64()).unwrap()),
+            duration_f64,
+            self.time_interpolate_rate.mul(duration_f64),
         ) {
             Some(interpolated) => {
                 debug!("interpolated len={}", interpolated.len());


### PR DESCRIPTION
SelfCollisionChecker is similar to JointPathPlaner, and we start to create a new struct describing common parameters of them.

As the first step of the challenge, this PR introduces generics in SelfCollisionChecker as used in JointPathPlanner.

Reference:
https://github.com/openrr/openrr/blob/52af54eaf69ad0b9152dd2d1e6000dd36c7e85a9/openrr-planner/src/planner/joint_path_planner.rs#L25-L390