### PR TITLE
Re-add resolver = "2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "arci",
     "arci-gamepad-gilrs",


### PR DESCRIPTION
At least when the workspace root is a virtual manifest, resolver = "2" does not seem to properly apply in the workspace, even if all workspace members are 2021 edition.

This issue was originally reported in one of our private projects.

https://github.com/taiki-e/cargo-hack/issues/15#issuecomment-1056937385