### PR TITLE
Fix format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - run: cargo fmt --all --check
       - name: Format YAML
-        run: prettier -c $(git ls-files '*.yml') || echo "::warning::Please run \`prettier -l -w \$(git ls-files '*.yml')\` to fix format"
+        run: prettier -c $(git ls-files '*.yml') || (echo "::warning::Please run \`prettier -l -w \$(git ls-files '*.yml')\` to fix format" && exit 1)
         if: always()
 
   clippy:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -3,8 +3,8 @@
 name: Spell checking
 on:
   push:
-    branches: ["**"]
-    tags-ignore: ["**"]
+    branches: ['**']
+    tags-ignore: ['**']
   pull_request_target:
   issue_comment:
     types: [created]
@@ -25,13 +25,13 @@ jobs:
       # note: If you use only_check_changed_files, you do not want cancel-in-progress
       cancel-in-progress: true
     steps:
-    - name: check-spelling
-      id: spelling
-      uses: check-spelling/check-spelling@v0.0.20
-      with:
-        suppress_push_for_open_pull_request: 1
-        checkout: true
-        post_comment: 0
+      - name: check-spelling
+        id: spelling
+        uses: check-spelling/check-spelling@v0.0.20
+        with:
+          suppress_push_for_open_pull_request: 1
+          checkout: true
+          post_comment: 0
 
   comment:
     name: Report
@@ -42,8 +42,8 @@ jobs:
       pull-requests: write
     if: (success() || failure()) && needs.spelling.outputs.followup
     steps:
-    - name: comment
-      uses: check-spelling/check-spelling@v0.0.20
-      with:
-        checkout: true
-        task: ${{ needs.spelling.outputs.followup }}
+      - name: comment
+        uses: check-spelling/check-spelling@v0.0.20
+        with:
+          checkout: true
+          task: ${{ needs.spelling.outputs.followup }}


### PR DESCRIPTION
Currently, when the format check of yaml failed, only a warning was displayed and CI did not fail.

<img width="563" alt="log" src="https://user-images.githubusercontent.com/43724913/182133968-0c6f0d8c-45ee-4e55-8bed-5ee06b28107f.png">
