### PR TITLE
[arci-ros2] Add Ros2ControlClient

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -277,3 +277,4 @@ readline
 rustyline
 uuid
 attr
+rrbot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
       - run: |
           apt-get update
           apt-get -y install curl libclang-dev
-          apt-get -y install ros-${{ matrix.distro }}-geometry-msgs ros-${{ matrix.distro }}-nav2-msgs
+          apt-get -y install ros-${{ matrix.distro }}-geometry-msgs ros-${{ matrix.distro }}-nav2-msgs ros-${{ matrix.distro }}-ros2-control ros-${{ matrix.distro }}-ros2-controllers
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -258,7 +258,7 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
-      - uses: Swatinem/rust-cache@v1
+      # - uses: Swatinem/rust-cache@v1
       - run: ci/ubuntu-install-dependencies.sh
       - name: Install ROS2
         run: |
@@ -267,7 +267,7 @@ jobs:
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
-            ros-foxy-ros-core ros-foxy-geometry-msgs ros-foxy-nav2-msgs
+            ros-foxy-ros-core ros-foxy-geometry-msgs ros-foxy-nav2-msgs ros-foxy-ros2-control ros-foxy-ros2-controllers
       - name: Run clippy
         run: |
           # for arci-ros2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,10 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
+      # TODO: If ros2-control is not installed, r2r will not generate the control_msg module.
+      #       Cached artifacts are generated in an environment where ros2-control is not installed,
+      #       and somehow clippy does not rebuild the dependencies, so disable the cache for now.
+      #       We should be able to re-enable this once the previous cache expires.
       # - uses: Swatinem/rust-cache@v1
       - run: ci/ubuntu-install-dependencies.sh
       - name: Install ROS2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             ros-noetic-ros-base ros-noetic-joy ros-noetic-pr2-description \
-            ros-foxy-ros-core ros-foxy-geometry-msgs ros-foxy-nav2-msgs
+            ros-foxy-ros-core ros-foxy-geometry-msgs ros-foxy-nav2-msgs ros-foxy-ros2-control ros-foxy-ros2-controllers
       # rustfmt is for openrr-remote (tonic-build)
       - name: Install Rust
         run: |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OpenRR (pronounced like "opener") is Open Rust Robotics platform.
 |Windows       |✔|✔|  |  |
 
 * You can use ROS *without ROS installation* on Linux/MacOS.
-* ROS2 Support is experimental. Only navigation is supported and it is highly under development. See [arci-ros2](https://github.com/openrr/openrr/tree/main/arci-ros2) for details.
+* ROS2 Support is experimental. See [arci-ros2](https://github.com/openrr/openrr/tree/main/arci-ros2) for details.
 
 ## Dependencies
 

--- a/arci-ros2/README.md
+++ b/arci-ros2/README.md
@@ -6,14 +6,15 @@ ROS2 implementation for arci.
 
 ## Dependencies
 
-* ROS2 Foxy
+* ROS2 [Foxy](https://docs.ros.org/en/foxy/Installation.html) or [Galactic](https://docs.ros.org/en/galactic/Installation.html)
 * [r2r](https://github.com/sequenceplanner/r2r)
 
 ## Install
 
 ```bash
-sudo apt install ros-foxy-nav2-msgs ros-foxy-geometry-msgs
-sudo apt install libclang-dev  # for r2r
+sudo apt install ros-foxy-nav2-msgs ros-foxy-geometry-msgs # for navigation
+sudo apt install ros-foxy-ros2-control ros-foxy-ros2-controllers # for ros2_control
+sudo apt install libclang-dev # for r2r
 ```
 
 ## Build
@@ -25,7 +26,7 @@ source /opt/ros/foxy/setup.bash
 cargo build --features ros2
 ```
 
-## How to use
+## How to use (navigation2)
 
 ### Install navigation2
 
@@ -51,4 +52,47 @@ Don't forget to set the initial pose of the robot before sending the goal pose u
 
 ```bash
 ./target/debug/openrr_apps_velocity_sender --config-path ./openrr-apps/config/turtlebot3_robot_client_config_ros2.toml
+```
+
+## How to use (ros2_control)
+
+### Install ros2_control_demos
+
+Clone and build [ros2_control_demos](https://github.com/ros-controls/ros2_control_demos)
+
+* if `ROS2_DISTRO` is foxy: checkout foxy branch, install it, and source `install/setup.bash`.
+* if `ROS2_DISTRO` is galactic: replace all "foxy" in the repository with "galactic", install it, and source `install/setup.bash`.
+
+### Launch rrbot example and controllers
+
+Launch rrbot example
+
+```bash
+ros2 launch ros2_control_demo_bringup rrbot.launch.py
+```
+
+Stop existing controllers.
+
+```bash
+ros2 control set_controller_state joint_state_broadcaster stop
+ros2 control set_controller_state forward_position_controller stop
+```
+
+Start `position_trajectory_controller` and `joint_state_broadcaster`.
+
+```bash
+ros2 control load_controller position_trajectory_controller --set-state start
+ros2 control set_controller_state joint_state_broadcaster start
+```
+
+### Run command line tools
+
+<!--
+TODO: add usage of openrr-apps + ros2_control
+-->
+
+#### Run ros2_control example of arci-ros2
+
+```sh
+cargo run --package arci-ros2 --example ros2_control --features ros2
 ```

--- a/arci-ros2/examples/ros2_control.rs
+++ b/arci-ros2/examples/ros2_control.rs
@@ -9,12 +9,25 @@ async fn main() -> anyhow::Result<()> {
     let ctx = r2r::Context::create().unwrap();
     let client = Ros2ControlClient::new(
         ctx,
-        "/position_trajectory_controller/follow_joint_trajectory",
+        "/position_trajectory_controller",
         vec!["joint1".into(), "joint2".into()],
     );
+    dbg!(client.current_joint_positions()).unwrap();
     client
-        .send_joint_positions(vec![1.0, 1.0], Duration::from_secs(10))?
+        .send_joint_positions(
+            vec![1.0; client.joint_names().len()],
+            Duration::from_secs(5),
+        )?
         .await?;
+    dbg!(client.current_joint_positions()).unwrap();
+    client
+        .send_joint_positions(
+            vec![0.5; client.joint_names().len()],
+            Duration::from_secs(5),
+        )?
+        .await?;
+    dbg!(client.current_joint_positions()).unwrap();
+
     Ok(())
 }
 

--- a/arci-ros2/examples/ros2_control.rs
+++ b/arci-ros2/examples/ros2_control.rs
@@ -1,0 +1,24 @@
+#[cfg(feature = "ros2")]
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    use std::time::Duration;
+
+    use arci::*;
+    use arci_ros2::{r2r, Ros2ControlClient};
+
+    let ctx = r2r::Context::create().unwrap();
+    let client = Ros2ControlClient::new(
+        ctx,
+        "/position_trajectory_controller/follow_joint_trajectory",
+        vec!["joint1".into(), "joint2".into()],
+    );
+    client
+        .send_joint_positions(vec![1.0, 1.0], Duration::from_secs(10))?
+        .await?;
+    Ok(())
+}
+
+#[cfg(not(feature = "ros2"))]
+fn main() {
+    println!("This example requires ros2 feature");
+}

--- a/arci-ros2/examples/ros2_control.rs
+++ b/arci-ros2/examples/ros2_control.rs
@@ -7,11 +7,8 @@ async fn main() -> anyhow::Result<()> {
     use arci_ros2::{r2r, Ros2ControlClient};
 
     let ctx = r2r::Context::create().unwrap();
-    let client = Ros2ControlClient::new(
-        ctx,
-        "/position_trajectory_controller",
-        vec!["joint1".into(), "joint2".into()],
-    );
+    let client = Ros2ControlClient::new(ctx, "/position_trajectory_controller");
+    dbg!(client.joint_names()); // => ["joint1", "joint2"]
     dbg!(client.current_joint_positions()).unwrap();
     client
         .send_joint_positions(

--- a/arci-ros2/src/lib.rs
+++ b/arci-ros2/src/lib.rs
@@ -15,8 +15,10 @@
 mod cmd_vel_move_base;
 mod navigation;
 mod plugin;
+mod ros2_control;
 
 pub use cmd_vel_move_base::*;
 pub use navigation::*;
 // re-export
 pub use r2r;
+pub use ros2_control::*;

--- a/arci-ros2/src/lib.rs
+++ b/arci-ros2/src/lib.rs
@@ -16,6 +16,7 @@ mod cmd_vel_move_base;
 mod navigation;
 mod plugin;
 mod ros2_control;
+mod utils;
 
 pub use cmd_vel_move_base::*;
 pub use navigation::*;

--- a/arci-ros2/src/ros2_control.rs
+++ b/arci-ros2/src/ros2_control.rs
@@ -1,0 +1,153 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use arci::*;
+use futures::stream::StreamExt;
+use parking_lot::Mutex;
+use r2r::{
+    builtin_interfaces::{msg as builtin_msg, msg::Time},
+    control_msgs::action::FollowJointTrajectory,
+    std_msgs::msg::Header,
+    trajectory_msgs::msg as trajectory_msg,
+};
+use serde::{Deserialize, Serialize};
+
+/// Implement arci::JointTrajectoryClient for ROS2
+pub struct Ros2ControlClient {
+    action_client: r2r::ActionClient<FollowJointTrajectory::Action>,
+    /// r2r::Node to handle the action
+    node: Arc<Mutex<r2r::Node>>,
+    joint_names: Vec<String>,
+}
+
+// TODO:
+unsafe impl Sync for Ros2ControlClient {}
+
+impl Ros2ControlClient {
+    /// Create instance from ROS2 context and names of action and joints.
+    pub fn new(ctx: r2r::Context, action_name: &str, joint_names: Vec<String>) -> Self {
+        // TODO: Use unique name
+        let mut node = r2r::Node::create(ctx, "ros2_control_node", "arci_ros2").unwrap();
+        let action_client = node
+            .create_action_client::<FollowJointTrajectory::Action>(action_name)
+            .unwrap();
+        Self {
+            action_client,
+            node: Arc::new(Mutex::new(node)),
+            joint_names,
+        }
+    }
+}
+
+impl JointTrajectoryClient for Ros2ControlClient {
+    fn joint_names(&self) -> Vec<String> {
+        self.joint_names.clone()
+    }
+
+    fn current_joint_positions(&self) -> Result<Vec<f64>, arci::Error> {
+        todo!()
+    }
+
+    fn send_joint_positions(
+        &self,
+        positions: Vec<f64>,
+        duration: Duration,
+    ) -> Result<WaitFuture, arci::Error> {
+        self.send_joint_trajectory(vec![TrajectoryPoint {
+            positions,
+            velocities: None,
+            time_from_start: duration,
+        }])
+    }
+
+    fn send_joint_trajectory(
+        &self,
+        trajectory: Vec<TrajectoryPoint>,
+    ) -> Result<WaitFuture, arci::Error> {
+        let node = self.node.clone();
+        let is_done = Arc::new(AtomicBool::new(false));
+        let is_done_clone = is_done.clone();
+        let action_client = self.action_client.clone();
+        let is_available = node.lock().is_available(&self.action_client).unwrap();
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let joint_names = self.joint_names.clone();
+        std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async move {
+                    tokio::spawn(async move {
+                        let mut clock = r2r::Clock::create(r2r::ClockType::RosTime).unwrap();
+                        let now = clock.get_now().unwrap();
+                        let goal = FollowJointTrajectory::Goal {
+                            trajectory: trajectory_msg::JointTrajectory {
+                                joint_names,
+                                points: trajectory
+                                    .into_iter()
+                                    .map(|tp| trajectory_msg::JointTrajectoryPoint {
+                                        velocities: vec![0.0; tp.positions.len()],
+                                        positions: tp.positions,
+                                        time_from_start: builtin_msg::Duration {
+                                            sec: tp
+                                                .time_from_start
+                                                .as_secs()
+                                                .try_into()
+                                                .unwrap_or(i32::MAX),
+                                            nanosec: tp.time_from_start.subsec_nanos(),
+                                        },
+                                        ..Default::default()
+                                    })
+                                    .collect(),
+                                header: Header {
+                                    stamp: Time {
+                                        sec: now.as_secs() as i32,
+                                        nanosec: now.subsec_nanos(),
+                                    },
+                                    ..Default::default()
+                                },
+                            },
+                            ..Default::default()
+                        };
+                        is_available.await.unwrap();
+                        let send_goal_request = action_client.send_goal_request(goal).unwrap();
+                        let (_goal, result, feedback) = send_goal_request.await.unwrap();
+                        tokio::spawn(
+                            async move { feedback.for_each(|_| std::future::ready(())).await },
+                        );
+                        result.await.unwrap(); // TODO: handle goal state
+                        is_done.store(true, Ordering::Relaxed);
+                    });
+                    loop {
+                        node.lock().spin_once(std::time::Duration::from_millis(100));
+                        tokio::task::yield_now().await;
+                        if is_done_clone.load(Ordering::Relaxed) {
+                            break;
+                        }
+                    }
+                    // TODO: "canceled" should be an error?
+                    let _ = sender.send(());
+                });
+        });
+        let wait =
+            WaitFuture::new(
+                async move { receiver.await.map_err(|e| arci::Error::Other(e.into())) },
+            );
+        Ok(wait)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+/// Configuration for Ros2ControlConfig
+pub struct Ros2ControlConfig {
+    /// Name of action control_msgs::action::FollowJointTrajectory
+    pub action_name: String,
+    /// Names of joints.
+    pub joint_names: Vec<String>,
+}

--- a/arci-ros2/src/ros2_control.rs
+++ b/arci-ros2/src/ros2_control.rs
@@ -11,14 +11,17 @@ use futures::stream::StreamExt;
 use parking_lot::Mutex;
 use r2r::{
     builtin_interfaces::{msg as builtin_msg, msg::Time},
-    control_msgs::action::FollowJointTrajectory,
+    control_msgs::{action::FollowJointTrajectory, msg::JointTrajectoryControllerState},
     std_msgs::msg::Header,
     trajectory_msgs::msg as trajectory_msg,
 };
 use serde::{Deserialize, Serialize};
 
+use crate::utils;
+
 /// Implement arci::JointTrajectoryClient for ROS2
 pub struct Ros2ControlClient {
+    state_topic: String,
     action_client: r2r::ActionClient<FollowJointTrajectory::Action>,
     /// r2r::Node to handle the action
     node: Arc<Mutex<r2r::Node>>,
@@ -29,14 +32,25 @@ pub struct Ros2ControlClient {
 unsafe impl Sync for Ros2ControlClient {}
 
 impl Ros2ControlClient {
-    /// Create instance from ROS2 context and names of action and joints.
+    /// Creates a new `Ros2ControlClient` from ROS2 context and names of action and joints.
+    #[track_caller]
     pub fn new(ctx: r2r::Context, action_name: &str, joint_names: Vec<String>) -> Self {
-        // TODO: Use unique name
-        let mut node = r2r::Node::create(ctx, "ros2_control_node", "arci_ros2").unwrap();
+        // TODO: Consider using unique name
+        let node = r2r::Node::create(ctx, "ros2_control_node", "arci_ros2").unwrap();
+        Self::from_node(node, action_name, joint_names)
+    }
+
+    /// Creates a new `Ros2ControlClient` from ROS2 node and names of action and joints.
+    #[track_caller]
+    pub fn from_node(mut node: r2r::Node, action_name: &str, joint_names: Vec<String>) -> Self {
         let action_client = node
-            .create_action_client::<FollowJointTrajectory::Action>(action_name)
+            .create_action_client::<FollowJointTrajectory::Action>(&format!(
+                "{}/follow_joint_trajectory",
+                action_name
+            ))
             .unwrap();
         Self {
+            state_topic: format!("{}/state", action_name),
             action_client,
             node: Arc::new(Mutex::new(node)),
             joint_names,
@@ -50,7 +64,33 @@ impl JointTrajectoryClient for Ros2ControlClient {
     }
 
     fn current_joint_positions(&self) -> Result<Vec<f64>, arci::Error> {
-        todo!()
+        let node = self.node.clone();
+        let mut state_subscriber = node
+            .lock()
+            .subscribe::<JointTrajectoryControllerState>(&self.state_topic)
+            .unwrap();
+        let is_done = Arc::new(AtomicBool::new(false));
+        let is_done_clone = is_done.clone();
+        Ok(utils::spawn_blocking(async move {
+            let handle = tokio::spawn(async move {
+                let next = state_subscriber.next().await;
+                is_done_clone.store(true, Ordering::SeqCst);
+                next
+            });
+            loop {
+                node.lock().spin_once(std::time::Duration::from_millis(100));
+                tokio::task::yield_now().await;
+                if is_done.load(Ordering::SeqCst) {
+                    break;
+                }
+            }
+            handle.await.unwrap()
+        })
+        .join()
+        .unwrap()
+        .unwrap()
+        .actual
+        .positions)
     }
 
     fn send_joint_positions(
@@ -76,63 +116,55 @@ impl JointTrajectoryClient for Ros2ControlClient {
         let is_available = node.lock().is_available(&self.action_client).unwrap();
         let (sender, receiver) = tokio::sync::oneshot::channel();
         let joint_names = self.joint_names.clone();
-        std::thread::spawn(move || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(async move {
-                    tokio::spawn(async move {
-                        let mut clock = r2r::Clock::create(r2r::ClockType::RosTime).unwrap();
-                        let now = clock.get_now().unwrap();
-                        let goal = FollowJointTrajectory::Goal {
-                            trajectory: trajectory_msg::JointTrajectory {
-                                joint_names,
-                                points: trajectory
-                                    .into_iter()
-                                    .map(|tp| trajectory_msg::JointTrajectoryPoint {
-                                        velocities: vec![0.0; tp.positions.len()],
-                                        positions: tp.positions,
-                                        time_from_start: builtin_msg::Duration {
-                                            sec: tp
-                                                .time_from_start
-                                                .as_secs()
-                                                .try_into()
-                                                .unwrap_or(i32::MAX),
-                                            nanosec: tp.time_from_start.subsec_nanos(),
-                                        },
-                                        ..Default::default()
-                                    })
-                                    .collect(),
-                                header: Header {
-                                    stamp: Time {
-                                        sec: now.as_secs() as i32,
-                                        nanosec: now.subsec_nanos(),
-                                    },
-                                    ..Default::default()
+        utils::spawn_blocking(async move {
+            tokio::spawn(async move {
+                let mut clock = r2r::Clock::create(r2r::ClockType::RosTime).unwrap();
+                let now = clock.get_now().unwrap();
+                let goal = FollowJointTrajectory::Goal {
+                    trajectory: trajectory_msg::JointTrajectory {
+                        joint_names,
+                        points: trajectory
+                            .into_iter()
+                            .map(|tp| trajectory_msg::JointTrajectoryPoint {
+                                velocities: vec![0.0; tp.positions.len()],
+                                positions: tp.positions,
+                                time_from_start: builtin_msg::Duration {
+                                    sec: tp
+                                        .time_from_start
+                                        .as_secs()
+                                        .try_into()
+                                        .unwrap_or(i32::MAX),
+                                    nanosec: tp.time_from_start.subsec_nanos(),
                                 },
+                                ..Default::default()
+                            })
+                            .collect(),
+                        header: Header {
+                            stamp: Time {
+                                sec: now.as_secs() as i32,
+                                nanosec: now.subsec_nanos(),
                             },
                             ..Default::default()
-                        };
-                        is_available.await.unwrap();
-                        let send_goal_request = action_client.send_goal_request(goal).unwrap();
-                        let (_goal, result, feedback) = send_goal_request.await.unwrap();
-                        tokio::spawn(
-                            async move { feedback.for_each(|_| std::future::ready(())).await },
-                        );
-                        result.await.unwrap(); // TODO: handle goal state
-                        is_done.store(true, Ordering::Relaxed);
-                    });
-                    loop {
-                        node.lock().spin_once(std::time::Duration::from_millis(100));
-                        tokio::task::yield_now().await;
-                        if is_done_clone.load(Ordering::Relaxed) {
-                            break;
-                        }
-                    }
-                    // TODO: "canceled" should be an error?
-                    let _ = sender.send(());
-                });
+                        },
+                    },
+                    ..Default::default()
+                };
+                is_available.await.unwrap();
+                let send_goal_request = action_client.send_goal_request(goal).unwrap();
+                let (_goal, result, feedback) = send_goal_request.await.unwrap();
+                tokio::spawn(async move { feedback.for_each(|_| std::future::ready(())).await });
+                result.await.unwrap(); // TODO: handle goal state
+                is_done.store(true, Ordering::Relaxed);
+            });
+            loop {
+                node.lock().spin_once(std::time::Duration::from_millis(100));
+                tokio::task::yield_now().await;
+                if is_done_clone.load(Ordering::Relaxed) {
+                    break;
+                }
+            }
+            // TODO: "canceled" should be an error?
+            let _ = sender.send(());
         });
         let wait =
             WaitFuture::new(

--- a/arci-ros2/src/utils.rs
+++ b/arci-ros2/src/utils.rs
@@ -1,0 +1,16 @@
+use std::thread;
+
+use futures::future::Future;
+
+// https://github.com/openrr/openrr/pull/501#discussion_r746183161
+pub(crate) fn spawn_blocking<T: Send + 'static>(
+    future: impl Future<Output = T> + Send + 'static,
+) -> thread::JoinHandle<T> {
+    std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future)
+    })
+}

--- a/arci-ros2/tests/test_ros2_control.rs
+++ b/arci-ros2/tests/test_ros2_control.rs
@@ -15,7 +15,10 @@ use futures::{
     stream::{Stream, StreamExt},
 };
 use parking_lot::Mutex;
-use r2r::control_msgs::action::FollowJointTrajectory;
+use r2r::{
+    control_msgs::{action::FollowJointTrajectory, msg::JointTrajectoryControllerState},
+    trajectory_msgs::msg as trajectory_msg,
+};
 
 // (node_name, action_name)
 fn node_and_action_name() -> (String, String) {
@@ -26,15 +29,14 @@ fn node_and_action_name() -> (String, String) {
     (node_name, action_name)
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_control() {
     let (node_name, action_name) = &node_and_action_name();
     let ctx = r2r::Context::create().unwrap();
-    let client = Ros2ControlClient::new(ctx.clone(), action_name, vec!["j1".into(), "j2".into()]);
-    let node = Arc::new(Mutex::new(
-        r2r::Node::create(ctx, node_name, "arci_ros2").unwrap(),
-    ));
 
+    let node = Arc::new(Mutex::new(
+        r2r::Node::create(ctx.clone(), node_name, "arci_ros2").unwrap(),
+    ));
     let server_requests = node
         .lock()
         .create_action_server::<FollowJointTrajectory::Action>(&format!(
@@ -42,36 +44,60 @@ async fn test_control() {
             action_name
         ))
         .unwrap();
-
+    let publisher = node
+        .lock()
+        .create_publisher::<JointTrajectoryControllerState>(&format!("{}/state", action_name))
+        .unwrap();
+    let state = Arc::new(Mutex::new(JointTrajectoryControllerState {
+        joint_names: vec!["j1".to_owned(), "j2".to_owned()],
+        actual: trajectory_msg::JointTrajectoryPoint {
+            positions: vec![0.0; 2],
+            ..Default::default()
+        },
+        ..Default::default()
+    }));
     let node_cb = node.clone();
-    tokio::spawn(test_control_server(node_cb, server_requests));
-
+    tokio::spawn(test_control_server(node_cb, server_requests, state.clone()));
+    tokio::spawn(async move {
+        loop {
+            publisher.publish(&state.lock()).unwrap();
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    });
     std::thread::spawn(move || loop {
         node.lock().spin_once(Duration::from_millis(100));
     });
 
+    let client = Ros2ControlClient::new(ctx, action_name);
+    assert_eq!(client.joint_names(), vec!["j1".to_owned(), "j2".to_owned()]);
+    assert_eq!(client.current_joint_positions().unwrap(), vec![0.0, 0.0]);
     client
-        .send_joint_positions(vec![1.0, 1.0], Duration::from_secs(80))
+        .send_joint_positions(vec![1.0, 0.5], Duration::from_secs(80))
         .unwrap()
         .await
         .unwrap();
+    assert_eq!(client.current_joint_positions().unwrap(), vec![1.0, 0.5]);
 }
 
 async fn run_goal(
     node: Arc<Mutex<r2r::Node>>,
-    g: r2r::ActionServerGoal<FollowJointTrajectory::Action>,
+    goal: r2r::ActionServerGoal<FollowJointTrajectory::Action>,
+    state: Arc<Mutex<JointTrajectoryControllerState>>,
 ) -> FollowJointTrajectory::Result {
     let mut timer = node // local timer, will be dropped after this request is processed.
         .lock()
         .create_wall_timer(Duration::from_millis(800))
         .expect("could not create timer");
 
-    let mut feedback_msg = FollowJointTrajectory::Feedback::default();
-    g.publish_feedback(feedback_msg.clone()).expect("fail");
+    state.lock().actual.positions = goal
+        .goal
+        .trajectory
+        .points
+        .last()
+        .unwrap()
+        .positions
+        .clone();
 
-    feedback_msg.actual = feedback_msg.desired.clone();
-    g.publish_feedback(feedback_msg.clone()).expect("fail");
-    println!("Sending feedback: {:?}", feedback_msg);
     timer.tick().await.unwrap();
 
     FollowJointTrajectory::Result::default()
@@ -81,20 +107,21 @@ async fn test_control_server(
     node: Arc<Mutex<r2r::Node>>,
     mut requests: impl Stream<Item = r2r::ActionServerGoalRequest<FollowJointTrajectory::Action>>
         + Unpin,
+    state: Arc<Mutex<JointTrajectoryControllerState>>,
 ) {
     while let Some(req) = requests.next().await {
         println!(
             "Got goal request with trajectory {:?}, goal id: {}",
             req.goal.trajectory, req.uuid
         );
-        let (mut g, mut cancel) = req.accept().expect("could not accept goal");
+        let (mut goal, mut cancel) = req.accept().expect("could not accept goal");
 
-        let goal_fut = tokio::task::spawn(run_goal(node.clone(), g.clone()));
+        let goal_fut = tokio::spawn(run_goal(node.clone(), goal.clone(), state.clone()));
 
         match future::select(goal_fut, cancel.next()).await {
             Either::Left((result, _)) => {
                 let result = result.unwrap();
-                g.succeed(result).expect("could not send result");
+                goal.succeed(result).expect("could not send result");
             }
             Either::Right((request, _)) => {
                 if let Some(request) = request {

--- a/arci-ros2/tests/test_ros2_control.rs
+++ b/arci-ros2/tests/test_ros2_control.rs
@@ -37,7 +37,10 @@ async fn test_control() {
 
     let server_requests = node
         .lock()
-        .create_action_server::<FollowJointTrajectory::Action>(action_name)
+        .create_action_server::<FollowJointTrajectory::Action>(&format!(
+            "{}/follow_joint_trajectory",
+            action_name
+        ))
         .unwrap();
 
     let node_cb = node.clone();

--- a/arci-ros2/tests/test_ros2_control.rs
+++ b/arci-ros2/tests/test_ros2_control.rs
@@ -1,0 +1,103 @@
+#![cfg(feature = "ros2")]
+
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use arci::*;
+use arci_ros2::{r2r, Ros2ControlClient};
+use futures::{
+    future::{self, Either},
+    stream::{Stream, StreamExt},
+};
+use parking_lot::Mutex;
+use r2r::control_msgs::action::FollowJointTrajectory;
+
+// (node_name, action_name)
+fn node_and_action_name() -> (String, String) {
+    static COUNT: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNT.fetch_add(1, Ordering::SeqCst);
+    let node_name = format!("test_ros2_control_node_{}", n);
+    let action_name = format!("/test_ros2_control_{}", n);
+    (node_name, action_name)
+}
+
+#[tokio::test]
+async fn test_control() {
+    let (node_name, action_name) = &node_and_action_name();
+    let ctx = r2r::Context::create().unwrap();
+    let client = Ros2ControlClient::new(ctx.clone(), action_name, vec!["j1".into(), "j2".into()]);
+    let node = Arc::new(Mutex::new(
+        r2r::Node::create(ctx, node_name, "arci_ros2").unwrap(),
+    ));
+
+    let server_requests = node
+        .lock()
+        .create_action_server::<FollowJointTrajectory::Action>(action_name)
+        .unwrap();
+
+    let node_cb = node.clone();
+    tokio::spawn(test_control_server(node_cb, server_requests));
+
+    std::thread::spawn(move || loop {
+        node.lock().spin_once(Duration::from_millis(100));
+    });
+
+    client
+        .send_joint_positions(vec![1.0, 1.0], Duration::from_secs(80))
+        .unwrap()
+        .await
+        .unwrap();
+}
+
+async fn run_goal(
+    node: Arc<Mutex<r2r::Node>>,
+    g: r2r::ActionServerGoal<FollowJointTrajectory::Action>,
+) -> FollowJointTrajectory::Result {
+    let mut timer = node // local timer, will be dropped after this request is processed.
+        .lock()
+        .create_wall_timer(Duration::from_millis(800))
+        .expect("could not create timer");
+
+    let mut feedback_msg = FollowJointTrajectory::Feedback::default();
+    g.publish_feedback(feedback_msg.clone()).expect("fail");
+
+    feedback_msg.actual = feedback_msg.desired.clone();
+    g.publish_feedback(feedback_msg.clone()).expect("fail");
+    println!("Sending feedback: {:?}", feedback_msg);
+    timer.tick().await.unwrap();
+
+    FollowJointTrajectory::Result::default()
+}
+
+async fn test_control_server(
+    node: Arc<Mutex<r2r::Node>>,
+    mut requests: impl Stream<Item = r2r::ActionServerGoalRequest<FollowJointTrajectory::Action>>
+        + Unpin,
+) {
+    while let Some(req) = requests.next().await {
+        println!(
+            "Got goal request with trajectory {:?}, goal id: {}",
+            req.goal.trajectory, req.uuid
+        );
+        let (mut g, mut cancel) = req.accept().expect("could not accept goal");
+
+        let goal_fut = tokio::task::spawn(run_goal(node.clone(), g.clone()));
+
+        match future::select(goal_fut, cancel.next()).await {
+            Either::Left((result, _)) => {
+                let result = result.unwrap();
+                g.succeed(result).expect("could not send result");
+            }
+            Either::Right((request, _)) => {
+                if let Some(request) = request {
+                    panic!("got cancel request: {}", request.uuid);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### How to run example

1\. Install ros2-control and ros2-controllers.

```sh
sudo apt install ros-$ROS2_DISTRO-ros2-control ros-$ROS2_DISTRO-ros2-controllers
```

2\. Clone and build https://github.com/ros-controls/ros2_control_demos

- if ROS2_DISTRO is foxy: checkout foxy branch, install it, and source install/setup.bash.
- if ROS2_DISTRO is galactic: replace all "foxy" in the repository with "galactic", install it, and source install/setup.bash.

3\. Launch rrbot example.

```sh
ros2 launch ros2_control_demo_bringup rrbot.launch.py
```

4\. Stop existing controllers.

```sh
ros2 control set_controller_state joint_state_broadcaster stop
ros2 control set_controller_state forward_position_controller stop
```

5\. Start position_trajectory_controller and joint_state_broadcaster.

```sh
ros2 control load_controller position_trajectory_controller --set-state start
ros2 control set_controller_state joint_state_broadcaster start
```

6\. Run ros2_control example of arci-ros2

```sh
cargo run -p arci-ros2 --example ros2_control --features ros2
```

Closes #290 