### PR TITLE
[openrr-planner] Use RobotCollisionDetector in SelfCollisionChecker

### DIFF
--- a/openrr-client/src/clients/collision_check_client.rs
+++ b/openrr-client/src/clients/collision_check_client.rs
@@ -79,20 +79,22 @@ pub fn create_collision_check_client<P: AsRef<Path>>(
     self_collision_check_pairs: &[String],
     config: &SelfCollisionCheckerConfig,
     client: Arc<dyn JointTrajectoryClient>,
-    full_chain: Arc<k::Chain<f64>>,
 ) -> CollisionCheckClient<Arc<dyn JointTrajectoryClient>> {
-    let nodes = full_chain.iter().map(|node| (*node).clone()).collect();
+    let collision_checker = Arc::new(create_self_collision_checker(
+        urdf_path,
+        self_collision_check_pairs,
+        config,
+    ));
+    // Reconstructs a robot chain to define using_joints without life-parameters
+    let nodes = collision_checker
+        .robot_collision_detector
+        .robot
+        .iter()
+        .map(|node| (*node).clone())
+        .collect();
     let using_joints = k::Chain::<f64>::from_nodes(nodes);
-    CollisionCheckClient::new(
-        client,
-        using_joints,
-        Arc::new(create_self_collision_checker(
-            urdf_path,
-            self_collision_check_pairs,
-            config,
-            full_chain,
-        )),
-    )
+
+    CollisionCheckClient::new(client, using_joints, collision_checker)
 }
 
 #[cfg(test)]
@@ -103,7 +105,7 @@ mod tests {
     async fn test_create_collision_check_client() {
         let urdf_path = Path::new("sample.urdf");
         let urdf_robot = urdf_rs::read_file(urdf_path).unwrap();
-        let robot = Arc::new(k::Chain::<f64>::from(&urdf_robot));
+        let robot = k::Chain::<f64>::from(&urdf_robot);
         let client = arci::DummyJointTrajectoryClient::new(
             robot
                 .iter_joints()
@@ -121,7 +123,6 @@ mod tests {
             &["root:l_shoulder_roll".into()],
             &SelfCollisionCheckerConfig::default(),
             Arc::new(client),
-            robot,
         );
 
         assert_eq!(

--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -96,7 +96,6 @@ where
                 &config.self_collision_check_pairs,
                 &config.collision_check_clients_configs,
                 &all_joint_trajectory_clients,
-                full_chain_for_collision_checker.clone(),
             );
 
             let mut self_collision_checkers = HashMap::new();
@@ -554,7 +553,6 @@ pub fn create_collision_check_clients<P: AsRef<Path>>(
     self_collision_check_pairs: &[String],
     configs: &[CollisionCheckClientConfig],
     name_to_joint_trajectory_client: &HashMap<String, Arc<dyn JointTrajectoryClient>>,
-    full_chain: Arc<k::Chain<f64>>,
 ) -> HashMap<String, Arc<CollisionCheckClient<Arc<dyn JointTrajectoryClient>>>> {
     let mut clients = HashMap::new();
     for config in configs {
@@ -565,7 +563,6 @@ pub fn create_collision_check_clients<P: AsRef<Path>>(
                 self_collision_check_pairs,
                 &config.self_collision_checker_config,
                 name_to_joint_trajectory_client[&config.client_name].clone(),
-                full_chain.clone(),
             )),
         );
     }

--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::Arc, time::Duration};
+use std::{path::Path, time::Duration};
 
 use k::nalgebra as na;
 use na::RealField;
@@ -7,18 +7,19 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::{
-    collision::parse_colon_separated_pairs, errors::*, interpolate, CollisionDetector,
-    TrajectoryPoint,
+    collision::{
+        create_robot_collision_detector, parse_colon_separated_pairs, RobotCollisionDetector,
+        RobotCollisionDetectorConfig,
+    },
+    errors::*,
+    interpolate, TrajectoryPoint,
 };
 
 pub struct SelfCollisionChecker<N>
 where
     N: RealField + k::SubsetOf<f64>,
 {
-    pub collision_check_robot: Arc<k::Chain<N>>,
-    pub collision_detector: CollisionDetector<N>,
-    pub collision_pairs: Vec<(String, String)>,
-
+    pub robot_collision_detector: RobotCollisionDetector<N>,
     pub time_interpolate_rate: N,
 }
 
@@ -28,9 +29,7 @@ where
 {
     #[track_caller]
     pub fn new(
-        collision_check_robot: Arc<k::Chain<N>>,
-        collision_detector: CollisionDetector<N>,
-        collision_pairs: Vec<(String, String)>,
+        robot_collision_detector: RobotCollisionDetector<N>,
         time_interpolate_rate: N,
     ) -> Self {
         assert!(
@@ -40,9 +39,7 @@ where
         );
 
         Self {
-            collision_check_robot,
-            collision_detector,
-            collision_pairs,
+            robot_collision_detector,
             time_interpolate_rate,
         }
     }
@@ -54,7 +51,7 @@ where
         duration: std::time::Duration,
     ) -> Result<()> {
         self.check_partial_joint_positions(
-            &self.collision_check_robot,
+            &self.robot_collision_detector.robot,
             current,
             positions,
             duration,
@@ -78,10 +75,8 @@ where
                 debug!("interpolated len={}", interpolated.len());
                 for v in interpolated {
                     using_joints.set_joint_positions_clamped(&v.position);
-                    self.collision_check_robot.update_transforms();
-                    let mut self_checker = self
-                        .collision_detector
-                        .detect_self(&self.collision_check_robot, &self.collision_pairs);
+                    self.robot_collision_detector.robot.update_transforms();
+                    let mut self_checker = self.robot_collision_detector.detect_self();
                     if let Some(names) = self_checker.next() {
                         return Err(Error::Collision {
                             point: UnfeasibleTrajectory::StartPoint,
@@ -104,7 +99,7 @@ where
     }
 
     pub fn check_joint_trajectory(&self, trajectory: &[TrajectoryPoint<N>]) -> Result<()> {
-        self.check_partial_joint_trajectory(&self.collision_check_robot, trajectory)
+        self.check_partial_joint_trajectory(&self.robot_collision_detector.robot, trajectory)
     }
 
     pub fn check_partial_joint_trajectory(
@@ -114,11 +109,7 @@ where
     ) -> Result<()> {
         for v in trajectory {
             using_joints.set_joint_positions(&v.position)?;
-            if let Some(names) = self
-                .collision_detector
-                .detect_self(&self.collision_check_robot, &self.collision_pairs)
-                .next()
-            {
+            if let Some(names) = self.robot_collision_detector.detect_self().next() {
                 return Err(Error::Collision {
                     point: UnfeasibleTrajectory::StartPoint,
                     collision_link_names: vec![names.0, names.1],
@@ -159,28 +150,22 @@ pub fn create_self_collision_checker<P: AsRef<Path>>(
     urdf_path: P,
     self_collision_check_pairs: &[String],
     config: &SelfCollisionCheckerConfig,
-    full_chain: Arc<k::Chain<f64>>,
 ) -> SelfCollisionChecker<f64> {
-    SelfCollisionChecker::new(
-        full_chain,
-        CollisionDetector::from_urdf_robot(
-            &urdf_rs::utils::read_urdf_or_xacro(urdf_path).unwrap(),
-            config.prediction,
-        ),
+    let robot_collision_detector = create_robot_collision_detector(
+        urdf_path,
+        RobotCollisionDetectorConfig::new(config.prediction),
         parse_colon_separated_pairs(self_collision_check_pairs).unwrap(),
-        config.time_interpolate_rate,
-    )
+    );
+    SelfCollisionChecker::new(robot_collision_detector, config.time_interpolate_rate)
 }
 
 #[test]
 fn test_create_self_collision_checker() {
-    let urdf_robot = urdf_rs::read_file("sample.urdf").unwrap();
-    let robot = Arc::new(k::Chain::<f64>::from(&urdf_robot));
+    let urdf_path = Path::new("sample.urdf");
     let self_collision_checker = create_self_collision_checker(
-        "sample.urdf",
+        urdf_path,
         &["root:l_shoulder_roll".into()],
         &SelfCollisionCheckerConfig::default(),
-        robot.clone(),
     );
 
     assert!(self_collision_checker
@@ -194,6 +179,7 @@ fn test_create_self_collision_checker() {
         )
         .is_err());
 
+    let robot = &self_collision_checker.robot_collision_detector.robot;
     let nodes = robot.iter().take(2).map(|node| (*node).clone()).collect();
     let using_joints = k::Chain::<f64>::from_nodes(nodes);
 


### PR DESCRIPTION
Remind that RobotCollisionDetector is a struct wrapping CollisionDetector with a robot model, and RobotCollisionDetector provides APIs of robot collision detection (see #444).

This change (and #...) contribute to unify robot collision detection processes.