### PR TITLE
[openrr-planner] Use AABB-based pruning in self-collision checking

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,3 +1,4 @@
+aabb
 abi
 actionlib
 adduser
@@ -13,6 +14,8 @@ attr
 backend
 bringup
 buf
+BVH
+BVT
 cdylib
 cfg
 checkbox

--- a/openrr-planner/src/collision/collision_detector.rs
+++ b/openrr-planner/src/collision/collision_detector.rs
@@ -188,6 +188,7 @@ where
         };
 
         // Check potential conflicts by an AABB-based sweep and prune algorithm
+        let start_time = Instant::now();
         for obj1 in obj_vec1 {
             let aabb1 = obj1.0.aabb(&(pose1 * obj1.1));
 
@@ -204,8 +205,6 @@ where
 
             bvt.visit(&mut visitor);
 
-            let mut last_time = Instant::now();
-
             if collector.is_empty() {
                 // a case without conflict possibility
                 break;
@@ -221,19 +220,21 @@ where
                     if dist < self.detector.prediction {
                         return Some((j1.to_owned(), j2.to_owned()));
                     }
-                    let elapsed = last_time.elapsed();
-                    *self
-                        .used_duration
-                        .entry(j1.to_owned())
-                        .or_insert_with(|| Duration::from_nanos(0)) += elapsed;
-                    *self
-                        .used_duration
-                        .entry(j2.to_owned())
-                        .or_insert_with(|| Duration::from_nanos(0)) += elapsed;
-                    last_time = Instant::now();
                 }
             }
         }
+
+        // Record the time used for this collision checking
+        let elapsed = start_time.elapsed();
+        *self
+            .used_duration
+            .entry(j1.to_owned())
+            .or_insert_with(|| Duration::from_nanos(0)) += elapsed;
+        *self
+            .used_duration
+            .entry(j2.to_owned())
+            .or_insert_with(|| Duration::from_nanos(0)) += elapsed;
+
         self.next()
     }
 }


### PR DESCRIPTION
This PR implements a sweep and prune algorithm with AABB (Axis Aligned Bounding Box), in order to accelerate self-collision checking. This implementation is based on bounding volume trees provided by ncollide3d (see https://www.ncollide.org/bounding_volumes/#spacial-partitioning ).

We can evaluate the improvement in computational time with `cargo bench`.
The results in my environment are as follows:

```
[Before]
bench_check_self_collisions                        
                        time:   [4.6853 ms 4.7762 ms 4.8687 ms]

[After (this PR is applied)]
bench_check_self_collisions                        
                        time:   [177.70 us 179.92 us 182.28 us]
                        change: [-96.318% -96.233% -96.146%] (p = 0.00 < 0.05)
                        Performance has improved.
```