### PR TITLE
[openrr-plugin] Ignore repr_transparent_external_private_fields lint

### DIFF
--- a/openrr-plugin/src/lib.rs
+++ b/openrr-plugin/src/lib.rs
@@ -2,6 +2,8 @@
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 // buggy: https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+derive_partial_eq_without_eq
 #![allow(clippy::derive_partial_eq_without_eq)]
+// https://github.com/rodrimati1992/abi_stable_crates/issues/94
+#![allow(repr_transparent_external_private_fields)]
 
 mod proxy;
 


### PR DESCRIPTION
This is an upstream issue: https://github.com/rodrimati1992/abi_stable_crates/issues/94

```
error: zero-sized fields in repr(transparent) cannot contain external non-exhaustive types
  --> openrr-plugin/src/gen/proxy.rs:10:1
   |
10 | #[sabi_trait]
   | ^^^^^^^^^^^^^
   |
   = note: `-D repr-transparent-external-private-fields` implied by `-D warnings`
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
   = note: this struct contains `UnsafeIgnoredType<SyncSend>`, which contains private fields, and makes it not a breaking change to become non-zero-sized in the future.
   = note: this error originates in the attribute macro `sabi_trait` (in Nightly builds, run with -Z macro-backtrace for more info)
```