### PR TITLE
[openrr-planner] Rename functions of CollisionDetector

### DIFF
--- a/openrr-planner/examples/reach.rs
+++ b/openrr-planner/examples/reach.rs
@@ -267,7 +267,7 @@ impl CollisionAvoidApp {
                                 .planner
                                 .path_planner
                                 .collision_detector
-                                .check_self(
+                                .detect_self(
                                     &self.planner.path_planner.collision_check_robot,
                                     &self.self_collision_pairs,
                                 )

--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -74,7 +74,7 @@ where
                     self.collision_check_robot.update_transforms();
                     let mut self_checker = self
                         .collision_detector
-                        .check_self(&self.collision_check_robot, &self.collision_pairs);
+                        .detect_self(&self.collision_check_robot, &self.collision_pairs);
                     if let Some(names) = self_checker.next() {
                         return Err(Error::Collision {
                             point: UnfeasibleTrajectory::StartPoint,
@@ -101,7 +101,7 @@ where
             self.using_joints.set_joint_positions(&v.position)?;
             if let Some(names) = self
                 .collision_detector
-                .check_self(&self.collision_check_robot, &self.collision_pairs)
+                .detect_self(&self.collision_check_robot, &self.collision_pairs)
                 .next()
             {
                 return Err(Error::Collision {

--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -89,7 +89,7 @@ where
         for shape in objects.shapes() {
             if self
                 .collision_detector
-                .check_env(&self.collision_check_robot, &*shape.1, &shape.0)
+                .detect_env(&self.collision_check_robot, &*shape.1, &shape.0)
                 .next()
                 .is_some()
             {
@@ -105,7 +105,7 @@ where
         for shape in objects.shapes() {
             let mut colliding_names = self
                 .collision_detector
-                .check_env(&self.collision_check_robot, &*shape.1, &shape.0)
+                .detect_env(&self.collision_check_robot, &*shape.1, &shape.0)
                 .collect();
             ret.append(&mut colliding_names);
         }
@@ -126,7 +126,7 @@ where
     /// Check if there are any colliding links
     pub fn has_any_colliding_with_self(&self) -> bool {
         self.collision_detector
-            .check_self(&self.collision_check_robot, &self.self_collision_pairs)
+            .detect_self(&self.collision_check_robot, &self.self_collision_pairs)
             .next()
             .is_some()
     }
@@ -134,7 +134,7 @@ where
     /// Get the names of colliding links
     pub fn colliding_link_names_with_self(&self) -> Vec<(String, String)> {
         self.collision_detector
-            .check_self(&self.collision_check_robot, &self.self_collision_pairs)
+            .detect_self(&self.collision_check_robot, &self.self_collision_pairs)
             .collect()
     }
 
@@ -406,7 +406,7 @@ mod tests {
 
         let robot = k::Chain::<f32>::from(&urdf_robot);
 
-        let names: Vec<String> = detector.check_env(&robot, &target, &target_pose).collect();
+        let names: Vec<String> = detector.detect_env(&robot, &target, &target_pose).collect();
         assert_eq!(
             names,
             vec![
@@ -419,7 +419,7 @@ mod tests {
         );
         let angles = vec![-1.3, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         robot.set_joint_positions(&angles).unwrap();
-        let names: Vec<String> = detector.check_env(&robot, &target, &target_pose).collect();
+        let names: Vec<String> = detector.detect_env(&robot, &target, &target_pose).collect();
         assert_eq!(
             names,
             vec![
@@ -430,7 +430,7 @@ mod tests {
             ]
         );
         let target_pose = Isometry3::new(Vector3::new(0.7, 0.0, 0.0), na::zero());
-        let names: Vec<String> = detector.check_env(&robot, &target, &target_pose).collect();
+        let names: Vec<String> = detector.detect_env(&robot, &target, &target_pose).collect();
         assert_eq!(
             names,
             vec![


### PR DESCRIPTION
As proposed in #439 , `CollisionChecker` was renamed into `CollisionDetector`. However, the names of its member functions have not changed yet. This PR therefore renames them: `check_env` -> `detect_env` and `check_self` -> `detect_self`.

This PR also changes some comments/variable names to remove the word `check`.