### PR TITLE
[openrr-planner] Rename enum describing trajectory invalidity

### DIFF
--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -67,7 +67,7 @@ impl SelfCollisionChecker {
                         .check_self(&self.collision_check_robot, &self.collision_pairs);
                     if let Some(names) = self_checker.next() {
                         return Err(Error::Collision {
-                            part: CollisionPart::Start,
+                            point: UnfeasibleTrajectory::StartPoint,
                             collision_link_names: vec![names.0, names.1],
                         });
                     }
@@ -95,7 +95,7 @@ impl SelfCollisionChecker {
                 .next()
             {
                 return Err(Error::Collision {
-                    part: CollisionPart::Start,
+                    point: UnfeasibleTrajectory::StartPoint,
                     collision_link_names: vec![names.0, names.1],
                 });
             }

--- a/openrr-planner/src/errors.rs
+++ b/openrr-planner/src/errors.rs
@@ -19,9 +19,9 @@ use std::io;
 use thiserror::Error;
 
 #[derive(Debug)]
-pub enum CollisionPart {
-    Start,
-    End,
+pub enum UnfeasibleTrajectory {
+    StartPoint,
+    GoalPoint,
 }
 
 /// Error for `openrr_planner`
@@ -32,14 +32,14 @@ pub enum Error {
     Other { error: String },
     #[error("Node name {} not found", .0)]
     NotFound(String),
-    #[error("Collision error: {collision_link_names:?} is colliding ({part:?})")]
+    #[error("Collision error: {collision_link_names:?} is colliding ({point:?})")]
     Collision {
-        part: CollisionPart,
+        point: UnfeasibleTrajectory,
         collision_link_names: Vec<String>,
     },
-    #[error("Self Collision error: {collision_link_names:?} is colliding ({part:?})")]
+    #[error("Self Collision error: {collision_link_names:?} is colliding ({point:?})")]
     SelfCollision {
-        part: CollisionPart,
+        point: UnfeasibleTrajectory,
         collision_link_names: Vec<(String, String)>,
     },
     #[error("Interpolation error: {:?}", .0)]

--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -162,14 +162,14 @@ where
             let collision_link_names = self.colliding_link_names(objects);
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::Collision {
-                part: CollisionPart::Start,
+                point: UnfeasibleTrajectory::StartPoint,
                 collision_link_names,
             });
         } else if !self.is_feasible(using_joints, goal_angles, objects) {
             let collision_link_names = self.colliding_link_names(objects);
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::Collision {
-                part: CollisionPart::End,
+                point: UnfeasibleTrajectory::GoalPoint,
                 collision_link_names,
             });
         }
@@ -220,14 +220,14 @@ where
             let collision_link_names = self.colliding_link_names_with_self();
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::SelfCollision {
-                part: CollisionPart::Start,
+                point: UnfeasibleTrajectory::StartPoint,
                 collision_link_names,
             });
         } else if !self.is_feasible_with_self(using_joints, goal_angles) {
             let collision_link_names = self.colliding_link_names_with_self();
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::SelfCollision {
-                part: CollisionPart::End,
+                point: UnfeasibleTrajectory::GoalPoint,
                 collision_link_names,
             });
         }


### PR DESCRIPTION
`CollisionPart` is not a good name and sometimes confuses us: e.g. the name reminds us NOT a trajectory point BUT a LINK colliding with itself or environments.