### PR TITLE
[arci-ros] Clean up define_action_client macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ members = [
     "openrr-remote",
     "openrr-sleep",
     "openrr-teleop",
+
+    # internal
+    "arci-ros/tests/hygiene",
     "openrr-plugin/examples/plugin",
     "tools/codegen",
 ]

--- a/arci-ros/src/lib.rs
+++ b/arci-ros/src/lib.rs
@@ -18,7 +18,11 @@ pub mod ros_transform_resolver;
 pub mod rosrust_utils;
 
 // re-export
-pub use rosrust::{init, is_ok, name, rate};
+#[doc(hidden)] // re-export for macros
+pub use parking_lot;
+#[doc(hidden)] // re-export for macros
+pub use paste;
+pub use rosrust::{self, init, is_ok, name, rate};
 
 pub use crate::{
     cmd_vel_move_base::*, error::Error, joy_gamepad::*, ros_control::*, ros_localization_client::*,

--- a/arci-ros/src/ros_control/ros_control_action_client.rs
+++ b/arci-ros/src/ros_control/ros_control_action_client.rs
@@ -9,14 +9,14 @@ use parking_lot::Mutex;
 
 use crate::{
     create_joint_trajectory_message_for_send_joint_positions,
-    create_joint_trajectory_message_for_send_joint_trajectory, define_action_client_internal,
+    create_joint_trajectory_message_for_send_joint_trajectory, define_action_client,
     extract_current_joint_positions_from_state, msg, JointStateProvider,
     JointStateProviderFromJointState, LazyJointStateProvider, SubscriberHandler,
 };
 
 const ACTION_TIMEOUT_DURATION_RATIO: u32 = 10;
 
-define_action_client_internal!(SimpleActionClient, msg::control_msgs, FollowJointTrajectory);
+define_action_client!(SimpleActionClient, msg::control_msgs, FollowJointTrajectory);
 
 #[derive(Clone)]
 pub struct RosControlActionClient(Arc<RosControlActionClientInner>);

--- a/arci-ros/src/ros_nav_client.rs
+++ b/arci-ros/src/ros_nav_client.rs
@@ -5,8 +5,8 @@ use nalgebra as na;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{define_action_client_internal, msg, ActionResultWait};
-define_action_client_internal!(SimpleActionClient, msg::move_base_msgs, MoveBase);
+use crate::{define_action_client, msg, ActionResultWait};
+define_action_client!(SimpleActionClient, msg::move_base_msgs, MoveBase);
 
 rosrust::rosmsg_include! {
     std_srvs / Empty

--- a/arci-ros/tests/hygiene/Cargo.toml
+++ b/arci-ros/tests/hygiene/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "arci-ros-hygiene-test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+arci = "0.0.6"
+arci-ros = "0.0.6"

--- a/arci-ros/tests/hygiene/src/lib.rs
+++ b/arci-ros/tests/hygiene/src/lib.rs
@@ -1,0 +1,5 @@
+// Check if the macro depends on another crate.
+
+use arci_ros::msg;
+
+arci_ros::define_action_client!(SimpleActionClient, msg::move_base_msgs, MoveBase);


### PR DESCRIPTION
- Users no longer need to add parking_lot, past, and rosrust as dependencies to use this macro.
- Remove define_action_client_internal and define_action_client_with_namespace macros (merged to define_action_client macro).
- Add a test to check if the macro depends on another crate.