### PR TITLE
[arci] Add `send_goal_pose_with_thresholds` function to `Navigation` trait

### DIFF
--- a/arci/src/error.rs
+++ b/arci/src/error.rs
@@ -67,6 +67,8 @@ pub enum Error {
     Lazy(Arc<Error>),
     #[error("arci: urdf: {:?}", .0)]
     Urdf(#[from] urdf_rs::UrdfError),
+    #[error("arci: Not implemented: {}", message)]
+    NotImplemented { message: String },
     #[error("arci: Other: {:?}", .0)]
     Other(#[from] anyhow::Error),
 }

--- a/arci/src/traits/navigation.rs
+++ b/arci/src/traits/navigation.rs
@@ -11,5 +11,16 @@ pub trait Navigation: Send + Sync {
         timeout: std::time::Duration,
     ) -> Result<WaitFuture, Error>;
 
+    #[allow(unused_variables)]
+    fn send_goal_pose_with_thresholds(
+        &self,
+        goal: Isometry2<f64>,
+        thresholds: [f64; 3],
+        frame_id: &str,
+        timeout: std::time::Duration,
+    ) -> Result<WaitFuture, Error> {
+        Err(anyhow::anyhow!("Not implemented").into())
+    }
+
     fn cancel(&self) -> Result<(), Error>;
 }

--- a/arci/src/traits/navigation.rs
+++ b/arci/src/traits/navigation.rs
@@ -19,7 +19,9 @@ pub trait Navigation: Send + Sync {
         frame_id: &str,
         timeout: std::time::Duration,
     ) -> Result<WaitFuture, Error> {
-        Err(anyhow::anyhow!("Not implemented").into())
+        Err(Error::NotImplemented {
+            message: "method `send_goal_pose_with_thresholds`".to_owned(),
+        })
     }
 
     fn cancel(&self) -> Result<(), Error>;


### PR DESCRIPTION
for navigation in which movement accuracy is not needed