### PR TITLE
Fix `cargo publish` errors

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -12,7 +12,8 @@ MEMBERS=(
 
   # depend on arci
   "openrr-plugin"
-  "openrr-remote"
+  # TODO: https://github.com/openrr/openrr/issues/747
+  # "openrr-remote"
 
   # depend on arci and openrr-planner
   "openrr-client"
@@ -48,7 +49,7 @@ for i in "${!MEMBERS[@]}"; do
   (
     cd "${MEMBERS[${i}]}"
     cargo clean
-    cargo publish
+    cargo +stable publish
   )
   if [[ $((i + 1)) != "${#MEMBERS[@]}" ]]; then
     sleep 45

--- a/openrr/README.md
+++ b/openrr/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/openrr/src/lib.rs
+++ b/openrr/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
 // buggy: https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+derive_partial_eq_without_eq
 #![allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
openrr:
```
error: couldn't read src/../../README.md: No such file or directory (os error 2)
 --> src/lib.rs:1:10
  |
1 | #![doc = include_str!("../../README.md")]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Fixing openrr-remote is somewhat complicated and will not be done in this PR. (see #747 for more)