### PR TITLE
[openrr-command] Fix typo

### DIFF
--- a/openrr-command/src/robot_command.rs
+++ b/openrr-command/src/robot_command.rs
@@ -110,7 +110,7 @@ pub enum RobotCommand {
         #[clap(short, long, default_value = "100.0")]
         timeout_secs: f64,
     },
-    /// Cancel navigation gaol.
+    /// Cancel navigation goal.
     CancelNavigationGoal,
     /// Send base velocity.
     SendBaseVelocity {


### PR DESCRIPTION
This typo is appeared when executing `openrr_apps_robot_command --help`.