### PR TITLE
[openrr-apps] Update sample config for twin arm sample model

### DIFF
--- a/openrr-apps/config/sample_robot/sample_robot_speak_audio_sine.txt
+++ b/openrr-apps/config/sample_robot/sample_robot_speak_audio_sine.txt
@@ -1,0 +1,1 @@
+openrr_apps_robot_command speak audio sine

--- a/openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml
+++ b/openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml
@@ -1,5 +1,5 @@
 [[urdf_viz_clients_configs]]
-name = "arm"
+name = "l_arm"
 joint_names = [
     "l_shoulder_yaw",
     "l_shoulder_pitch",
@@ -20,23 +20,67 @@ joint_position_limits = [
     { lower = -2.0, upper = 2.0 },
 ]
 
+[[urdf_viz_clients_configs]]
+name = "r_arm"
+joint_names = [
+    "r_shoulder_yaw",
+    "r_shoulder_pitch",
+    "r_shoulder_roll",
+    "r_elbow_pitch",
+    "r_wrist_yaw",
+    "r_wrist_pitch",
+]
+wrap_with_joint_position_limiter = true
+# If joint_position_limits is not specified, limits will be got from URDF.
+# The following values are the same as if getting limits from URDF.
+joint_position_limits = [
+    { lower = -3.0, upper = 3.0 },
+    { lower = -2.0, upper = 1.5 },
+    { lower = -1.5, upper = 2.0 },
+    { lower = -2.0, upper = 1.5 },
+    { lower = -3.0, upper = 3.0 },
+    { lower = -2.0, upper = 2.0 },
+]
+
 [openrr_clients_config]
 urdf_path = "../../openrr-planner/sample.urdf"
-self_collision_check_pairs = ["l_shoulder_yaw:l_gripper_linear1"]
+self_collision_check_pairs = [
+    "l_shoulder_yaw:l_gripper_linear1",
+    "r_shoulder_yaw:r_gripper_linear1",
+]
 
+# Client config for left arm
 [[openrr_clients_config.collision_check_clients_configs]]
-name = "arm_collision_checked"
-client_name = "arm"
+name = "l_arm_collision_checked"
+client_name = "l_arm"
 
 [[openrr_clients_config.ik_clients_configs]]
-name = "arm_ik"
-client_name = "arm_collision_checked"
-solver_name = "arm_ik_solver"
+name = "l_arm_ik"
+client_name = "l_arm_collision_checked"
+solver_name = "l_arm_ik_solver"
 
 [[openrr_clients_config.joints_poses]]
 pose_name = "zero"
-client_name = "arm_collision_checked"
+client_name = "l_arm_collision_checked"
 positions = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
-[openrr_clients_config.ik_solvers_configs.arm_ik_solver]
+[openrr_clients_config.ik_solvers_configs.l_arm_ik_solver]
 ik_target = "l_tool_fixed"
+
+# Client config for right arm
+[[openrr_clients_config.collision_check_clients_configs]]
+name = "r_arm_collision_checked"
+client_name = "r_arm"
+
+[[openrr_clients_config.ik_clients_configs]]
+name = "r_arm_ik"
+client_name = "r_arm_collision_checked"
+solver_name = "r_arm_ik_solver"
+
+[[openrr_clients_config.joints_poses]]
+pose_name = "zero"
+client_name = "r_arm_collision_checked"
+positions = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+[openrr_clients_config.ik_solvers_configs.r_arm_ik_solver]
+ik_target = "r_tool_fixed"

--- a/openrr-apps/config/sample_robot_client_config_for_urdf_viz_with_multiple_speaker.toml
+++ b/openrr-apps/config/sample_robot_client_config_for_urdf_viz_with_multiple_speaker.toml
@@ -1,5 +1,5 @@
 [[urdf_viz_clients_configs]]
-name = "arm"
+name = "l_arm"
 joint_names = [
     "l_shoulder_yaw",
     "l_shoulder_pitch",
@@ -7,6 +7,17 @@ joint_names = [
     "l_elbow_pitch",
     "l_wrist_yaw",
     "l_wrist_pitch",
+]
+
+[[urdf_viz_clients_configs]]
+name = "r_arm"
+joint_names = [
+    "r_shoulder_yaw",
+    "r_shoulder_pitch",
+    "r_shoulder_roll",
+    "r_elbow_pitch",
+    "r_wrist_yaw",
+    "r_wrist_pitch",
 ]
 
 [speak_configs."print"]
@@ -24,21 +35,41 @@ sine = "../audio/sine.mp3"
 
 [openrr_clients_config]
 urdf_path = "../../openrr-planner/sample.urdf"
-self_collision_check_pairs = ["l_shoulder_yaw:l_gripper_linear1"]
+self_collision_check_pairs = [
+    "l_shoulder_yaw:l_gripper_linear1",
+    "r_shoulder_yaw:r_gripper_linear1",
+]
 
 [[openrr_clients_config.collision_check_clients_configs]]
-name = "arm_collision_checked"
-client_name = "arm"
+name = "l_arm_collision_checked"
+client_name = "l_arm"
 
 [[openrr_clients_config.ik_clients_configs]]
-name = "arm_ik"
-client_name = "arm_collision_checked"
-solver_name = "arm_ik_solver"
+name = "l_arm_ik"
+client_name = "l_arm_collision_checked"
+solver_name = "l_arm_ik_solver"
 
 [[openrr_clients_config.joints_poses]]
 pose_name = "zero"
-client_name = "arm_collision_checked"
+client_name = "l_arm_collision_checked"
 positions = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
-[openrr_clients_config.ik_solvers_configs.arm_ik_solver]
+[openrr_clients_config.ik_solvers_configs.l_arm_ik_solver]
 ik_target = "l_tool_fixed"
+
+[[openrr_clients_config.collision_check_clients_configs]]
+name = "r_arm_collision_checked"
+client_name = "r_arm"
+
+[[openrr_clients_config.ik_clients_configs]]
+name = "r_arm_ik"
+client_name = "r_arm_collision_checked"
+solver_name = "r_arm_ik_solver"
+
+[[openrr_clients_config.joints_poses]]
+pose_name = "zero"
+client_name = "r_arm_collision_checked"
+positions = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+[openrr_clients_config.ik_solvers_configs.r_arm_ik_solver]
+ik_target = "r_tool_fixed"

--- a/openrr-apps/config/sample_teleop_config_urdf_viz_with_multiple_speaker.toml
+++ b/openrr-apps/config/sample_teleop_config_urdf_viz_with_multiple_speaker.toml
@@ -1,4 +1,4 @@
-robot_config_path = "sample_robot_client_config_for_urdf_viz.toml"
+robot_config_path = "sample_robot_client_config_for_urdf_viz_with_multiple_speaker.toml"
 
 [control_nodes_config]
 move_base_mode = "base"
@@ -30,3 +30,7 @@ client_name = "r_arm_collision_checked"
 
 [control_nodes_config.joy_joint_teleop_configs.config]
 mode = "r_arm"
+
+[[control_nodes_config.command_configs]]
+name = "audio sine"
+file_path = "sample_robot/sample_robot_speak_audio_sine.txt"


### PR DESCRIPTION
The other day, the sample model `./openrr-planner/sample.urdf` was updated to twin arm robot. But the sample configs in `openrr-apps` have not updated.