### PR TITLE
[arci-urdf-viz] Mark test_send_joint_positions test as flaky

### DIFF
--- a/arci-ros/tests/test_rosrust_utils.rs
+++ b/arci-ros/tests/test_rosrust_utils.rs
@@ -50,7 +50,7 @@ fn test_convert_ros_time_to_system_time() {
     );
 }
 
-#[test]
+#[flaky_test::flaky_test]
 fn test_convert_system_time_to_ros_time() {
     let _roscore =
         run_roscore_and_rosrust_init_once(&"test_convert_system_time_to_ros_time".to_owned());

--- a/arci-urdf-viz/tests/test_client.rs
+++ b/arci-urdf-viz/tests/test_client.rs
@@ -157,8 +157,12 @@ fn test_current_joint_positions() {
     assert_approx_eq!(v[1], -1.0);
 }
 
-#[tokio::test]
-async fn test_send_joint_positions() {
+#[flaky_test::flaky_test]
+fn test_send_joint_positions() {
+    test_send_joint_positions_inner();
+}
+#[tokio::main(flavor = "current_thread")]
+async fn test_send_joint_positions_inner() {
     const PORT: u16 = 7780;
     let web_server = WebServer::new(PORT, Default::default());
     web_server.set_current_joint_positions(JointNamesAndPositions {


### PR DESCRIPTION
Closes #527

This also marks test_convert_system_time_to_ros_time test as flaky: https://github.com/openrr/openrr/runs/4308736017?check_suite_focus=true