### PR TITLE
[openrr-planner] Correct joint possitions at the end of planning

### DIFF
--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -152,6 +152,10 @@ where
             step_length,
             num_smoothing,
         );
+
+        // The joint positions of using_joint can be changed in the smoothing,
+        // so we need to surely set the goal at the end.
+        using_joints.set_joint_positions(goal_angles)?;
         Ok(path)
     }
 


### PR DESCRIPTION
In `plan` function of JointPathPlanner, the joint positions of `using_joint` can be changed in interpolation. This means that the joint positions after planning is uncertainty.

This PR adds a correction to deal with this problem.
Note that the added `set_joint_positions` provably returns Ok because feasibility of `goal_angles` has been checked above.