### PR TITLE
Rename CollisionChecker into CollisionDetector to prevent misleading

### DIFF
--- a/openrr-client/src/clients/collision_avoidance_client.rs
+++ b/openrr-client/src/clients/collision_avoidance_client.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use arci::{Error, JointTrajectoryClient, TrajectoryPoint, WaitFuture};
-use openrr_planner::{CollisionChecker, JointPathPlannerBuilder};
+use openrr_planner::{CollisionDetector, JointPathPlannerBuilder};
 
 // TODO: speed limit
 fn trajectory_from_positions(
@@ -113,9 +113,9 @@ pub fn create_collision_avoidance_client<P: AsRef<Path>>(
     client: Arc<dyn JointTrajectoryClient>,
 ) -> CollisionAvoidanceClient<Arc<dyn JointTrajectoryClient>> {
     let urdf_robot = urdf_rs::read_file(urdf_path.as_ref()).unwrap();
-    let collision_checker =
-        CollisionChecker::from_urdf_robot(&urdf_robot, collision_check_prediction);
-    let planner_builder = JointPathPlannerBuilder::new(urdf_robot.clone(), collision_checker)
+    let collision_detector =
+        CollisionDetector::from_urdf_robot(&urdf_robot, collision_check_prediction);
+    let planner_builder = JointPathPlannerBuilder::new(urdf_robot.clone(), collision_detector)
         .self_collision_pairs(self_collision_check_pairs);
     CollisionAvoidanceClient::new(
         client,

--- a/openrr-planner/examples/reach.rs
+++ b/openrr-planner/examples/reach.rs
@@ -266,7 +266,7 @@ impl CollisionAvoidApp {
                             let pairs: Vec<_> = self
                                 .planner
                                 .path_planner
-                                .collision_checker
+                                .collision_detector
                                 .check_self(
                                     &self.planner.path_planner.collision_check_robot,
                                     &self.self_collision_pairs,

--- a/openrr-planner/src/collision.rs
+++ b/openrr-planner/src/collision.rs
@@ -1,6 +1,6 @@
-mod collision_checker;
+mod collision_detector;
 mod mesh;
 mod self_collision_checker;
 mod urdf;
 
-pub use self::{collision_checker::*, self_collision_checker::*};
+pub use self::{collision_detector::*, self_collision_checker::*};

--- a/openrr-planner/src/lib.rs
+++ b/openrr-planner/src/lib.rs
@@ -38,7 +38,7 @@ mod planner;
 pub use k::{InverseKinematicsSolver, JacobianIkSolver};
 
 pub use crate::{
-    collision::{CollisionChecker, FromUrdf, SelfCollisionChecker, SelfCollisionCheckerConfig},
+    collision::{CollisionDetector, FromUrdf, SelfCollisionChecker, SelfCollisionCheckerConfig},
     errors::Error,
     funcs::*,
     ik::*,


### PR DESCRIPTION
After this change, 'check' becomes a term only used in contexts of planning.

I note that this PR does not include functional changes nor effects on our private repos.