### PR TITLE
Fix newly added clippy warnings

### DIFF
--- a/arci-ros/src/rosrust_utils.rs
+++ b/arci-ros/src/rosrust_utils.rs
@@ -270,11 +270,11 @@ pub fn convert_system_time_to_ros_time(time: &SystemTime) -> Time {
     // https://doc.rust-lang.org/std/time/struct.SystemTime.html#method.duration_since
     if system_now < *time {
         Time::from_nanos(
-            time.duration_since(system_now).unwrap().as_nanos() as i64 + ros_now.nanos() as i64,
+            time.duration_since(system_now).unwrap().as_nanos() as i64 + ros_now.nanos(),
         )
     } else {
         Time::from_nanos(
-            ros_now.nanos() as i64 - system_now.duration_since(*time).unwrap().as_nanos() as i64,
+            ros_now.nanos() - system_now.duration_since(*time).unwrap().as_nanos() as i64,
         )
     }
 }

--- a/arci-urdf-viz/tests/test_client.rs
+++ b/arci-urdf-viz/tests/test_client.rs
@@ -209,9 +209,11 @@ fn test_send_joint_positions_no_wait() {
     web_server.start_background();
     let client = UrdfVizWebClient::new(url).unwrap();
     client.run_send_joint_positions_thread();
-    let _ = client
-        .send_joint_positions(vec![1.0], Duration::from_secs(1))
-        .unwrap();
+    drop(
+        client
+            .send_joint_positions(vec![1.0], Duration::from_secs(1))
+            .unwrap(),
+    );
     let v = client.current_joint_positions().unwrap();
     assert_approx_eq!(v[0], 0.0);
     std::thread::sleep(Duration::from_secs(2));
@@ -276,9 +278,11 @@ fn send_joint_positions_without_send_joint_positions_thread() {
     });
     web_server.start_background();
     let client = UrdfVizWebClient::new(url).unwrap();
-    let _ = client
-        .send_joint_positions(vec![1.0], Duration::from_secs(1))
-        .unwrap();
+    drop(
+        client
+            .send_joint_positions(vec![1.0], Duration::from_secs(1))
+            .unwrap(),
+    );
 }
 
 #[test]

--- a/arci-urdf-viz/tests/test_web.rs
+++ b/arci-urdf-viz/tests/test_web.rs
@@ -66,13 +66,14 @@ fn test_set_get_pose_no_wait() {
     assert_approx_eq!(pose.translation.x, 0.0);
     assert_approx_eq!(pose.translation.y, 0.0);
     assert_approx_eq!(pose.rotation.angle(), f64::consts::PI);
-    let _ = c
-        .send_goal_pose(
+    drop(
+        c.send_goal_pose(
             nalgebra::Isometry2::new(nalgebra::Vector2::new(1.0, 2.0), 3.0),
             "",
             Duration::from_secs(0),
         )
-        .unwrap();
+        .unwrap(),
+    );
     std::thread::sleep(Duration::from_millis(10));
     let pose = c.current_pose("").unwrap();
     assert_approx_eq!(pose.translation.x, 1.0);

--- a/arci/src/clients/dummy_navigation.rs
+++ b/arci/src/clients/dummy_navigation.rs
@@ -80,13 +80,14 @@ mod tests {
     #[test]
     fn test_set_no_wait() {
         let nav = DummyNavigation::new();
-        let _ = nav
-            .send_goal_pose(
+        drop(
+            nav.send_goal_pose(
                 Isometry2::new(Vector2::new(1.0, 2.0), 3.0),
                 "",
                 std::time::Duration::default(),
             )
-            .unwrap();
+            .unwrap(),
+        );
 
         let current_goal_pose = nav.current_goal_pose().unwrap();
         assert_approx_eq!(current_goal_pose.translation.x, 1.0);

--- a/arci/src/clients/dummy_speaker.rs
+++ b/arci/src/clients/dummy_speaker.rs
@@ -44,7 +44,7 @@ mod tests {
         let speaker = DummySpeaker::new();
 
         assert_eq!(speaker.current_message(), "");
-        let _ = speaker.speak("abc").unwrap();
+        drop(speaker.speak("abc").unwrap());
         assert_eq!(speaker.current_message(), "abc");
     }
 }

--- a/arci/src/utils.rs
+++ b/arci/src/utils.rs
@@ -35,8 +35,10 @@ where
     let mut prev_current_position = positions[joint_index];
     positions[joint_index] = target_position;
     // use send_joint_trajectory, to send target trajectory with max velocity from start time.
-    let _ = joint_trajectory_client
-        .send_joint_trajectory(vec![TrajectoryPoint::new(positions, target_duration)])?;
+    drop(
+        joint_trajectory_client
+            .send_joint_trajectory(vec![TrajectoryPoint::new(positions, target_duration)])?,
+    );
     let mut stopped_count: u64 = 0;
     let stopped_count_threshold =
         (stopped_duration.as_secs_f64() / monitor_interval.as_secs_f64()).ceil() as u64;

--- a/openrr-apps/src/bin/config.rs
+++ b/openrr-apps/src/bin/config.rs
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
             config_path,
             config: overwrite,
         } => {
-            let s = &fs::read_to_string(&config_path)?;
+            let s = &fs::read_to_string(config_path)?;
             let s = &openrr_config::overwrite_str(s, &overwrite)?;
             // check if the edited document is valid config.
             let _base: Config = toml::from_str(s)?;

--- a/openrr-apps/src/robot_config.rs
+++ b/openrr-apps/src/robot_config.rs
@@ -313,7 +313,7 @@ impl PluginMap {
     pub fn load(&mut self, name: impl AsRef<str>) -> Result<Option<Arc<PluginProxy>>, arci::Error> {
         let name = name.as_ref();
         if let Some((name, path)) = self.path.remove_entry(name) {
-            let plugin = Arc::new(PluginProxy::from_path(&path)?);
+            let plugin = Arc::new(PluginProxy::from_path(path)?);
             self.cache.insert(name, plugin.clone());
             Ok(Some(plugin))
         } else {
@@ -914,7 +914,7 @@ impl RobotConfig {
             for instance in &mut plugin_config.instances {
                 if let Some(args_path) = instance.args_from_path.take() {
                     instance.args_from_path =
-                        Some(openrr_client::resolve_relative_path(path, &args_path)?);
+                        Some(openrr_client::resolve_relative_path(path, args_path)?);
                 }
             }
         }

--- a/openrr-apps/src/robot_teleop_config.rs
+++ b/openrr-apps/src/robot_teleop_config.rs
@@ -88,7 +88,7 @@ impl RobotTeleopConfig {
             resolve_plugin_path(&mut plugin_config.path, path)?;
             if let Some(args_path) = plugin_config.args_from_path.take() {
                 plugin_config.args_from_path =
-                    Some(openrr_client::resolve_relative_path(path, &args_path)?);
+                    Some(openrr_client::resolve_relative_path(path, args_path)?);
             }
         }
         Ok(config)

--- a/openrr-apps/tests/test_robot_config.rs
+++ b/openrr-apps/tests/test_robot_config.rs
@@ -16,9 +16,7 @@ fn verify_sample_configs() {
         if cfg!(not(feature = "ros")) && f.contains("ros") {
             assert!(
                 matches!(result, Err(openrr_apps::Error::ConfigRequireRos(..))),
-                "{:?} {:?}",
-                f,
-                result
+                "{f:?} {result:?}",
             );
         } else if cfg!(not(feature = "ros")) && (f.contains("pr2") || f.contains("ur10")) {
             assert!(
@@ -28,14 +26,12 @@ fn verify_sample_configs() {
                         openrr_client::Error::Other(..)
                     ))
                 ),
-                "{:?} {:?}",
-                f,
-                result
+                "{f:?} {result:?}",
             );
         } else {
-            assert!(result.is_ok(), "{:?} {:?}", f, result);
+            assert!(result.is_ok(), "{f:?} {result:?}");
             let ser_result = toml::to_string(&result.unwrap());
-            assert!(ser_result.is_ok(), "{:?} {:?}", f, ser_result);
+            assert!(ser_result.is_ok(), "{f:?} {ser_result:?}");
         }
     }
 }

--- a/openrr-apps/tests/test_robot_teleop_config.rs
+++ b/openrr-apps/tests/test_robot_teleop_config.rs
@@ -12,9 +12,9 @@ fn verify_sample_configs() {
 
     for f in files {
         let result = RobotTeleopConfig::new(f);
-        assert!(result.is_ok(), "{:?} {:?}", f, result);
+        assert!(result.is_ok(), "{f:?} {result:?}");
         let ser_result = toml::to_string(&result.unwrap());
-        assert!(ser_result.is_ok(), "{:?} {:?}", f, ser_result);
+        assert!(ser_result.is_ok(), "{f:?} {ser_result:?}");
     }
 }
 

--- a/openrr-client/src/clients/chain_wrapper.rs
+++ b/openrr-client/src/clients/chain_wrapper.rs
@@ -85,18 +85,22 @@ mod test {
 
         assert_eq!(chain_wrapper.joint_names(), vec![String::from("joint")]);
 
-        let _ = chain_wrapper
-            .send_joint_positions(vec![1.0], Duration::from_secs(1))
-            .unwrap();
+        drop(
+            chain_wrapper
+                .send_joint_positions(vec![1.0], Duration::from_secs(1))
+                .unwrap(),
+        );
         assert_approx_eq!(chain_wrapper.current_joint_positions().unwrap()[0], 1.0);
 
-        let _ = chain_wrapper
-            .send_joint_trajectory(vec![TrajectoryPoint {
-                positions: vec![1.5],
-                velocities: Some(vec![1.0]),
-                time_from_start: Duration::from_secs(1),
-            }])
-            .unwrap();
+        drop(
+            chain_wrapper
+                .send_joint_trajectory(vec![TrajectoryPoint {
+                    positions: vec![1.5],
+                    velocities: Some(vec![1.0]),
+                    time_from_start: Duration::from_secs(1),
+                }])
+                .unwrap(),
+        );
         assert_approx_eq!(chain_wrapper.current_joint_positions().unwrap()[0], 1.5);
     }
 }

--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -566,7 +566,7 @@ impl OpenrrClientsConfig {
         if let Some(urdf_path) = self.urdf_path.as_ref() {
             // TODO: pass Some(config_file_dir)
             let urdf_path = openrr_config::evaluate(urdf_path, None)?;
-            self.urdf_full_path = Some(resolve_relative_path(path, &urdf_path)?);
+            self.urdf_full_path = Some(resolve_relative_path(path, urdf_path)?);
         } else {
             return Err(Error::NoUrdfPath);
         }

--- a/openrr-client/tests/test_robot_client.rs
+++ b/openrr-client/tests/test_robot_client.rs
@@ -347,7 +347,7 @@ fn test_manipulation_accessors() {
     let hash_speakers = client.speakers();
     assert_eq!(hash_speakers.keys().len(), 1);
 
-    let _ = client.speak("speaker", "aa").unwrap();
+    drop(client.speak("speaker", "aa").unwrap());
 }
 
 #[tokio::test]

--- a/openrr-gui/src/joint_position_sender.rs
+++ b/openrr-gui/src/joint_position_sender.rs
@@ -613,7 +613,7 @@ where
             {
                 errors = errors.push(
                     self.theme.text()["error"]
-                        .new(&format!("Error: {msg}"))
+                        .new(format!("Error: {msg}"))
                         .width(Length::Fill),
                 );
             }

--- a/openrr-gui/src/velocity_sender.rs
+++ b/openrr-gui/src/velocity_sender.rs
@@ -537,7 +537,7 @@ where
             .iter()
             .filter_map(|e| e.as_ref())
             {
-                errors = errors.push(self.theme.text()["error"].new(&format!("Error: {msg}")));
+                errors = errors.push(self.theme.text()["error"].new(format!("Error: {msg}")));
             }
             if self.errors.update_on_error {
                 errors = errors.push(

--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -37,8 +37,7 @@ where
     ) -> Self {
         assert!(
             time_interpolate_rate > na::convert(0.0) && time_interpolate_rate <= na::convert(1.0),
-            "time_interpolate_rate must be 0.0~1.0 but {}",
-            time_interpolate_rate
+            "time_interpolate_rate must be 0.0~1.0 but {time_interpolate_rate}",
         );
 
         Self {

--- a/openrr-plugin/benches/proxy.rs
+++ b/openrr-plugin/benches/proxy.rs
@@ -171,7 +171,7 @@ fn proxy_same_crate_send_joint_positions(c: &mut Criterion) {
 
 fn proxy_diff_crate_joint_names(c: &mut Criterion) {
     let plugin_path = test_plugin().unwrap();
-    let plugin = PluginProxy::from_path(&plugin_path).unwrap();
+    let plugin = PluginProxy::from_path(plugin_path).unwrap();
 
     let joint_names: Vec<_> = (0..100).map(|n| n.to_string()).collect();
     let client = plugin
@@ -186,7 +186,7 @@ fn proxy_diff_crate_joint_names(c: &mut Criterion) {
 
 fn proxy_diff_crate_current_joint_positions(c: &mut Criterion) {
     let plugin_path = test_plugin().unwrap();
-    let plugin = PluginProxy::from_path(&plugin_path).unwrap();
+    let plugin = PluginProxy::from_path(plugin_path).unwrap();
 
     let joint_names: Vec<_> = (0..100).map(|n| n.to_string()).collect();
     let client = plugin
@@ -201,7 +201,7 @@ fn proxy_diff_crate_current_joint_positions(c: &mut Criterion) {
 
 fn proxy_diff_crate_send_joint_positions(c: &mut Criterion) {
     let plugin_path = test_plugin().unwrap();
-    let plugin = PluginProxy::from_path(&plugin_path).unwrap();
+    let plugin = PluginProxy::from_path(plugin_path).unwrap();
 
     let joint_names: Vec<_> = (0..100).map(|n| n.to_string()).collect();
     let positions: Vec<_> = (0..joint_names.len()).map(|n| n as f64).collect();

--- a/openrr-plugin/examples/plugin/src/lib.rs
+++ b/openrr-plugin/examples/plugin/src/lib.rs
@@ -25,25 +25,25 @@ impl Plugin for MyPlugin {
     }
 
     fn new_speaker(&self, _args: String) -> Result<Option<Box<dyn arci::Speaker>>, arci::Error> {
-        Ok(Some(Box::new(PrintSpeaker::default())))
+        Ok(Some(Box::<PrintSpeaker>::default()))
     }
 
     fn new_move_base(&self, _args: String) -> Result<Option<Box<dyn arci::MoveBase>>, arci::Error> {
-        Ok(Some(Box::new(DummyMoveBase::default())))
+        Ok(Some(Box::<DummyMoveBase>::default()))
     }
 
     fn new_navigation(
         &self,
         _args: String,
     ) -> Result<Option<Box<dyn arci::Navigation>>, arci::Error> {
-        Ok(Some(Box::new(DummyNavigation::default())))
+        Ok(Some(Box::<DummyNavigation>::default()))
     }
 
     fn new_localization(
         &self,
         _args: String,
     ) -> Result<Option<Box<dyn arci::Localization>>, arci::Error> {
-        Ok(Some(Box::new(DummyLocalization::default())))
+        Ok(Some(Box::<DummyLocalization>::default()))
     }
 
     #[cfg(unix)]

--- a/openrr-remote/tests/test.rs
+++ b/openrr-remote/tests/test.rs
@@ -67,13 +67,13 @@ async fn joint_trajectory_client() -> Result<()> {
     assert_eq!(client.current_joint_positions()?, vec![3.0]);
 
     // no wait
-    let _ = client.send_joint_positions(vec![4.0], Duration::from_secs_f64(0.1))?;
+    drop(client.send_joint_positions(vec![4.0], Duration::from_secs_f64(0.1))?);
     tokio::time::sleep(Duration::from_secs_f64(0.5)).await;
     assert_eq!(client.current_joint_positions()?, vec![4.0]);
-    let _ = client.send_joint_trajectory(vec![TrajectoryPoint::new(
+    drop(client.send_joint_trajectory(vec![TrajectoryPoint::new(
         vec![5.0],
         Duration::from_secs_f64(0.1),
-    )])?;
+    )])?);
     tokio::time::sleep(Duration::from_secs_f64(0.5)).await;
     assert_eq!(client.current_joint_positions()?, vec![5.0]);
 

--- a/openrr-teleop/src/joints.rs
+++ b/openrr-teleop/src/joints.rs
@@ -151,10 +151,11 @@ where
     fn handle_event(&self, event: GamepadEvent) {
         if let Some(submode) = self.inner.lock().handle_event(event) {
             // do not wait
-            let _ = self
-                .speaker
-                .speak(&format!("{}{submode}", self.mode))
-                .unwrap();
+            drop(
+                self.speaker
+                    .speak(&format!("{}{submode}", self.mode))
+                    .unwrap(),
+            );
         }
     }
 
@@ -167,10 +168,11 @@ where
                 .unwrap();
             let pos = inner.get_target_positions(pos);
             // do not wait
-            let _ = self
-                .joint_trajectory_client
-                .send_joint_positions(pos, self.step_duration)
-                .unwrap();
+            drop(
+                self.joint_trajectory_client
+                    .send_joint_positions(pos, self.step_duration)
+                    .unwrap(),
+            );
         }
     }
 

--- a/openrr-teleop/src/joints_pose_sender.rs
+++ b/openrr-teleop/src/joints_pose_sender.rs
@@ -130,10 +130,11 @@ where
     fn handle_event(&self, event: arci::gamepad::GamepadEvent) {
         if let Some(submode) = self.inner.lock().handle_event(event) {
             // do not wait
-            let _ = self
-                .speaker
-                .speak(&format!("{}{submode}", self.mode))
-                .unwrap();
+            drop(
+                self.speaker
+                    .speak(&format!("{}{submode}", self.mode))
+                    .unwrap(),
+            );
         }
     }
 
@@ -141,16 +142,18 @@ where
         let inner = self.inner.lock();
         let (name, target) = inner.get_target_name_positions();
         let client = self.joint_trajectory_clients.get(&name).unwrap();
-        let _ = client
-            .send_joint_positions(
-                if inner.is_sending && inner.is_trigger_holding {
-                    target
-                } else {
-                    client.current_joint_positions().unwrap()
-                },
-                self.duration,
-            )
-            .unwrap();
+        drop(
+            client
+                .send_joint_positions(
+                    if inner.is_sending && inner.is_trigger_holding {
+                        target
+                    } else {
+                        client.current_joint_positions().unwrap()
+                    },
+                    self.duration,
+                )
+                .unwrap(),
+        );
     }
 
     fn mode(&self) -> &str {
@@ -357,16 +360,18 @@ mod test {
             .joint_trajectory_clients
             .get(&name)
             .unwrap();
-        let _ = client
-            .send_joint_positions(
-                if inner.is_sending && inner.is_trigger_holding {
-                    target
-                } else {
-                    client.current_joint_positions().unwrap()
-                },
-                joints_pose_sender.duration,
-            )
-            .unwrap();
+        drop(
+            client
+                .send_joint_positions(
+                    if inner.is_sending && inner.is_trigger_holding {
+                        target
+                    } else {
+                        client.current_joint_positions().unwrap()
+                    },
+                    joints_pose_sender.duration,
+                )
+                .unwrap(),
+        );
 
         joints_pose_sender.joint_trajectory_clients[&name]
             .current_joint_positions()

--- a/openrr-teleop/src/robot_command_executor.rs
+++ b/openrr-teleop/src/robot_command_executor.rs
@@ -113,7 +113,7 @@ where
     fn handle_event(&self, event: arci::gamepad::GamepadEvent) {
         if let Some(submode) = self.inner.lock().handle_event(event) {
             // do not wait
-            let _ = self.speaker.speak(&format!("{MODE} {submode}")).unwrap();
+            drop(self.speaker.speak(&format!("{MODE} {submode}")).unwrap());
         }
     }
 

--- a/tools/codegen/src/rpc.rs
+++ b/tools/codegen/src/rpc.rs
@@ -24,7 +24,7 @@ pub fn gen(workspace_root: &Path) -> Result<()> {
     let mut traits = vec![];
 
     let mut pb_traits = vec![];
-    let pb_file = fs::read_to_string(&workspace_root.join("openrr-remote/src/generated/arci.rs"))?;
+    let pb_file = fs::read_to_string(workspace_root.join("openrr-remote/src/generated/arci.rs"))?;
     CollectTrait(&mut pb_traits).visit_file_mut(&mut syn::parse_file(&pb_file)?);
 
     for item in arci_traits(workspace_root)? {


### PR DESCRIPTION
This resolves clippy warnings added in Rust 1.66.

- clippy::needless_borrow
- clippy::unnecessary_cast
- clippy::box_default

This also resolves clippy warnings that will be added in Rust 1.67 (currently beta).

- clippy::uninlined_format_args
- clippy::let_underscore_future

See commit messages for actual warnings.