### PR TITLE
[openrr-planner] Remove a unused member from CollisionDetector

### DIFF
--- a/openrr-planner/src/collision/collision_detector.rs
+++ b/openrr-planner/src/collision/collision_detector.rs
@@ -214,7 +214,6 @@ where
     name_collision_model_map: NameShapeMap<T>,
     /// margin length for collision detection
     pub prediction: T,
-    pub self_collision_pairs: Vec<(String, String)>,
 }
 
 impl<T> CollisionDetector<T>
@@ -226,7 +225,6 @@ where
         CollisionDetector {
             name_collision_model_map,
             prediction,
-            self_collision_pairs: Vec::new(),
         }
     }
 
@@ -264,7 +262,6 @@ where
         CollisionDetector {
             name_collision_model_map,
             prediction,
-            self_collision_pairs: Vec::new(),
         }
     }
 


### PR DESCRIPTION
The removed member would never be used here.

Instead, `self_collision_check_pairs` is introduced in RobotCollisionDetector with a robot model, as I proposed in #444 .