### PR TITLE
[openrr-planner] Add a benchmark to evaluate environmental collision checking

### DIFF
--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -38,5 +38,5 @@ tracing-subscriber = "0.3"
 urdf-viz = "0.37"
 
 [[bench]]
-name = "self_collision_detection"
+name = "collision_detection"
 harness = false

--- a/openrr-planner/benches/collision_detection.rs
+++ b/openrr-planner/benches/collision_detection.rs
@@ -24,6 +24,41 @@ where
         .collect()
 }
 
+fn bench_check_environmental_collisions(c: &mut Criterion) {
+    let urdf_path = Path::new("sample.urdf");
+    let urdf_robot = urdf_rs::read_file(urdf_path).unwrap();
+    let robot = k::Chain::<f64>::from(&urdf_robot);
+    let collision_pairs = create_all_collision_pairs(&robot);
+
+    let robot_collision_detector = create_robot_collision_detector(
+        urdf_path,
+        RobotCollisionDetectorConfig::default(),
+        collision_pairs,
+    );
+    let limits = robot_collision_detector
+        .robot
+        .iter_joints()
+        .map(|j| j.limits)
+        .collect::<Vec<Option<Range<f64>>>>();
+
+    let obstacle = openrr_planner::FromUrdf::from_urdf_file("obstacles.urdf").unwrap();
+
+    c.bench_function("bench_check_environmental_collisions", |b| {
+        b.iter(|| {
+            // Set random joint positions to the robot
+            let angles = generate_random_joint_angles_from_limits(&limits);
+            robot_collision_detector
+                .robot
+                .set_joint_positions(&angles)
+                .unwrap();
+            robot_collision_detector.robot.update_transforms();
+
+            // Check collisions
+            robot_collision_detector.env_collision_link_names(&obstacle);
+        });
+    });
+}
+
 fn bench_check_self_collisions(c: &mut Criterion) {
     let urdf_path = Path::new("sample.urdf");
     let urdf_robot = urdf_rs::read_file(urdf_path).unwrap();
@@ -60,5 +95,5 @@ fn bench_check_self_collisions(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default().sample_size(100);
-    targets = bench_check_self_collisions);
+    targets = bench_check_environmental_collisions, bench_check_self_collisions);
 criterion_main!(benches);


### PR DESCRIPTION
This PR adds a benchmark to evaluate environmental-collision checking from the viewpoint of computational time, as same as #613 .