### PR TITLE
Revert "Move using_joints from SelfCollisionChecker to CollisionCheckerClient"

### DIFF
--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -15,6 +15,7 @@ pub struct SelfCollisionChecker<N>
 where
     N: RealField + k::SubsetOf<f64>,
 {
+    pub using_joints: k::Chain<N>,
     pub collision_check_robot: Arc<k::Chain<N>>,
     pub collision_detector: CollisionDetector<N>,
     pub collision_pairs: Vec<(String, String)>,
@@ -28,6 +29,7 @@ where
 {
     #[track_caller]
     pub fn new(
+        joint_names: Vec<String>,
         collision_check_robot: Arc<k::Chain<N>>,
         collision_detector: CollisionDetector<N>,
         collision_pairs: Vec<(String, String)>,
@@ -38,8 +40,14 @@ where
             "time_interpolate_rate must be 0.0~1.0 but {}",
             time_interpolate_rate
         );
-
+        let using_joints = k::Chain::<N>::from_nodes(
+            joint_names
+                .into_iter()
+                .map(|joint_name| collision_check_robot.find(&joint_name).unwrap().clone())
+                .collect(),
+        );
         Self {
+            using_joints,
             collision_check_robot,
             collision_detector,
             collision_pairs,
@@ -53,21 +61,6 @@ where
         positions: &[N],
         duration: std::time::Duration,
     ) -> Result<()> {
-        self.check_partial_joint_positions(
-            &self.collision_check_robot,
-            current,
-            positions,
-            duration,
-        )
-    }
-
-    pub fn check_partial_joint_positions(
-        &self,
-        using_joints: &k::Chain<N>,
-        current: &[N],
-        positions: &[N],
-        duration: std::time::Duration,
-    ) -> Result<()> {
         let duration_f64 = num_traits::NumCast::from::<f64>(duration.as_secs_f64()).unwrap();
         match interpolate(
             &[current.to_vec(), positions.to_vec()],
@@ -77,7 +70,7 @@ where
             Some(interpolated) => {
                 debug!("interpolated len={}", interpolated.len());
                 for v in interpolated {
-                    using_joints.set_joint_positions_clamped(&v.position);
+                    self.using_joints.set_joint_positions_clamped(&v.position);
                     self.collision_check_robot.update_transforms();
                     let mut self_checker = self
                         .collision_detector
@@ -104,16 +97,8 @@ where
     }
 
     pub fn check_joint_trajectory(&self, trajectory: &[TrajectoryPoint<N>]) -> Result<()> {
-        self.check_partial_joint_trajectory(&self.collision_check_robot, trajectory)
-    }
-
-    pub fn check_partial_joint_trajectory(
-        &self,
-        using_joints: &k::Chain<N>,
-        trajectory: &[TrajectoryPoint<N>],
-    ) -> Result<()> {
         for v in trajectory {
-            using_joints.set_joint_positions(&v.position)?;
+            self.using_joints.set_joint_positions(&v.position)?;
             if let Some(names) = self
                 .collision_detector
                 .detect_self(&self.collision_check_robot, &self.collision_pairs)
@@ -158,10 +143,12 @@ impl Default for SelfCollisionCheckerConfig {
 pub fn create_self_collision_checker<P: AsRef<Path>>(
     urdf_path: P,
     self_collision_check_pairs: &[String],
+    joint_names: Vec<String>,
     config: &SelfCollisionCheckerConfig,
     full_chain: Arc<k::Chain<f64>>,
 ) -> SelfCollisionChecker<f64> {
     SelfCollisionChecker::new(
+        joint_names,
         full_chain,
         CollisionDetector::from_urdf_robot(
             &urdf_rs::utils::read_urdf_or_xacro(urdf_path).unwrap(),
@@ -179,8 +166,12 @@ fn test_create_self_collision_checker() {
     let self_collision_checker = create_self_collision_checker(
         "sample.urdf",
         &["root:l_shoulder_roll".into()],
+        robot
+            .iter_joints()
+            .map(|joint| joint.name.clone())
+            .collect(),
         &SelfCollisionCheckerConfig::default(),
-        robot.clone(),
+        robot,
     );
 
     assert!(self_collision_checker
@@ -190,26 +181,6 @@ fn test_create_self_collision_checker() {
         .check_joint_positions(
             &[0.0; 8],
             &[1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            std::time::Duration::new(1, 0),
-        )
-        .is_err());
-
-    let nodes = robot.iter().take(2).map(|node| (*node).clone()).collect();
-    let using_joints = k::Chain::<f64>::from_nodes(nodes);
-
-    assert!(self_collision_checker
-        .check_partial_joint_positions(
-            &using_joints,
-            &[0.0],
-            &[0.0],
-            std::time::Duration::new(1, 0),
-        )
-        .is_ok());
-    assert!(self_collision_checker
-        .check_partial_joint_positions(
-            &using_joints,
-            &[0.0],
-            &[1.57],
             std::time::Duration::new(1, 0),
         )
         .is_err());


### PR DESCRIPTION
This reverts commit 9550712d081652909c0b1c0145be14bccf28ba92.

This commit causes error when sending partial joint trajectory e.g. chitose_demo ( private pacakge of smile robotics ).

With this PR, chitose_demo will work well.