### PR TITLE
[openrr-planner] Add a benchmark to evaluate self-collision checking

### DIFF
--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -31,6 +31,12 @@ urdf-rs = "0.6"
 [dev-dependencies]
 assert_approx_eq = "1.1"
 clap = { version = "3.1", features = ["derive"] }
+criterion = "0.3"
 nalgebra = "0.30"
+rand = "0.8"
 tracing-subscriber = "0.3"
 urdf-viz = "0.37"
+
+[[bench]]
+name = "self_collision_detection"
+harness = false

--- a/openrr-planner/benches/self_collision_detection.rs
+++ b/openrr-planner/benches/self_collision_detection.rs
@@ -1,0 +1,64 @@
+use std::{f64::consts::PI, path::Path};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use k::joint::Range;
+use na::RealField;
+use nalgebra as na;
+use openrr_planner::collision::{
+    create_all_collision_pairs, create_robot_collision_detector, RobotCollisionDetectorConfig,
+};
+
+fn generate_random_joint_angles_from_limits<T>(limits: &[Option<k::joint::Range<T>>]) -> Vec<T>
+where
+    T: RealField,
+{
+    limits
+        .iter()
+        .map(|range| match range {
+            Some(range) => {
+                (range.max.clone() - range.min.clone()) * na::convert(rand::random())
+                    + range.min.clone()
+            }
+            None => na::convert::<f64, T>(rand::random::<f64>() - 0.5) * na::convert(2.0 * PI),
+        })
+        .collect()
+}
+
+fn bench_check_self_collisions(c: &mut Criterion) {
+    let urdf_path = Path::new("sample.urdf");
+    let urdf_robot = urdf_rs::read_file(urdf_path).unwrap();
+    let robot = k::Chain::<f64>::from(&urdf_robot);
+    let collision_pairs = create_all_collision_pairs(&robot);
+
+    let robot_collision_detector = create_robot_collision_detector(
+        urdf_path,
+        RobotCollisionDetectorConfig::default(),
+        collision_pairs,
+    );
+    let limits = robot_collision_detector
+        .robot
+        .iter_joints()
+        .map(|j| j.limits)
+        .collect::<Vec<Option<Range<f64>>>>();
+
+    c.bench_function("bench_check_self_collisions", |b| {
+        b.iter(|| {
+            // Set random joint positions to the robot
+            let angles = generate_random_joint_angles_from_limits(&limits);
+            robot_collision_detector
+                .robot
+                .set_joint_positions(&angles)
+                .unwrap();
+            robot_collision_detector.robot.update_transforms();
+
+            // Check collisions
+            robot_collision_detector.self_collision_link_pairs();
+        });
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(100);
+    targets = bench_check_self_collisions);
+criterion_main!(benches);


### PR DESCRIPTION
This PR adds a benchmark to evaluate self-collision checking from from the viewpoint of computational time.

---
This PR will open after #612 is merged.