### PR TITLE
Update CI for Rust 1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check
 
   clippy:
     name: Clippy
@@ -293,12 +293,10 @@ jobs:
           sudo apt-get install -y \
             ros-foxy-ros-core ros-foxy-geometry-msgs ros-foxy-nav2-msgs ros-foxy-ros2-control ros-foxy-ros2-controllers
       - name: Run clippy
-        # NOTE: clippy::disallowed_methods/clippy::disallowed_types has been changed
-        # to warned-by-default in Rust 1.60.
         run: |
           # for arci-ros2
           source /opt/ros/foxy/setup.bash
-          cargo clippy --all-features --all-targets -- -D clippy::disallowed_methods -D clippy::disallowed_types
+          cargo clippy --all-features --all-targets
 
   docs:
     name: Docs

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,9 +35,7 @@ jobs:
             ros-noetic-ros-base ros-noetic-joy ros-noetic-pr2-description \
             ros-foxy-ros-core ros-foxy-geometry-msgs ros-foxy-nav2-msgs ros-foxy-ros2-control ros-foxy-ros2-controllers
       - name: Install Rust
-        run: |
-          rustup toolchain install beta --component llvm-tools-preview
-          rustup default beta
+        run: rustup toolchain install stable --component llvm-tools-preview
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/openrr-gui/src/velocity_sender.rs
+++ b/openrr-gui/src/velocity_sender.rs
@@ -416,12 +416,9 @@ where
 
         let velocity = self.current_velocity();
         debug!(?velocity, "send_velocity");
-        match self.move_base.send_velocity(&velocity) {
-            Err(e) => {
-                error!("{e}");
-                self.errors.other = Some(e.to_string());
-            }
-            Ok(()) => {}
+        if let Err(e) = self.move_base.send_velocity(&velocity) {
+            error!("{e}");
+            self.errors.other = Some(e.to_string());
         }
         Command::none()
     }


### PR DESCRIPTION
- clippy::disallowed_methods/clippy::disallowed_types are now warned by default
- source-based code coverage has been stabilized
- --check is now a flag of cargo fmt subcommand

The last change was actually made in a bit earlier version.