### PR TITLE
Remove authors field from Cargo.toml

### DIFF
--- a/arci-gamepad-gilrs/Cargo.toml
+++ b/arci-gamepad-gilrs/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arci-gamepad-gilrs"
 version = "0.0.6"
-authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "arci::Gamepad implementation using gilrs"

--- a/arci-gamepad-keyboard/Cargo.toml
+++ b/arci-gamepad-keyboard/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arci-gamepad-keyboard"
 version = "0.0.6"
-authors = ["Taiki Endo <taiki@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "arci::Gamepad implementation for keyboard"

--- a/arci-ros/Cargo.toml
+++ b/arci-ros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arci-ros"
 version = "0.0.6"
-authors = ["Takashi Ogura <t.ogura@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "arci implementation using ROS1"

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arci-ros2"
 version = "0.0.6"
-authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "arci implementation using ROS2"

--- a/arci-speak-audio/Cargo.toml
+++ b/arci-speak-audio/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arci-speak-audio"
 version = "0.0.6"
-authors = ["Koki Shinjo <sktometometo@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "arci::Speaker implementation for playing audio files"

--- a/arci-speak-cmd/Cargo.toml
+++ b/arci-speak-cmd/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arci-speak-cmd"
 version = "0.0.6"
-authors = ["Taiki Endo <taiki@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "arci::Speaker implementation using local command"

--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arci-urdf-viz"
 version = "0.0.6"
-authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "arci implementation using urdf-viz"

--- a/arci/Cargo.toml
+++ b/arci/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "arci"
 version = "0.0.6"
-authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "Abstract Robot Control Interface"

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-apps"
 version = "0.0.6"
-authors = ["Mitsuharu Kojima <kojima@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "applications using openrr"

--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-client"
 version = "0.0.6"
-authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "openrr useful client libraries"

--- a/openrr-command/Cargo.toml
+++ b/openrr-command/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-command"
 version = "0.0.6"
-authors = ["Mitsuharu Kojima <kojima@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "openrr command line tool library"

--- a/openrr-config/Cargo.toml
+++ b/openrr-config/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-config"
 version = "0.0.6"
-authors = ["Taiki Endo <taiki@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "Utilities for modifying configuration files"

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-gui"
 version = "0.0.6"
-authors = ["Taiki Endo <taiki@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "openrr GUI library"

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-planner"
 version = "0.0.6"
-authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "Collision avoidance path planning for robotics"

--- a/openrr-plugin/Cargo.toml
+++ b/openrr-plugin/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-plugin"
 version = "0.0.6"
-authors = ["Taiki Endo <taiki@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin support for arci"

--- a/openrr-plugin/examples/plugin/Cargo.toml
+++ b/openrr-plugin/examples/plugin/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-plugin-example"
 version = "0.1.0"
-authors = ["Taiki Endo <taiki@smilerobotics.com>"]
 edition = "2021"
 publish = false
 

--- a/openrr-remote/Cargo.toml
+++ b/openrr-remote/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-remote"
 version = "0.0.6"
-authors = ["Taiki Endo <taiki@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "Remote execution support for arci"

--- a/openrr-sleep/Cargo.toml
+++ b/openrr-sleep/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-sleep"
 version = "0.0.6"
-authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "openrr sleep library"

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr-teleop"
 version = "0.0.6"
-authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 description = "openrr teleoperation library"

--- a/openrr/Cargo.toml
+++ b/openrr/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "openrr"
 version = "0.0.6"
-authors = ["Takashi Ogura <ogura@smilerobotics.com>"]
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://openrr.github.io"


### PR DESCRIPTION
This field is soft-deprecated, cargo no longer generates this field by default, and Rust's official services no longer reference this field at all.

See [RFC3052](https://rust-lang.github.io/rfcs/3052-optional-authors-field.html) for more.