### PR TITLE
Remove doc URL from Cargo.toml

### DIFF
--- a/arci-gamepad-gilrs/Cargo.toml
+++ b/arci-gamepad-gilrs/Cargo.toml
@@ -8,7 +8,6 @@ description = "arci::Gamepad implementation using gilrs"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/arci-gamepad-gilrs"
 
 [dependencies]
 arci = "0.0.6"

--- a/arci-gamepad-keyboard/Cargo.toml
+++ b/arci-gamepad-keyboard/Cargo.toml
@@ -8,7 +8,6 @@ description = "arci::Gamepad implementation for keyboard"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "http://docs.rs/arci-gamepad-keyboard"
 
 [dependencies]
 arci = "0.0.6"

--- a/arci-ros/Cargo.toml
+++ b/arci-ros/Cargo.toml
@@ -8,7 +8,6 @@ description = "arci implementation using ROS1"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/arci-ros"
 
 [dependencies]
 anyhow = "1.0"

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -8,7 +8,6 @@ description = "arci implementation using ROS2"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/arci-ros2"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/arci-speak-audio/Cargo.toml
+++ b/arci-speak-audio/Cargo.toml
@@ -8,7 +8,6 @@ description = "arci::Speaker implementation for playing audio files"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/arci-speak-audio"
 
 [dependencies]
 arci = "0.0.6"

--- a/arci-speak-cmd/Cargo.toml
+++ b/arci-speak-cmd/Cargo.toml
@@ -8,7 +8,6 @@ description = "arci::Speaker implementation using local command"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/arci-speak-cmd"
 
 [dependencies]
 arci = "0.0.6"

--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -8,7 +8,6 @@ description = "arci implementation using urdf-viz"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/arci-urdf-viz"
 
 [dependencies]
 anyhow = "1.0"

--- a/arci/Cargo.toml
+++ b/arci/Cargo.toml
@@ -8,7 +8,6 @@ description = "Abstract Robot Control Interface"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/arci"
 
 [dependencies]
 anyhow = "1.0"

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -8,7 +8,6 @@ description = "applications using openrr"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-apps"
 
 [features]
 default = ["assimp", "gui", "ros"]

--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -8,7 +8,6 @@ description = "openrr useful client libraries"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-client"
 
 [features]
 default = ["assimp"]

--- a/openrr-command/Cargo.toml
+++ b/openrr-command/Cargo.toml
@@ -8,7 +8,6 @@ description = "openrr command line tool library"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-command"
 
 [features]
 default = ["assimp"]

--- a/openrr-config/Cargo.toml
+++ b/openrr-config/Cargo.toml
@@ -8,7 +8,6 @@ description = "Utilities for modifying configuration files"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics", "gui"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-config"
 
 [dependencies]
 anyhow = "1"

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -8,7 +8,6 @@ description = "openrr GUI library"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics", "gui"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-gui"
 
 [features]
 default = ["assimp"]

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -8,7 +8,6 @@ description = "Collision avoidance path planning for robotics"
 keywords = ["pathplanning", "robotics", "robot"]
 categories = ["algorithms", "science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-planner"
 
 [features]
 default = ["assimp"]

--- a/openrr-plugin/Cargo.toml
+++ b/openrr-plugin/Cargo.toml
@@ -8,7 +8,6 @@ description = "Experimental plugin support for arci"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-plugin"
 
 [dependencies]
 abi_stable = "0.10"

--- a/openrr-remote/Cargo.toml
+++ b/openrr-remote/Cargo.toml
@@ -8,7 +8,6 @@ description = "Remote execution support for arci"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-remote"
 
 [build-dependencies]
 tonic-build = "0.5"

--- a/openrr-sleep/Cargo.toml
+++ b/openrr-sleep/Cargo.toml
@@ -8,7 +8,6 @@ description = "openrr sleep library"
 keywords = ["robotics", "robot"]
 categories = ["algorithms", "science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-sleep"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -8,7 +8,6 @@ description = "openrr teleoperation library"
 keywords = ["robotics", "robot"]
 categories = ["algorithms", "science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr-teleop"
 
 [features]
 default = ["assimp"]

--- a/openrr/Cargo.toml
+++ b/openrr/Cargo.toml
@@ -9,7 +9,6 @@ description = "Open Rust Robotics framework"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
 repository = "https://github.com/openrr/openrr"
-documentation = "https://docs.rs/openrr"
 readme = "../README.md"
 
 [features]


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field

> If no URL is specified in the manifest file, crates.io will
> automatically link your crate to the corresponding docs.rs page.