### PR TITLE
Make installation of cargo-hack & cargo-llvm-cov faster and robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,8 @@ jobs:
         run: rustup update stable
       - uses: Swatinem/rust-cache@v1
       - run: ci/ubuntu-install-dependencies.sh
-      - run: cargo install cargo-hack
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - run: cargo hack check --all --feature-powerset --optional-deps --exclude arci-ros2
 
   fmt:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,8 @@ jobs:
           rustup toolchain install ${{ env.nightly }} --component rustfmt,llvm-tools-preview
           rustup default ${{ env.nightly }}
       - uses: Swatinem/rust-cache@v1
-      - run: cargo install cargo-llvm-cov
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
         run: |
           # for test of arci-ros2


### PR DESCRIPTION
Use [taiki-e/install-action](https://github.com/taiki-e/install-action) to install prebuilt binaries. This makes the installation faster and may avoid the impact of [problems caused by upstream changes](https://github.com/tokio-rs/bytes/issues/506).