### PR TITLE
[openrr-planner] Use RobotCollisionDetector in JointPathPlanner

### DIFF
--- a/openrr-client/src/clients/collision_avoidance_client.rs
+++ b/openrr-client/src/clients/collision_avoidance_client.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use arci::{Error, JointTrajectoryClient, TrajectoryPoint, WaitFuture};
-use openrr_planner::{CollisionDetector, JointPathPlannerBuilder};
+use openrr_planner::JointPathPlannerBuilder;
 
 // TODO: speed limit
 fn trajectory_from_positions(
@@ -113,10 +113,9 @@ pub fn create_collision_avoidance_client<P: AsRef<Path>>(
     client: Arc<dyn JointTrajectoryClient>,
 ) -> CollisionAvoidanceClient<Arc<dyn JointTrajectoryClient>> {
     let urdf_robot = urdf_rs::read_file(urdf_path.as_ref()).unwrap();
-    let collision_detector =
-        CollisionDetector::from_urdf_robot(&urdf_robot, collision_check_prediction);
-    let planner_builder = JointPathPlannerBuilder::new(urdf_robot.clone(), collision_detector)
-        .self_collision_pairs(self_collision_check_pairs);
+    let planner_builder = JointPathPlannerBuilder::from_urdf_robot(urdf_robot.clone())
+        .self_collision_pairs(self_collision_check_pairs)
+        .collision_check_margin(collision_check_prediction);
     CollisionAvoidanceClient::new(
         client,
         k::Chain::<f64>::from(&urdf_robot),

--- a/openrr-planner/examples/reach.rs
+++ b/openrr-planner/examples/reach.rs
@@ -67,11 +67,15 @@ impl CollisionAvoidApp {
             urdf_rs::utils::read_urdf_or_xacro(obstacle_path).expect("obstacle file not found");
         let obstacles = Compound::from_urdf_robot(&urdf_obstacles);
         viewer.add_robot(&mut window, &urdf_obstacles);
-        println!("robot={}", planner.path_planner.collision_check_robot);
+        println!(
+            "robot={}",
+            planner.path_planner.robot_collision_detector.robot
+        );
         let arm = {
             let end_link = planner
                 .path_planner
-                .collision_check_robot
+                .robot_collision_detector
+                .robot
                 .find(end_link_name)
                 .unwrap_or_else(|| panic!("{} not found", end_link_name));
             k::SerialChain::from_end(end_link)
@@ -101,15 +105,17 @@ impl CollisionAvoidApp {
         let ja = self
             .planner
             .path_planner
-            .collision_check_robot
+            .robot_collision_detector
+            .robot
             .joint_positions();
         self.planner
             .path_planner
-            .collision_check_robot
+            .robot_collision_detector
+            .robot
             .set_joint_positions(&ja)
             .unwrap();
         self.viewer
-            .update(&self.planner.path_planner.collision_check_robot);
+            .update(&self.planner.path_planner.robot_collision_detector.robot);
     }
 
     fn update_ik_target(&mut self) {
@@ -266,9 +272,10 @@ impl CollisionAvoidApp {
                             let pairs: Vec<_> = self
                                 .planner
                                 .path_planner
+                                .robot_collision_detector
                                 .collision_detector
                                 .detect_self(
-                                    &self.planner.path_planner.collision_check_robot,
+                                    &self.planner.path_planner.robot_collision_detector.robot,
                                     &self.self_collision_pairs,
                                 )
                                 .collect();
@@ -294,7 +301,7 @@ impl CollisionAvoidApp {
                                 is_collide_show,
                             );
                             self.viewer
-                                .update(&self.planner.path_planner.collision_check_robot);
+                                .update(&self.planner.path_planner.robot_collision_detector.robot);
                         }
                         Key::X => {
                             println!("start reachable region calculation");

--- a/openrr-planner/src/planner/ik_planner.rs
+++ b/openrr-planner/src/planner/ik_planner.rs
@@ -83,7 +83,9 @@ where
     }
 
     pub fn colliding_link_names(&self, objects: &Compound<T>) -> Vec<String> {
-        self.path_planner.colliding_link_names(objects)
+        self.path_planner
+            .robot_collision_detector
+            .env_collision_link_names(objects)
     }
 
     /// Solve IK and get the path to the final joint positions
@@ -111,7 +113,8 @@ where
     ) -> Result<Vec<Vec<T>>> {
         let end_link: &k::Node<T> = self
             .path_planner
-            .collision_check_robot
+            .robot_collision_detector
+            .robot
             .find(target_name)
             .ok_or_else(|| Error::NotFound(target_name.to_owned()))?;
         let arm = k::SerialChain::from_end(end_link);


### PR DESCRIPTION
JointPathPlanner ver. of the PR #457 .

Note that the removed functions were moved to RobotCollisionDetector.