### PR TITLE
Temporarily disable ROS2 foxy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - distro: foxy
-            os: ubuntu-20.04
+          # TODO: failed to build
+          # - distro: foxy
+          #   os: ubuntu-20.04
           - distro: humble
             os: ubuntu-22.04
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This is currently failing to build: https://github.com/openrr/openrr/actions/runs/3152588967/jobs/5128002998