### PR TITLE
[openrr-planner] Capsulize RobotCollisionDetector in JointPathPlanner

### DIFF
--- a/openrr-client/src/clients/collision_avoidance_client.rs
+++ b/openrr-client/src/clients/collision_avoidance_client.rs
@@ -121,8 +121,7 @@ pub fn create_collision_avoidance_client<P: AsRef<Path>>(
     );
 
     let nodes = planner
-        .robot_collision_detector
-        .robot
+        .collision_check_robot()
         .iter()
         .map(|node| (*node).clone())
         .collect();

--- a/openrr-planner/src/planner/ik_planner.rs
+++ b/openrr-planner/src/planner/ik_planner.rs
@@ -86,9 +86,7 @@ where
     }
 
     pub fn colliding_link_names(&self, objects: &Compound<T>) -> Vec<String> {
-        self.path_planner
-            .robot_collision_detector
-            .env_collision_link_names(objects)
+        self.path_planner.env_collision_link_names(objects)
     }
 
     /// Solve IK and get the path to the final joint positions
@@ -118,8 +116,7 @@ where
 
         let end_link = self
             .path_planner
-            .robot_collision_detector
-            .robot
+            .collision_check_robot()
             .find(target_name)
             .ok_or_else(|| Error::NotFound(target_name.to_owned()))?;
         let arm = k::SerialChain::from_end(end_link);

--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -36,7 +36,7 @@ where
     /// Robot for reference (read only and assumed to hold the latest full states)
     reference_robot: Arc<k::Chain<N>>,
     /// Robot collision detector
-    pub robot_collision_detector: RobotCollisionDetector<N>,
+    robot_collision_detector: RobotCollisionDetector<N>,
     /// Unit length for searching
     ///
     /// If the value is large, the path become sparse.
@@ -262,6 +262,23 @@ where
             .iter_joints()
             .map(|j| j.name.clone())
             .collect()
+    }
+
+    // Get the robot model used for collision checking
+    pub fn collision_check_robot(&self) -> &k::Chain<N> {
+        &self.robot_collision_detector.robot
+    }
+
+    /// Get names of links colliding with environmental objects
+    /// objects: environmental objects
+    pub fn env_collision_link_names(&self, objects: &Compound<N>) -> Vec<String> {
+        self.robot_collision_detector
+            .env_collision_link_names(objects)
+    }
+
+    /// Get names of self-colliding links
+    pub fn self_collision_link_pairs(&self) -> Vec<(String, String)> {
+        self.robot_collision_detector.self_collision_link_pairs()
     }
 }
 


### PR DESCRIPTION
This PR makes robot_collision_detector, a field of JointPathPlanner, private. Along with this visibility change, this PR also adds some APIs to access information the detector only holds.

This PR is related to https://github.com/openrr/openrr/pull/671#discussion_r964365305