### PR TITLE
Revert "[arci-speak-audio] pin alsa to 0.5.0"

### DIFF
--- a/arci-speak-audio/Cargo.toml
+++ b/arci-speak-audio/Cargo.toml
@@ -16,10 +16,6 @@ thiserror = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 tokio = { version = "1", features = ["sync"] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
-# https://github.com/diwic/alsa-rs/issues/81
-alsa = "=0.5.0"
-
 [dev-dependencies]
 structopt = "0.3"
 tokio = { version = "1.0", features = ["full"] }


### PR DESCRIPTION
This reverts commit 89bf3ad3e7e2ee5c710e01fe4ce86831dc562359.

alsa 0.5.1 has been yanked, so we no longer need to pin it.