### PR TITLE
Use workspace inheritance for [package] table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ version = "0.0.7"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/openrr/openrr"
+homepage = "https://openrr.github.io"
 
 [patch.crates-io]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,12 @@ members = [
     "tools/codegen",
 ]
 
+[workspace.package]
+version = "0.0.7"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/openrr/openrr"
+
 [patch.crates-io]
 
 arci = { path = "arci" }

--- a/arci-gamepad-gilrs/Cargo.toml
+++ b/arci-gamepad-gilrs/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "arci-gamepad-gilrs"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "arci::Gamepad implementation using gilrs"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [dependencies]
 arci = "0.0.7"

--- a/arci-gamepad-keyboard/Cargo.toml
+++ b/arci-gamepad-keyboard/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "arci-gamepad-keyboard"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "arci::Gamepad implementation for keyboard"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [dependencies]
 arci = "0.0.7"

--- a/arci-ros/Cargo.toml
+++ b/arci-ros/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "arci-ros"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "arci implementation using ROS1"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [dependencies]
 anyhow = "1.0"

--- a/arci-ros/tests/hygiene/Cargo.toml
+++ b/arci-ros/tests/hygiene/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "arci-ros-hygiene-test"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "arci-ros2"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "arci implementation using ROS2"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/arci-speak-audio/Cargo.toml
+++ b/arci-speak-audio/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "arci-speak-audio"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "arci::Speaker implementation for playing audio files"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [dependencies]
 arci = "0.0.7"

--- a/arci-speak-cmd/Cargo.toml
+++ b/arci-speak-cmd/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "arci-speak-cmd"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "arci::Speaker implementation using local command"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [dependencies]
 arci = "0.0.7"

--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "arci-urdf-viz"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "arci implementation using urdf-viz"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [dependencies]
 anyhow = "1.0"

--- a/arci/Cargo.toml
+++ b/arci/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "arci"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Abstract Robot Control Interface"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [dependencies]
 anyhow = "1.0"

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openrr-apps"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "applications using openrr"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [features]
 default = ["assimp", "gui", "ros"]

--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openrr-client"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "openrr useful client libraries"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [features]
 default = ["assimp"]

--- a/openrr-command/Cargo.toml
+++ b/openrr-command/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openrr-command"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "openrr command line tool library"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [features]
 default = ["assimp"]

--- a/openrr-config/Cargo.toml
+++ b/openrr-config/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openrr-config"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Utilities for modifying configuration files"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics", "gui"]
-repository = "https://github.com/openrr/openrr"
 
 [dependencies]
 anyhow = "1"

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openrr-gui"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "openrr GUI library"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics", "gui"]
-repository = "https://github.com/openrr/openrr"
 
 [features]
 default = ["assimp"]

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openrr-planner"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Collision avoidance path planning for robotics"
 keywords = ["pathplanning", "robotics", "robot"]
 categories = ["algorithms", "science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [features]
 default = ["assimp"]

--- a/openrr-plugin/Cargo.toml
+++ b/openrr-plugin/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openrr-plugin"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Plugin support for arci"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [dependencies]
 abi_stable = "0.11"

--- a/openrr-plugin/examples/plugin/Cargo.toml
+++ b/openrr-plugin/examples/plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrr-plugin-example"
-version = "0.1.0"
-edition = "2021"
+version = "0.0.0"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/openrr-remote/Cargo.toml
+++ b/openrr-remote/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openrr-remote"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Remote execution support for arci"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [build-dependencies]
 tonic-build = "0.8"

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "openrr-teleop"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "openrr teleoperation library"
 keywords = ["robotics", "robot"]
 categories = ["algorithms", "science::robotics"]
-repository = "https://github.com/openrr/openrr"
 
 [features]
 default = ["assimp"]

--- a/openrr/Cargo.toml
+++ b/openrr/Cargo.toml
@@ -4,11 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-homepage = "https://openrr.github.io"
+homepage.workspace = true
 description = "Open Rust Robotics framework"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-readme = "../README.md"
 
 [features]
 default = ["assimp"]

--- a/openrr/Cargo.toml
+++ b/openrr/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "openrr"
-version = "0.0.7"
-edition = "2021"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 homepage = "https://openrr.github.io"
 description = "Open Rust Robotics framework"
 keywords = ["robotics", "robot"]
 categories = ["science::robotics"]
-repository = "https://github.com/openrr/openrr"
 readme = "../README.md"
 
 [features]

--- a/tools/codegen/Cargo.toml
+++ b/tools/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openrr-internal-codegen"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Use workspace inheritance stabilized in Rust 1.64: https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#cargo-improvements-workspace-inheritance-and-multi-target-builds

Refs: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table