### PR TITLE
Add function to edit RobotCommand

### DIFF
--- a/openrr-command/src/robot_command.rs
+++ b/openrr-command/src/robot_command.rs
@@ -481,6 +481,35 @@ pub fn load_command_file_and_filter(file_path: PathBuf) -> Result<Vec<String>, O
         .collect())
 }
 
+pub fn robot_command_editor(robot_command: &RobotCommand) -> RobotCommand {
+    match robot_command {
+        RobotCommand::ExecuteCommand { command } => {
+            let mut concatenation = false;
+            let mut command_vector: Vec<String> = Vec::new();
+
+            for element in command {
+                let command_element = element.replace('\"', "");
+                if concatenation {
+                    let mut new_command = command_vector.pop().unwrap() + " ";
+                    new_command += command_element.as_str();
+                    command_vector.push(new_command);
+                } else {
+                    command_vector.push(command_element.to_string());
+                }
+                if element.match_indices('\"').count() == 1 {
+                    concatenation = !concatenation;
+                }
+            }
+            RobotCommand::ExecuteCommand {
+                command: command_vector,
+            }
+        }
+        _ => {
+            panic!("not supported {robot_command:?}");
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/openrr-teleop/src/robot_command_executor.rs
+++ b/openrr-teleop/src/robot_command_executor.rs
@@ -7,7 +7,7 @@ use arci::{
 use async_trait::async_trait;
 use clap::Parser;
 use openrr_client::{resolve_relative_path, ArcRobotClient};
-use openrr_command::{load_command_file_and_filter, RobotCommand};
+use openrr_command::{load_command_file_and_filter, robot_command_editor, RobotCommand};
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -139,7 +139,10 @@ where
                             }
                             let command_parsed_iter = command.split_whitespace();
                             // Parse the command
-                            let read_opt = RobotCommand::parse_from(command_parsed_iter);
+                            let mut read_opt = RobotCommand::parse_from(command_parsed_iter);
+                            if let RobotCommand::ExecuteCommand { command: _ } = read_opt {
+                                read_opt = robot_command_editor(&read_opt);
+                            }
                             // Execute the parsed command
                             info!("Executing {command} {i}/{commands_len}");
 


### PR DESCRIPTION
The purpose of this PR is to fix #643

Edit RobotCommand to remove `\"` and recover ` ` (space) that are required for the argument in the string.