### PR TITLE
[arci-ros] Use flume instead of std::sync::mpsc

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,9 +1,18 @@
+# https://rust-lang.github.io/rust-clippy/master/#disallowed_methods
+disallowed-methods = [
+    # use faster `flume` instead
+    "std::sync::mpsc::channel",
+    "std::sync::mpsc::sync_channel",
+    # TODO: use `reason =` syntax once 1.57 became stable:
+    # { path = "std::sync::mpsc::channel", reason = "use faster `flume::unbounded` instead" },
+    # { path = "std::sync::mpsc::sync_channel", reason = "use faster `flume::bounded` instead" },
+]
 # https://rust-lang.github.io/rust-clippy/master/#disallowed_types
 disallowed-types = [
     # use faster `parking_lot::{Mutex, RwLock, CondVar}` instead
     "std::sync::Mutex",
     "std::sync::RwLock",
     "std::sync::CondVar",
-    # TODO: use `reason =` syntax once 1.57 became stable:
+    # TODO: use `reason =` syntax once 1.58 became stable:
     # { path = "std::sync::Mutex", reason = "use faster `parking_lot::Mutex` instead" },
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,4 +261,5 @@ jobs:
         run: |
           # for arci-ros2
           source /opt/ros/foxy/setup.bash
-          cargo clippy --all-features --all-targets -- -D clippy::disallowed_type
+          # NOTE: clippy::disallowed_method/clippy::disallowed_type has been renamed to clippy::disallowed_methods/clippy::disallowed_types in Rust 1.58.
+          cargo clippy --all-features --all-targets -- -D clippy::disallowed_method -D clippy::disallowed_type

--- a/arci-ros/src/lib.rs
+++ b/arci-ros/src/lib.rs
@@ -19,6 +19,8 @@ pub mod rosrust_utils;
 
 // re-export
 #[doc(hidden)] // re-export for macros
+pub use flume;
+#[doc(hidden)] // re-export for macros
 pub use parking_lot;
 #[doc(hidden)] // re-export for macros
 pub use paste;


### PR DESCRIPTION
~~Depend on #529~~

`std::sync::mpsc` is buggy and slow. Recommended alternatives are faster `crossbeam-channel` or `flume`.

We are already using `flume` in some crates (https://github.com/openrr/openrr/pull/250), so this patch replaces the remaining use of `std::sync::mpsc` with `flume`.