### PR TITLE
[openrr-planner] Enhance tests for JointPathPlanner

### DIFF
--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -32,6 +32,7 @@ urdf-rs = "0.6"
 assert_approx_eq = "1.1"
 clap = { version = "3.1", features = ["derive"] }
 criterion = "0.4"
+flaky_test = "0.1"
 nalgebra = "0.30"
 rand = "0.8"
 tracing-subscriber = "0.3"


### PR DESCRIPTION
This PR ...

- improves the test coverage
- introduces `flaky_test` to test planning functions using RRTs, which potentially fail