### PR TITLE
Refactor SelfCollisionChecker

### DIFF
--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -140,9 +140,9 @@ where
             if let Some(names) = self_checker.next() {
                 return Err(Error::Collision {
                     point: match i {
-                        0 => UnfeasibleTrajectory::StartPoint,
-                        index if index == last_index => UnfeasibleTrajectory::GoalPoint,
-                        _ => UnfeasibleTrajectory::Waypoint,
+                        0 => UnfeasibleTrajectoryPoint::Start,
+                        index if index == last_index => UnfeasibleTrajectoryPoint::Goal,
+                        _ => UnfeasibleTrajectoryPoint::WayPoint,
                     },
                     collision_link_names: vec![names.0, names.1],
                 });

--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -117,7 +117,8 @@ where
             .set_joint_positions_clamped(self.reference_robot.joint_positions().as_slice());
 
         // Check the partial trajectory
-        for v in trajectory {
+        let last_index = trajectory.len() - 1;
+        for (i, v) in trajectory.iter().enumerate() {
             match using_joint_names {
                 Some(joint_names) => {
                     for (joint_name, position) in joint_names.iter().zip(v.position.clone()) {
@@ -137,7 +138,11 @@ where
             let mut self_checker = self.robot_collision_detector.detect_self();
             if let Some(names) = self_checker.next() {
                 return Err(Error::Collision {
-                    point: UnfeasibleTrajectory::StartPoint,
+                    point: match i {
+                        0 => UnfeasibleTrajectory::StartPoint,
+                        index if index == last_index => UnfeasibleTrajectory::GoalPoint,
+                        _ => UnfeasibleTrajectory::Waypoint,
+                    },
                     collision_link_names: vec![names.0, names.1],
                 });
             }

--- a/openrr-planner/src/errors.rs
+++ b/openrr-planner/src/errors.rs
@@ -19,10 +19,10 @@ use std::io;
 use thiserror::Error;
 
 #[derive(Debug)]
-pub enum UnfeasibleTrajectory {
-    StartPoint,
-    Waypoint,
-    GoalPoint,
+pub enum UnfeasibleTrajectoryPoint {
+    Start,
+    WayPoint,
+    Goal,
 }
 
 /// Error for `openrr_planner`
@@ -35,12 +35,12 @@ pub enum Error {
     NotFound(String),
     #[error("Collision error: {collision_link_names:?} is colliding ({point:?})")]
     Collision {
-        point: UnfeasibleTrajectory,
+        point: UnfeasibleTrajectoryPoint,
         collision_link_names: Vec<String>,
     },
     #[error("Self Collision error: {collision_link_names:?} is colliding ({point:?})")]
     SelfCollision {
-        point: UnfeasibleTrajectory,
+        point: UnfeasibleTrajectoryPoint,
         collision_link_names: Vec<(String, String)>,
     },
     #[error("Interpolation error: {:?}", .0)]

--- a/openrr-planner/src/errors.rs
+++ b/openrr-planner/src/errors.rs
@@ -21,6 +21,7 @@ use thiserror::Error;
 #[derive(Debug)]
 pub enum UnfeasibleTrajectory {
     StartPoint,
+    Waypoint,
     GoalPoint,
 }
 

--- a/openrr-planner/src/funcs.rs
+++ b/openrr-planner/src/funcs.rs
@@ -195,3 +195,24 @@ where
     let limits = robot.iter_joints().map(|j| j.limits).collect();
     robot.set_joint_positions(&generate_random_joint_positions_from_limits(&limits))
 }
+
+/// Create a sub-chain of the collision check model by a name list
+pub fn create_chain_from_joint_names<N>(
+    robot: &k::Chain<N>,
+    joint_names: &[String],
+) -> Result<k::Chain<N>>
+where
+    N: RealField + num_traits::Float + k::SubsetOf<f64>,
+{
+    let nodes = joint_names
+        .iter()
+        .map(|joint_name| {
+            robot
+                .find(joint_name)
+                .ok_or_else(|| Error::NotFound(joint_name.to_owned()))
+                .unwrap()
+                .clone()
+        })
+        .collect::<Vec<k::Node<N>>>();
+    Ok(k::Chain::from_nodes(nodes))
+}

--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -95,21 +95,6 @@ where
         }
     }
 
-    /// Create a sub-chain of the collision check model by a name list
-    fn create_chain_from_names(&self, using_joint_names: &[String]) -> Result<k::Chain<N>> {
-        let nodes = using_joint_names
-            .iter()
-            .map(|joint_name| {
-                self.collision_check_robot()
-                    .find(joint_name)
-                    .ok_or_else(|| Error::NotFound(joint_name.to_owned()))
-                    .unwrap()
-                    .clone()
-            })
-            .collect::<Vec<k::Node<N>>>();
-        Ok(k::Chain::from_nodes(nodes))
-    }
-
     /// Plan the sequence of joint angles of `using_joints`
     ///
     /// # Arguments
@@ -127,7 +112,8 @@ where
     ) -> Result<Vec<Vec<N>>> {
         self.sync_joint_positions_with_reference();
 
-        let using_joints = self.create_chain_from_names(using_joint_names)?;
+        let using_joints =
+            create_chain_from_joint_names(self.collision_check_robot(), using_joint_names)?;
         let limits = using_joints.iter_joints().map(|j| j.limits).collect();
         let step_length = self.step_length;
         let max_try = self.max_try;
@@ -192,7 +178,8 @@ where
     ) -> Result<Vec<Vec<N>>> {
         self.sync_joint_positions_with_reference();
 
-        let using_joints = self.create_chain_from_names(using_joint_names)?;
+        let using_joints =
+            create_chain_from_joint_names(self.collision_check_robot(), using_joint_names)?;
         let limits = using_joints.iter_joints().map(|j| j.limits).collect();
         let step_length = self.step_length;
         let max_try = self.max_try;

--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -123,14 +123,14 @@ where
             let collision_link_names = self.env_collision_link_names(objects);
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::Collision {
-                point: UnfeasibleTrajectory::StartPoint,
+                point: UnfeasibleTrajectoryPoint::Start,
                 collision_link_names,
             });
         } else if !self.is_feasible(&using_joints, goal_angles, objects) {
             let collision_link_names = self.env_collision_link_names(objects);
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::Collision {
-                point: UnfeasibleTrajectory::GoalPoint,
+                point: UnfeasibleTrajectoryPoint::Goal,
                 collision_link_names,
             });
         }
@@ -189,14 +189,14 @@ where
             let collision_link_names = self.self_collision_link_pairs();
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::SelfCollision {
-                point: UnfeasibleTrajectory::StartPoint,
+                point: UnfeasibleTrajectoryPoint::Start,
                 collision_link_names,
             });
         } else if !self.is_feasible_with_self(&using_joints, goal_angles) {
             let collision_link_names = self.self_collision_link_pairs();
             using_joints.set_joint_positions(&current_angles)?;
             return Err(Error::SelfCollision {
-                point: UnfeasibleTrajectory::GoalPoint,
+                point: UnfeasibleTrajectoryPoint::Goal,
                 collision_link_names,
             });
         }


### PR DESCRIPTION
This PR aims to refactor SelfCollisionChecker with...

- making error information of self-collision checks detailed
- reduce the number of comparison by reversing an order of `match` and `for`

