### PR TITLE
Resolve clippy warnings for needless borrowing

### DIFF
--- a/openrr-apps/src/bin/robot_command.rs
+++ b/openrr-apps/src/bin/robot_command.rs
@@ -117,10 +117,10 @@ mod tests {
     #[test]
     fn parse_args() {
         let bin = env!("CARGO_BIN_NAME");
-        assert!(RobotCommandArgs::try_parse_from(&[bin]).is_ok());
-        assert!(RobotCommandArgs::try_parse_from(&[bin, "--show-default-config"]).is_ok());
-        assert!(RobotCommandArgs::try_parse_from(&[bin, "--config-path", "path", "list"]).is_ok());
-        assert!(RobotCommandArgs::try_parse_from(&[
+        assert!(RobotCommandArgs::try_parse_from([bin]).is_ok());
+        assert!(RobotCommandArgs::try_parse_from([bin, "--show-default-config"]).is_ok());
+        assert!(RobotCommandArgs::try_parse_from([bin, "--config-path", "path", "list"]).is_ok());
+        assert!(RobotCommandArgs::try_parse_from([
             bin,
             "--show-default-config",
             "--config-path",
@@ -158,7 +158,7 @@ mod tests {
             let config_path_arg = "--config-path=".to_string() + config_path.to_str().unwrap();
             let sample_command_path = manifest_dir.join(command_path);
 
-            let sample_command = RobotCommandArgs::try_parse_from(&[
+            let sample_command = RobotCommandArgs::try_parse_from([
                 bin,
                 config_path_arg.as_str(),
                 "load_commands",

--- a/openrr-apps/src/bin/robot_teleop.rs
+++ b/openrr-apps/src/bin/robot_teleop.rs
@@ -200,10 +200,10 @@ mod tests {
     #[test]
     fn parse_args() {
         let bin = env!("CARGO_BIN_NAME");
-        assert!(RobotTeleopArgs::try_parse_from(&[bin]).is_ok());
-        assert!(RobotTeleopArgs::try_parse_from(&[bin, "--show-default-config"]).is_ok());
-        assert!(RobotTeleopArgs::try_parse_from(&[bin, "--config-path", "path"]).is_ok());
-        assert!(RobotTeleopArgs::try_parse_from(&[
+        assert!(RobotTeleopArgs::try_parse_from([bin]).is_ok());
+        assert!(RobotTeleopArgs::try_parse_from([bin, "--show-default-config"]).is_ok());
+        assert!(RobotTeleopArgs::try_parse_from([bin, "--config-path", "path"]).is_ok());
+        assert!(RobotTeleopArgs::try_parse_from([
             bin,
             "--show-default-config",
             "--config-path",

--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -88,8 +88,7 @@ where
             ik_solvers,
         ) = if let Some(urdf_full_path) = config.urdf_full_path() {
             debug!("Loading {urdf_full_path:?}");
-            let full_chain_for_collision_checker =
-                Arc::new(Chain::from_urdf_file(&urdf_full_path)?);
+            let full_chain_for_collision_checker = Arc::new(Chain::from_urdf_file(urdf_full_path)?);
 
             let collision_check_clients = create_collision_check_clients(
                 urdf_full_path,

--- a/openrr-planner/examples/reach.rs
+++ b/openrr-planner/examples/reach.rs
@@ -56,7 +56,7 @@ impl CollisionAvoidApp {
         self_collision_pairs: Vec<(String, String)>,
     ) -> Self {
         let reference_robot = Arc::new(k::Chain::from_urdf_file(robot_path).unwrap());
-        let planner = openrr_planner::JointPathPlannerBuilder::from_urdf_file(&robot_path)
+        let planner = openrr_planner::JointPathPlannerBuilder::from_urdf_file(robot_path)
             .unwrap()
             .collision_check_margin(0.01f64)
             .reference_robot(reference_robot.clone())
@@ -67,7 +67,7 @@ impl CollisionAvoidApp {
         let planner = openrr_planner::JointPathPlannerWithIk::new(planner, solver);
         let (mut viewer, mut window) = urdf_viz::Viewer::new("openrr_planner: example reach");
         let urdf_robot =
-            urdf_rs::utils::read_urdf_or_xacro(&robot_path).expect("robot file not found");
+            urdf_rs::utils::read_urdf_or_xacro(robot_path).expect("robot file not found");
         viewer.add_robot_with_base_dir(&mut window, &urdf_robot, robot_path.parent());
         viewer.add_axis_cylinders(&mut window, "origin", 1.0);
 

--- a/openrr-plugin/benches/proxy.rs
+++ b/openrr-plugin/benches/proxy.rs
@@ -293,7 +293,7 @@ struct TestClientConfig {
     }
 
     let status = Command::new("cargo")
-        .args(&["build", "--release", "--manifest-path"])
+        .args(["build", "--release", "--manifest-path"])
         .arg(&tmpdir_path.join("Cargo.toml"))
         .status()?;
     assert!(status.success());

--- a/tools/codegen/src/main.rs
+++ b/tools/codegen/src/main.rs
@@ -98,7 +98,7 @@ fn header() -> String {
 fn write(path: &Path, contents: TokenStream) -> Result<()> {
     let mut out = header().into_bytes();
     out.extend_from_slice(prettyplease::unparse(&syn::parse2(contents).unwrap()).as_bytes());
-    if path.is_file() && fs::read(&path)? == out {
+    if path.is_file() && fs::read(path)? == out {
         return Ok(());
     }
     fs::write(path, out)?;


### PR DESCRIPTION
This PR partially resolves #688 , focusing on `clippy::needless_borrow`.