### PR TITLE
Revert "Pin clap to ~3.1"

### DIFF
--- a/arci-speak-audio/Cargo.toml
+++ b/arci-speak-audio/Cargo.toml
@@ -16,6 +16,6 @@ tracing = { version = "0.1", features = ["log"] }
 tokio = { version = "1", features = ["sync", "parking_lot"] }
 
 [dev-dependencies]
-clap = { version = "~3.1", features = ["derive"] }
+clap = { version = "3.1", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing-subscriber = "0.3"

--- a/arci-speak-cmd/Cargo.toml
+++ b/arci-speak-cmd/Cargo.toml
@@ -14,6 +14,6 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["sync", "parking_lot"] }
 
 [dev-dependencies]
-clap = { version = "~3.1", features = ["derive"] }
+clap = { version = "3.1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.3"

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -28,8 +28,8 @@ arci-gamepad-gilrs = "0.0.6"
 arci-speak-audio = "0.0.6"
 arci-speak-cmd = "0.0.6"
 arci-urdf-viz = "0.0.6"
-clap = { version = "~3.1", features = ["derive"] }
-clap_complete = "~3.1"
+clap = { version = "3.1", features = ["derive"] }
+clap_complete = "3"
 k = "0.28"
 openrr-client = { version = "0.0.6", default-features = false }
 openrr-command = { version = "0.0.6", default-features = false }

--- a/openrr-command/Cargo.toml
+++ b/openrr-command/Cargo.toml
@@ -15,8 +15,8 @@ assimp = ["openrr-client/assimp"]
 [dependencies]
 arci = "0.0.6"
 async-recursion = "1.0"
-clap = { version = "~3.1", features = ["derive"] }
-clap_complete = "~3.1"
+clap = { version = "3.1", features = ["derive"] }
+clap_complete = "3"
 k = "0.28"
 openrr-client = { version = "0.0.6", default-features = false }
 rustyline = "9.0.0"

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -30,7 +30,7 @@ urdf-rs = "0.6"
 
 [dev-dependencies]
 assert_approx_eq = "1.1"
-clap = { version = "~3.1", features = ["derive"] }
+clap = { version = "3.1", features = ["derive"] }
 nalgebra = "0.30"
 tracing-subscriber = "0.3"
 urdf-viz = "0.37"

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -16,7 +16,7 @@ assimp = ["openrr-client/assimp"]
 arci = "0.0.6"
 async-trait = "0.1"
 auto_impl = "1.0.0"
-clap = { version = "~3.1", features = ["derive"] }
+clap = { version = "3.1", features = ["derive"] }
 k = "0.28"
 openrr-client = { version = "0.0.6", default-features = false }
 openrr-command = { version = "0.0.6", default-features = false }


### PR DESCRIPTION
This reverts commit 648a33f792669178ef884e5ab158164895d24168.

See https://github.com/openrr/openrr/pull/618#discussion_r898131417