### PR TITLE
[openrr-planner] Refactor impl blocks of JointPathPlannerBuilder

### DIFF
--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -347,12 +347,7 @@ where
         planner.self_collision_pairs = self.self_collision_pairs;
         planner
     }
-}
 
-impl<N> JointPathPlannerBuilder<N>
-where
-    N: RealField + k::SubsetOf<f64> + num_traits::Float,
-{
     /// Try to create `JointPathPlannerBuilder` instance from URDF file and end link name
     pub fn from_urdf_file<P>(file: P) -> Result<JointPathPlannerBuilder<N>>
     where


### PR DESCRIPTION
https://github.com/openrr/openrr/blob/d6971f240cb9fc5fd3a84da9a43dfbe8c222be8b/openrr-planner/src/planner/joint_path_planner.rs#L288-L290

https://github.com/openrr/openrr/blob/d6971f240cb9fc5fd3a84da9a43dfbe8c222be8b/openrr-planner/src/planner/joint_path_planner.rs#L352-L354

As shown above, there exist two same `impl` blocks in succession. This PR just resolves the duplication. 