### PR TITLE
[openrr-client] Support the situation when there are no kinematics model.

### DIFF
--- a/openrr-client/src/error.rs
+++ b/openrr-client/src/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
     TomlParseFailure(PathBuf, #[source] toml::de::Error),
     #[error("openrr-client: urdf-rs: {:?}", .0)]
     UrdfRs(#[from] UrdfError),
+    #[error("openrr-client: Full Chain is none")]
+    FullChainNotFound(String),
     #[error("openrr-client: Other: {:?}", .0)]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
When there are no urdf_path in the config, the full_chain can be None.
(This happens when we use the apps without any arguments (default: urdf-viz (localhost:7777) and all joints))

This change fixes the situation to work some functionalities without urdf file path.