### PR TITLE
Update k requirement from 0.28 to 0.29

### DIFF
--- a/arci-ros/Cargo.toml
+++ b/arci-ros/Cargo.toml
@@ -30,7 +30,7 @@ urdf-rs = "0.6"
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 flaky_test = "0.1"
-k = "0.28"
+k = "0.29"
 
 # for tests/utils (using same version of rosrust 0.9.5)
 

--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -29,4 +29,4 @@ easy-ext = "1"
 flaky_test = "0.1"
 portpicker = "0.1"
 tokio = { version = "1.0", features = ["full"] }
-urdf-viz = "0.40"
+urdf-viz = "0.41"

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -30,7 +30,7 @@ arci-speak-cmd = "0.0.6"
 arci-urdf-viz = "0.0.6"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
-k = "0.28"
+k = "0.29"
 openrr-client = { version = "0.0.6", default-features = false }
 openrr-command = { version = "0.0.6", default-features = false }
 openrr-config = "0.0.6"

--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -15,7 +15,7 @@ assimp = ["openrr-planner/assimp"]
 [dependencies]
 anyhow = "1.0"
 arci = "0.0.6"
-k = { version = "0.28", features = ["serde-serialize"] }
+k = { version = "0.29", features = ["serde-serialize"] }
 openrr-config = "0.0.6"
 openrr-planner = { version = "0.0.6", default-features = false }
 schemars = "0.8.3"

--- a/openrr-command/Cargo.toml
+++ b/openrr-command/Cargo.toml
@@ -17,7 +17,7 @@ arci = "0.0.6"
 async-recursion = "1.0"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
-k = "0.28"
+k = "0.29"
 openrr-client = { version = "0.0.6", default-features = false }
 rustyline = "10.0.0"
 thiserror = "1.0"

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -13,7 +13,7 @@ default = ["assimp"]
 
 [dependencies]
 assimp = { version = "0.3", optional = true }
-k = "0.28"
+k = "0.29"
 mesh-loader = "0.0.2"
 ncollide3d = "0.33"
 num-traits = "0.2"
@@ -36,7 +36,7 @@ flaky_test = "0.1"
 nalgebra = "0.30"
 rand = "0.8"
 tracing-subscriber = "0.3"
-urdf-viz = "0.40"
+urdf-viz = "0.41"
 
 [[bench]]
 name = "collision_detection"

--- a/openrr-planner/src/collision/collision_detector.rs
+++ b/openrr-planner/src/collision/collision_detector.rs
@@ -398,7 +398,7 @@ mod tests {
             .is_none());
 
         let angles = [
-            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.7, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            -0.7, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
         ];
         robot.set_joint_positions(&angles).unwrap();
         let names: Vec<String> = detector.detect_env(&robot, &target, &target_pose).collect();
@@ -407,8 +407,8 @@ mod tests {
             vec![
                 "l_wrist_yaw",
                 "l_wrist_pitch",
-                "l_gripper_linear2",
-                "l_gripper_linear1"
+                "l_gripper_linear1",
+                "l_gripper_linear2"
             ]
         );
 
@@ -440,7 +440,7 @@ mod tests {
             .is_none());
 
         let angles = [
-            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            -1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
         ];
         robot.set_joint_positions(&angles).unwrap();
         let result: Vec<(String, String)> = detector

--- a/openrr-planner/src/collision/robot_collision_detector.rs
+++ b/openrr-planner/src/collision/robot_collision_detector.rs
@@ -162,7 +162,7 @@ fn test_robot_collision_detector() {
     robot_collision_detector
         .robot
         .set_joint_positions_clamped(&[
-            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            -1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
         ]);
     assert!(robot_collision_detector.is_self_collision_detected());
 }

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -17,7 +17,7 @@ arci = "0.0.6"
 async-trait = "0.1"
 auto_impl = "1.0.0"
 clap = { version = "4", features = ["derive"] }
-k = "0.28"
+k = "0.29"
 openrr-client = { version = "0.0.6", default-features = false }
 openrr-command = { version = "0.0.6", default-features = false }
 parking_lot = "0.12"


### PR DESCRIPTION
Some tests are fixed because updating `k` changed the order of joints.