### PR TITLE
[openrr-plugin] Remove Plugin::name method

### DIFF
--- a/arci-ros2/src/plugin.rs
+++ b/arci-ros2/src/plugin.rs
@@ -5,10 +5,6 @@ openrr_plugin::export_plugin!(Ros2Plugin {});
 struct Ros2Plugin {}
 
 impl openrr_plugin::Plugin for Ros2Plugin {
-    fn name(&self) -> String {
-        "arci-ros2-plugin".into()
-    }
-
     fn new_move_base(&self, args: String) -> Result<Option<Box<dyn arci::MoveBase>>, arci::Error> {
         let config: Ros2CmdVelMoveBaseConfig =
             toml::from_str(&args).map_err(anyhow::Error::from)?;

--- a/openrr-plugin/benches/proxy.rs
+++ b/openrr-plugin/benches/proxy.rs
@@ -262,10 +262,6 @@ openrr_plugin::export_plugin!(TestPlugin);
 pub struct TestPlugin;
 
 impl openrr_plugin::Plugin for TestPlugin {
-    fn name(&self) -> String {
-        "TestPlugin".into()
-    }
-
     fn new_joint_trajectory_client(
         &self,
         args: String,

--- a/openrr-plugin/examples/load_plugin.rs
+++ b/openrr-plugin/examples/load_plugin.rs
@@ -8,7 +8,6 @@ use openrr_plugin::PluginProxy;
 async fn main() -> Result<()> {
     let plugin = PluginProxy::from_path("./target/debug/libopenrr_plugin_example.dylib")?;
 
-    println!("Plugin: {}", plugin.name());
     if let Some(joint_trajectory_client) =
         plugin.new_joint_trajectory_client(r#"{ "joint_names": ["a", "b"] }"#.into())?
     {

--- a/openrr-plugin/examples/plugin/src/lib.rs
+++ b/openrr-plugin/examples/plugin/src/lib.rs
@@ -10,10 +10,6 @@ openrr_plugin::export_plugin!(MyPlugin);
 pub struct MyPlugin;
 
 impl Plugin for MyPlugin {
-    fn name(&self) -> String {
-        "Example".into()
-    }
-
     fn new_joint_trajectory_client(
         &self,
         args: String,

--- a/openrr-plugin/src/gen/api.rs
+++ b/openrr-plugin/src/gen/api.rs
@@ -10,10 +10,6 @@ use arci::{BaseVelocity, Error, Isometry2, Isometry3, WaitFuture};
 use super::*;
 /// The plugin trait.
 pub trait Plugin: Send + Sync + 'static {
-    /// Returns the name of this plugin.
-    ///
-    /// NOTE: This is *not* a unique identifier.
-    fn name(&self) -> String;
     /// Creates a new instance of [`arci::Gamepad`] with the specified arguments.
     fn new_gamepad(&self, args: String) -> Result<Option<Box<dyn arci::Gamepad>>, arci::Error> {
         let _ = args;

--- a/openrr-plugin/src/gen/proxy.rs
+++ b/openrr-plugin/src/gen/proxy.rs
@@ -13,7 +13,6 @@ use super::*;
 pub(crate) type PluginTraitObject = RPluginTrait_TO<RBox<()>>;
 #[sabi_trait]
 pub(crate) trait RPluginTrait: Send + Sync + 'static {
-    fn name(&self) -> RString;
     fn new_gamepad(&self, args: RString) -> RResult<ROption<crate::GamepadProxy>, RError>;
     fn new_joint_trajectory_client(
         &self,
@@ -33,10 +32,6 @@ impl<T> RPluginTrait for T
 where
     T: crate::Plugin,
 {
-    fn name(&self) -> RString {
-        crate::Plugin::name(self).into()
-    }
-
     fn new_gamepad(&self, args: RString) -> RResult<ROption<crate::GamepadProxy>, RError> {
         ROk(rtry!(crate::Plugin::new_gamepad(self, args.into()))
             .map(crate::GamepadProxy::new)

--- a/openrr-plugin/src/lib.rs
+++ b/openrr-plugin/src/lib.rs
@@ -32,9 +32,6 @@ use crate::proxy::{GamepadTraitObject, JointTrajectoryClientTraitObject};
 /// pub struct MyPlugin;
 ///
 /// impl Plugin for MyPlugin {
-///     fn name(&self) -> String {
-///         "MyPlugin".into()
-///     }
 /// }
 /// ```
 #[macro_export]
@@ -71,20 +68,11 @@ impl PluginProxy {
 
         Ok(plugin)
     }
-
-    /// Returns the name of this plugin.
-    ///
-    /// NOTE: This is *not* a unique identifier.
-    pub fn name(&self) -> String {
-        self.0.name().into()
-    }
 }
 
 impl fmt::Debug for PluginProxy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PluginProxy")
-            .field("name", &self.name())
-            .finish()
+        f.debug_struct("PluginProxy").finish()
     }
 }
 

--- a/tools/codegen/src/plugin.rs
+++ b/tools/codegen/src/plugin.rs
@@ -250,10 +250,6 @@ fn gen_plugin_trait(traits: &[Ident]) -> (TokenStream, TokenStream) {
     let api = quote! {
         /// The plugin trait.
         pub trait Plugin: Send + Sync + 'static {
-            /// Returns the name of this plugin.
-            ///
-            /// NOTE: This is *not* a unique identifier.
-            fn name(&self) -> String;
             #(#plugin_method_def)*
         }
         #proxy_type
@@ -266,7 +262,6 @@ fn gen_plugin_trait(traits: &[Ident]) -> (TokenStream, TokenStream) {
 
         #[sabi_trait]
         pub(crate) trait RPluginTrait: Send + Sync + 'static {
-            fn name(&self) -> RString;
             #(#sabi_plugin_method_def)*
         }
 
@@ -274,9 +269,6 @@ fn gen_plugin_trait(traits: &[Ident]) -> (TokenStream, TokenStream) {
         where
             T: crate::Plugin,
         {
-            fn name(&self) -> RString {
-                crate::Plugin::name(self).into()
-            }
             #(#sabi_plugin_method_impl)*
         }
     };


### PR DESCRIPTION
Since the name of the plugin is specified by config, this method is currently unused.

https://github.com/openrr/openrr/blob/bc5d4e50636c1eba6ff1243a11e1644c036ab51e/openrr-apps/config/sample_robot_client_config_for_plugin.toml#L55

Considering that the name is not a unique identifier and we can get the package name from the plugin filename, I think it is unlikely that this will actually be needed in the future.