### PR TITLE
[openrr-planner] Fix to read a xacro file in an example

### DIFF
--- a/openrr-planner/examples/reach.rs
+++ b/openrr-planner/examples/reach.rs
@@ -59,7 +59,8 @@ impl CollisionAvoidApp {
         let solver = openrr_planner::RandomInitializeIkSolver::new(solver, 100);
         let planner = openrr_planner::JointPathPlannerWithIk::new(planner, solver);
         let (mut viewer, mut window) = urdf_viz::Viewer::new("openrr_planner: example reach");
-        let urdf_robot = urdf_rs::read_file(&robot_path).unwrap();
+        let urdf_robot =
+            urdf_rs::utils::read_urdf_or_xacro(&robot_path).expect("robot file not found");
         viewer.add_robot_with_base_dir(&mut window, &urdf_robot, robot_path.parent());
         viewer.add_axis_cylinders(&mut window, "origin", 1.0);
 


### PR DESCRIPTION
This PR resolves a bug generated by #453 . Sorry for inconvenience.

We should use `urdf_rs::utils::read_urdf_or_xacro()` instead of `urdf_rs::read_file()`, in order to accept not only raw-urdf files but also xacro files.