### PR TITLE
[openrr-planner] Remove transform update in CollisionDetector

### DIFF
--- a/openrr-planner/src/collision/collision_detector.rs
+++ b/openrr-planner/src/collision/collision_detector.rs
@@ -276,7 +276,6 @@ where
         target_shape: &'a dyn Shape<T>,
         target_pose: &'a na::Isometry3<T>,
     ) -> EnvCollisionNames<'a, 'a, T> {
-        robot.update_transforms();
         EnvCollisionNames::new(self, robot, target_shape, target_pose)
     }
 
@@ -289,7 +288,6 @@ where
         robot: &'a k::Chain<T>,
         self_collision_pairs: &'a [(String, String)],
     ) -> SelfCollisionPairs<'a, T> {
-        robot.update_transforms();
         SelfCollisionPairs::new(self, robot, self_collision_pairs)
     }
 }


### PR DESCRIPTION
Since a robot model is just a argument, CollisionDetector should not add any changes to it. 
Instead, the same update before collision calculation is implemented in RobotCollisionDetector:

https://github.com/openrr/openrr/blob/d6971f240cb9fc5fd3a84da9a43dfbe8c222be8b/openrr-planner/src/collision/robot_collision_detector.rs#L44-L68