### PR TITLE
[openrr-client] Correct JointAvoidanceClient registration

### DIFF
--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -105,6 +105,10 @@ where
                 full_chain_for_collision_checker.clone(),
             );
 
+            for (name, client) in &collision_avoidance_clients {
+                all_joint_trajectory_clients.insert(name.to_owned(), client.clone());
+            }
+
             let collision_check_clients = create_collision_check_clients(
                 urdf_full_path,
                 &config.self_collision_check_pairs,

--- a/openrr-client/tests/test_robot_client.rs
+++ b/openrr-client/tests/test_robot_client.rs
@@ -288,7 +288,7 @@ async fn test_joint_positions() {
     assert_eq!(client_names[0], "arm");
 
     let client_names = client.joint_trajectory_clients_names();
-    assert_eq!(client_names.len(), 3);
+    assert_eq!(client_names.len(), 4);
 }
 
 #[test]
@@ -306,7 +306,7 @@ fn test_manipulation_accessors() {
     .collect();
     let client = new_joint_client(joint_names);
     let hash_joint_trajectory_clients = client.joint_trajectory_clients();
-    assert_eq!(hash_joint_trajectory_clients.keys().len(), 3);
+    assert_eq!(hash_joint_trajectory_clients.keys().len(), 4);
 
     let hash_collision_avoidance_clients = client.collision_avoidance_clients();
     assert_eq!(hash_collision_avoidance_clients.keys().len(), 1);


### PR DESCRIPTION
This PR is a supplement of #697 .

Although the preceding PR tried to integrate JointAvoidanceClient to RobotClient, it missed to register JointAvoidanceClient as JointTrajectoryClient. This PR fixes the mistake and enables JointAvoidanceClient-s to send position commands with planning.

