### PR TITLE
Temporarily disable ROS2 galactic in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
       matrix:
         distro:
           - foxy
-          - galactic
+          # - galactic # TODO
     runs-on: ubuntu-20.04
     container:
       image: docker://ros:${{ matrix.distro }}


### PR DESCRIPTION
This has been failing to build for several days.