### PR TITLE
Fix CI failure on melodic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,17 @@ jobs:
           # Swatinem/rust-cache does not recognize the matrix.
           key: ros1_openrr_apps-${{ matrix.distro }}
       - run: ci/ubuntu-setup-lld.sh
+      # See ci/ubuntu-install-dependencies.sh
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades \
+            libudev1=237-3ubuntu10.53 \
+            libudev-dev=237-3ubuntu10.53 \
+            libasound2-dev \
+            libxkbcommon-dev
+        if: matrix.distro == 'melodic'
       - run: ci/ubuntu-install-dependencies.sh
+        if: matrix.distro != 'melodic'
       - name: cargo test
         shell: bash -ieo pipefail {0}
         working-directory: openrr-apps


### PR DESCRIPTION
https://github.com/openrr/openrr/runs/8177522904?check_suite_focus=true#logs
```
The following packages have unmet dependencies:
 libudev-dev : Depends: libudev1 (= 237-3ubuntu10.53) but 237-3ubuntu10.54 is to be installed
E: Unable to correct problems, you have held broken packages.
```