### PR TITLE
Update .clippy.toml to include disallowed reasons (disallowed-types)

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -7,11 +7,7 @@ disallowed-methods = [
 # https://rust-lang.github.io/rust-clippy/master/#disallowed_types
 disallowed-types = [
     # use faster `parking_lot` instead
-    "std::sync::Mutex",
-    "std::sync::RwLock",
-    "std::sync::Condvar",
-    # TODO: use `reason =` syntax once 1.58 became stable:
-    # { path = "std::sync::Mutex", reason = "use faster `parking_lot::Mutex` instead" },
-    # { path = "std::sync::RwLock", reason = "use faster `parking_lot::RwLock` instead" },
-    # { path = "std::sync::Condvar", reason = "use faster `parking_lot::Condvar` instead" },
+    { path = "std::sync::Mutex", reason = "use faster `parking_lot::Mutex` instead" },
+    { path = "std::sync::RwLock", reason = "use faster `parking_lot::RwLock` instead" },
+    { path = "std::sync::Condvar", reason = "use faster `parking_lot::Condvar` instead" },
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,10 +273,12 @@ jobs:
           sudo apt-get install -y \
             ros-foxy-ros-core ros-foxy-geometry-msgs ros-foxy-nav2-msgs ros-foxy-ros2-control ros-foxy-ros2-controllers
       - name: Run clippy
+        # NOTE: clippy::disallowed_method/clippy::disallowed_type has been renamed
+        # to clippy::disallowed_methods/clippy::disallowed_types in Rust 1.59.
+        # And warned-by-default in Rust 1.60.
         run: |
           # for arci-ros2
           source /opt/ros/foxy/setup.bash
-          # NOTE: clippy::disallowed_method/clippy::disallowed_type has been renamed to clippy::disallowed_methods/clippy::disallowed_types in Rust 1.58.
           cargo clippy --all-features --all-targets -- -D clippy::disallowed_method -D clippy::disallowed_type
 
   shellcheck:


### PR DESCRIPTION
similar to https://github.com/openrr/openrr/pull/560, but for clippy::disallowed_types.