### PR TITLE
[openrr-planner] Fix a self-collision checking algorithm

### DIFF
--- a/openrr-planner/src/collision/collision_detector.rs
+++ b/openrr-planner/src/collision/collision_detector.rs
@@ -205,10 +205,7 @@ where
 
             bvt.visit(&mut visitor);
 
-            if collector.is_empty() {
-                // a case without conflict possibility
-                break;
-            } else {
+            if !collector.is_empty() {
                 // Check conflicts precisely
                 for index in collector {
                     let obj2 = &obj_vec2[index];


### PR DESCRIPTION
This PR corrects the mistake in #630 : if there is no potential conflict in each for-loop, the procedure need to go to the next loop. 

Instead of replacing `break` into `continue`, this PR removes `break`, since it lies on the last part of the loop.