### PR TITLE
[arci-gamepad-gilrs] Fix unused_mut warning on macOS

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -276,3 +276,4 @@ ctrl
 readline
 rustyline
 uuid
+attr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
   nightly: nightly-2021-11-22
 
@@ -251,4 +252,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets -- -D warnings
+          args: --all-targets

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
   nightly: nightly-2021-11-22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
 
 defaults:

--- a/arci-gamepad-gilrs/src/lib.rs
+++ b/arci-gamepad-gilrs/src/lib.rs
@@ -226,6 +226,7 @@ impl GilGamepad {
         let is_running_cloned = is_running.clone();
         std::thread::spawn(move || {
             let mut gil = gilrs::Gilrs::new().unwrap();
+            #[cfg_attr(target_os = "macos", allow(unused_mut))]
             let mut selected_gamepad_id = None;
             // TODO: On MacOS `gamepads()` does not works.
             #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
```text
warning: variable does not need to be mutable
   --> arci-gamepad-gilrs/src/lib.rs:229:17
    |
229 |             let mut selected_gamepad_id = None;
    |                 ----^^^^^^^^^^^^^^^^^^^
    |                 |
    |                 help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default
```