### PR TITLE
[arci-speak-audio] pin alsa to 0.5.0

### DIFF
--- a/arci-speak-audio/Cargo.toml
+++ b/arci-speak-audio/Cargo.toml
@@ -16,6 +16,10 @@ thiserror = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 tokio = { version = "1", features = ["sync"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# https://github.com/diwic/alsa-rs/issues/81
+alsa = "=0.5.0"
+
 [dev-dependencies]
 structopt = "0.3"
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
```
error[E0308]: mismatched types
   --> /home/parallels/.cargo/registry/src/github.com-1ecc6299db9ec823/cpal-0.13.4/src/host/alsa/mod.rs:245:26
    |
244 |         let handle = match handle_result {
    |                            ------------- this expression has type `std::result::Result<host::alsa::alsa::PCM, (host::alsa::alsa::Error, Option<host::alsa::alsa::nix::errno::Errno>)>`
245 |             Err((_, Some(nix::errno::Errno::EBUSY))) => {
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `host::alsa::alsa::nix::errno::Errno`, found enum `nix::errno::Errno`
    |
    = note: perhaps two different versions of crate `nix` are being used?
```

refs: https://github.com/diwic/alsa-rs/issues/81