### PR TITLE
Remove manual installation of llvm-tools-preview

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,8 +36,6 @@ jobs:
             ros-noetic-ros-base ros-noetic-joy ros-noetic-pr2-description \
             ros-foxy-ros-core ros-foxy-geometry-msgs ros-foxy-nav2-msgs ros-foxy-ros2-control ros-foxy-ros2-controllers
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov


### PR DESCRIPTION
Since cargo-llvm-cov [0.5.0](https://github.com/taiki-e/cargo-llvm-cov/releases/tag/v0.5.0), you can omit this.