### PR TITLE
Add profile to reduce binary size in release mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   RUSTDOCFLAGS: -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  nightly: nightly-2021-11-22
+  nightly: nightly-2022-06-08
 
 jobs:
   windows:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,8 @@ openrr-plugin = { path = "openrr-plugin" }
 openrr-remote = { path = "openrr-remote" }
 openrr-sleep = { path = "openrr-sleep" }
 openrr-teleop = { path = "openrr-teleop" }
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = "symbols"


### PR DESCRIPTION

before (x86_64 macos)
```
 5477376 ../target/release/openrr_apps_config
20543392 ../target/release/openrr_apps_joint_position_sender
16224728 ../target/release/openrr_apps_robot_command
17416240 ../target/release/openrr_apps_robot_teleop
20423520 ../target/release/openrr_apps_velocity_sender
```

after (x86_64 macos)
```
 2914592 ../target/release/openrr_apps_config
12270000 ../target/release/openrr_apps_joint_position_sender
 9764920 ../target/release/openrr_apps_robot_command
10524688 ../target/release/openrr_apps_robot_teleop
12204144 ../target/release/openrr_apps_velocity_sender
```

refs:
- https://doc.rust-lang.org/cargo/reference/profiles.html
- https://github.com/johnthagen/min-sized-rust