### PR TITLE
Apply cargo clippy's warnings

### DIFF
--- a/openrr-command/src/robot_command.rs
+++ b/openrr-command/src/robot_command.rs
@@ -477,7 +477,12 @@ pub fn load_command_file_and_filter(file_path: PathBuf) -> Result<Vec<String>, O
             let command_parsed_iter = command.split_whitespace();
             // Ignore empty lines and comment lines
             command_parsed_iter.clone().count() > 0
-                && command_parsed_iter.clone().next().unwrap().find('#') == None
+                && command_parsed_iter
+                    .clone()
+                    .next()
+                    .unwrap()
+                    .find('#')
+                    .is_none()
         })
         .collect())
 }

--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -232,7 +232,7 @@ fn test_create_self_collision_checker() {
     let using_joints = k::SerialChain::from_end(l_shoulder_yaw_node);
     let using_joint_names = using_joints
         .iter_joints()
-        .map(|j| (*j).name.to_owned())
+        .map(|j| j.name.to_owned())
         .collect::<Vec<String>>();
 
     assert!(self_collision_checker


### PR DESCRIPTION
This PR just applies the changes suggested by clippy to deal with the following warnings:

```
warning: deref which would be done by auto-deref
   --> openrr-planner/src/collision/self_collision_checker.rs:235:18
    |
235 |         .map(|j| (*j).name.to_owned())
    |                  ^^^^ help: try this: `j`
    |
    = note: `#[warn(clippy::explicit_auto_deref)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

warning: binary comparison to literal `Option::None`
   --> openrr-command/src/robot_command.rs:480:20
    |
480 |                 && command_parsed_iter.clone().next().unwrap().find('#') == None
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `Option::is_none()` instead: `command_parsed_iter.clone().next().unwrap().find('#').is_none()`
    |
    = note: `#[warn(clippy::partialeq_to_none)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#partialeq_to_none
```