### PR TITLE
Move using_joints from SelfCollisionChecker to CollisionCheckerClient

### DIFF
--- a/openrr-client/src/clients/collision_check_client.rs
+++ b/openrr-client/src/clients/collision_check_client.rs
@@ -10,6 +10,8 @@ where
     T: JointTrajectoryClient,
 {
     pub client: T,
+    /// using_joints must be a part of collision_checker.collision_check_robot.
+    pub using_joints: k::Chain<f64>,
     pub collision_checker: Arc<SelfCollisionChecker<f64>>,
 }
 
@@ -17,9 +19,14 @@ impl<T> CollisionCheckClient<T>
 where
     T: JointTrajectoryClient,
 {
-    pub fn new(client: T, collision_checker: Arc<SelfCollisionChecker<f64>>) -> Self {
+    pub fn new(
+        client: T,
+        using_joints: k::Chain<f64>,
+        collision_checker: Arc<SelfCollisionChecker<f64>>,
+    ) -> Self {
         Self {
             client,
+            using_joints,
             collision_checker,
         }
     }
@@ -43,7 +50,12 @@ where
         duration: std::time::Duration,
     ) -> Result<WaitFuture, Error> {
         self.collision_checker
-            .check_joint_positions(&self.current_joint_positions()?, &positions, duration)
+            .check_partial_joint_positions(
+                &self.using_joints,
+                &self.current_joint_positions()?,
+                &positions,
+                duration,
+            )
             .map_err(|e| Error::Other(e.into()))?;
         self.client.send_joint_positions(positions, duration)
     }
@@ -56,7 +68,7 @@ where
             })
             .collect::<Vec<_>>();
         self.collision_checker
-            .check_joint_trajectory(&position_trajectory)
+            .check_partial_joint_trajectory(&self.using_joints, &position_trajectory)
             .map_err(|e| Error::Other(e.into()))?;
         self.client.send_joint_trajectory(trajectory)
     }
@@ -69,13 +81,14 @@ pub fn create_collision_check_client<P: AsRef<Path>>(
     client: Arc<dyn JointTrajectoryClient>,
     full_chain: Arc<k::Chain<f64>>,
 ) -> CollisionCheckClient<Arc<dyn JointTrajectoryClient>> {
-    let joint_names = client.joint_names();
+    let nodes = full_chain.iter().map(|node| (*node).clone()).collect();
+    let using_joints = k::Chain::<f64>::from_nodes(nodes);
     CollisionCheckClient::new(
         client,
+        using_joints,
         Arc::new(create_self_collision_checker(
             urdf_path,
             self_collision_check_pairs,
-            joint_names,
             config,
             full_chain,
         )),


### PR DESCRIPTION
Change the structures of `SelfCollisionChecker` and `CollisionCheckClient` by referring to those of `JointPathPlanner` and `CollisionAvoidanceClient`, which are shown below.

https://github.com/openrr/openrr/blob/b9688c220d6d82338da43ee064c0b0228b7e98a6/openrr-client/src/clients/collision_avoidance_client.rs#L23-L31