### PR TITLE
[openrr-apps] Add a collision avoidance demo for sample robot

### DIFF
--- a/openrr-apps/command/sample_cmd_urdf_viz.txt
+++ b/openrr-apps/command/sample_cmd_urdf_viz.txt
@@ -5,8 +5,12 @@ openrr_apps_robot_command send_joints_pose l_arm_collision_checked zero
 openrr_apps_robot_command send_joints l_arm -j 0=1.2 -j 1=1.2 -j 2=0.0 -j 3=-1.8 -j 4=-0.5 -j 5=0.0
 openrr_apps_robot_command send_joints l_arm -j 0=0.0 -j 1=0.0 -j 2=0.0 -j 3=0.0 -j 4=0.0 -j 5=0.0
 
-openrr_apps_robot_command send_joints l_arm_collision_checked -j 0=1.2 -j 1=1.2 -j 2=0.0 -j 3=-1.8 -j 4=-0.5 -j 5=0.0
-openrr_apps_robot_command send_joints l_arm_collision_checked -j 0=0.0 -j 1=0.0 -j 2=0.0 -j 3=0.0 -j 4=0.0 -j 5=0.0
+# self-collision avoidance demo
+openrr_apps_robot_command send_joints r_arm -j 0=0.5 -j 1=0.0 -j 2=0.0 -j 3=0.0 -j 4=0.0 -j 5=0.0
+openrr_apps_robot_command send_joints l_arm_collision_avoidance -j 0=-0.7 -j 1=0.3 -j 2=0.0 -j 3=0.0 -j 4=0.0 -j 5=0.0
+openrr_apps_robot_command send_joints l_arm_collision_avoidance -j 0=-0.7 -j 1=-0.3 -j 2=0.0 -j 3=0.0 -j 4=0.0 -j 5=0.0 -d 5.0
+openrr_apps_robot_command send_joints_pose l_arm_collision_checked zero
+openrr_apps_robot_command send_joints_pose r_arm_collision_checked zero
 
 openrr_apps_robot_command send_joints l_arm_ik -j 0=1.2 -j 1=1.2 -j 2=0.0 -j 3=-1.8 -j 4=-0.5 -j 5=0.0
 openrr_apps_robot_command send_joints l_arm_ik -j 0=0.0 -j 1=0.0 -j 2=0.0 -j 3=0.0 -j 4=0.0 -j 5=0.0

--- a/openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml
+++ b/openrr-apps/config/sample_robot_client_config_for_urdf_viz.toml
@@ -45,11 +45,19 @@ joint_position_limits = [
 [openrr_clients_config]
 urdf_path = "../../openrr-planner/sample.urdf"
 self_collision_check_pairs = [
-    "l_shoulder_yaw:l_gripper_linear1",
-    "r_shoulder_yaw:r_gripper_linear1",
+    "l_gripper_linear1:r_gripper_linear1",
+    "l_gripper_linear1:r_gripper_linear2",
+    "l_gripper_linear2:r_gripper_linear1",
+    "l_gripper_linear2:r_gripper_linear2",
+    "r_wrist_yaw:l_wrist_yaw",
+    "r_wrist_pitch:l_wrist_pitch",
 ]
 
 # Client config for left arm
+[[openrr_clients_config.collision_avoidance_clients_configs]]
+name = "l_arm_collision_avoidance"
+client_name = "l_arm"
+
 [[openrr_clients_config.collision_check_clients_configs]]
 name = "l_arm_collision_checked"
 client_name = "l_arm"
@@ -68,6 +76,10 @@ positions = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 ik_target = "l_tool_fixed"
 
 # Client config for right arm
+[[openrr_clients_config.collision_avoidance_clients_configs]]
+name = "r_arm_collision_avoidance"
+client_name = "r_arm"
+
 [[openrr_clients_config.collision_check_clients_configs]]
 name = "r_arm_collision_checked"
 client_name = "r_arm"


### PR DESCRIPTION
This PR adds a collision avoidance demo to the openrr-apps main sample.

The following video shows the beginning of the sample: the cross-handed motions (6s-) are generated by JointPathPlanner with self-collision avoidance!

https://user-images.githubusercontent.com/15957608/206153725-65d6abca-f809-40fe-beea-0451b585ebec.mp4

