### PR TITLE
Remove unnecessary allowed lints

### DIFF
--- a/arci-gamepad-gilrs/src/lib.rs
+++ b/arci-gamepad-gilrs/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 use std::{
     collections::HashMap,

--- a/arci-gamepad-keyboard/src/lib.rs
+++ b/arci-gamepad-keyboard/src/lib.rs
@@ -1,9 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg(unix)]
 #![warn(missing_docs, rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 use std::{
     collections::HashMap,

--- a/arci-ros/src/lib.rs
+++ b/arci-ros/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod cmd_vel_move_base;
 mod error;

--- a/arci-ros2/src/lib.rs
+++ b/arci-ros2/src/lib.rs
@@ -8,9 +8,6 @@
     single_use_lifetimes,
     unreachable_pub
 )]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod cmd_vel_move_base;
 mod navigation;

--- a/arci-speak-audio/src/lib.rs
+++ b/arci-speak-audio/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 use std::{
     collections::HashMap,

--- a/arci-speak-cmd/src/lib.rs
+++ b/arci-speak-cmd/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs, rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 use std::{io, process::Command};
 

--- a/arci-urdf-viz/src/lib.rs
+++ b/arci-urdf-viz/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod client;
 mod utils;

--- a/arci/src/lib.rs
+++ b/arci/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod clients;
 mod error;

--- a/openrr-apps/src/lib.rs
+++ b/openrr-apps/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod error;
 mod robot_config;

--- a/openrr-client/src/lib.rs
+++ b/openrr-client/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod clients;
 mod error;

--- a/openrr-command/src/lib.rs
+++ b/openrr-command/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod error;
 mod robot_command;

--- a/openrr-config/src/lib.rs
+++ b/openrr-config/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs, rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod overwrite;
 pub use overwrite::{overwrite, overwrite_str};

--- a/openrr-gui/src/lib.rs
+++ b/openrr-gui/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod error;
 mod joint_position_sender;

--- a/openrr-planner/src/lib.rs
+++ b/openrr-planner/src/lib.rs
@@ -16,9 +16,6 @@ limitations under the License.
 
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod errors;
 

--- a/openrr-plugin/src/lib.rs
+++ b/openrr-plugin/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod proxy;
 

--- a/openrr-remote/src/lib.rs
+++ b/openrr-remote/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations, rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod pb {
     include!("generated/arci.rs");

--- a/openrr-sleep/src/lib.rs
+++ b/openrr-sleep/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod scoped_sleep;
 

--- a/openrr-teleop/src/lib.rs
+++ b/openrr-teleop/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 mod control_node;
 mod control_nodes_config;

--- a/openrr/src/lib.rs
+++ b/openrr/src/lib.rs
@@ -1,8 +1,5 @@
 #![doc = include_str!("../../README.md")]
 #![warn(rust_2018_idioms)]
-// This lint is unable to correctly determine if an atomic is sufficient to replace the mutex use.
-// https://github.com/rust-lang/rust-clippy/issues/4295
-#![allow(clippy::mutex_atomic)]
 
 pub mod apps {
     pub use openrr_apps::*;


### PR DESCRIPTION
clippy::mutex_atomic has been moved to the allowed by default group in Rust 1.60 (https://github.com/rust-lang/rust-clippy/pull/8260).