### PR TITLE
[arci-ros] Add test for some `ROS` client.

### DIFF
--- a/arci-ros/tests/test_localization_client.rs
+++ b/arci-ros/tests/test_localization_client.rs
@@ -1,0 +1,72 @@
+#[cfg(target_os = "linux")]
+mod msg {
+    rosrust::rosmsg_include!(
+        geometry_msgs / PoseWithCovarianceStamped,
+        geometry_msgs / Point,
+        geometry_msgs / Pose,
+        geometry_msgs / Quaternion,
+        std_msgs / Header
+    );
+}
+use arci::Localization;
+
+mod util;
+use assert_approx_eq::assert_approx_eq;
+use util::run_roscore_and_rosrust_init_once;
+
+use crate::msg::{geometry_msgs, std_msgs};
+
+const AMCL_POSE_TOPIC: &str = "/amcl_pose";
+const NO_MOTION_UPDATE_SERVICE: &str = "request_nomotion_update";
+
+#[test]
+fn test_localization_client() {
+    println!("arci ros localization client test");
+
+    // Setup for ROS
+    let _roscore = run_roscore_and_rosrust_init_once("arci_ros_localization_client_test");
+
+    let pose_publisher =
+        rosrust::publish::<geometry_msgs::PoseWithCovarianceStamped>(AMCL_POSE_TOPIC, 1).unwrap();
+
+    std::thread::spawn(move || {
+        while rosrust::is_ok() && pose_publisher.subscriber_count() == 0 {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        pose_publisher
+            .send(geometry_msgs::PoseWithCovarianceStamped {
+                header: std_msgs::Header::default(),
+                pose: geometry_msgs::PoseWithCovariance {
+                    pose: geometry_msgs::Pose {
+                        position: geometry_msgs::Point {
+                            x: 2.0,
+                            y: 3.0,
+                            z: 4.0,
+                        },
+                        orientation: geometry_msgs::Quaternion {
+                            x: 0.0,
+                            y: 0.0,
+                            z: 0.0,
+                            w: 1.0,
+                        },
+                    },
+                    covariance: [1f64; 36],
+                },
+            })
+            .unwrap();
+    });
+
+    let client = arci_ros::RosLocalizationClient::new(
+        false,
+        NO_MOTION_UPDATE_SERVICE.to_string(),
+        AMCL_POSE_TOPIC.to_string(),
+    );
+
+    let pose = client.current_pose("frame_id").unwrap();
+
+    assert_approx_eq!(pose.rotation.re, 1.0);
+    assert_approx_eq!(pose.rotation.im, 0.0);
+    assert_approx_eq!(pose.translation.x, 2.0);
+    assert_approx_eq!(pose.translation.y, 3.0);
+}

--- a/arci-ros/tests/test_robot_client.rs
+++ b/arci-ros/tests/test_robot_client.rs
@@ -1,0 +1,76 @@
+#[cfg(target_os = "linux")]
+use arci::{JointTrajectoryClient, TrajectoryPoint};
+mod msg {
+    rosrust::rosmsg_include!(sensor_msgs / JointState, trajectory_msgs / JointTrajectory);
+}
+use arci_ros::subscribe_with_channel;
+use msg::{sensor_msgs, trajectory_msgs};
+mod util;
+use assert_approx_eq::assert_approx_eq;
+use util::run_roscore_and_rosrust_init_once;
+
+const JOINT_STATE_TOPIC_NAME: &str = "joint_state";
+const TRAJECTORY_TOPIC_NAME: &str = "trajectory";
+
+#[test]
+fn test_robot_client() {
+    println!("arci ros robot client test");
+
+    // Setup for ROS
+    let _roscore = run_roscore_and_rosrust_init_once("arci_ros_robot_client_test");
+
+    let joint_names = vec![
+        String::from("joint0"),
+        String::from("joint1"),
+        String::from("joint2"),
+    ];
+
+    let joint_state_publisher =
+        rosrust::publish::<sensor_msgs::JointState>(JOINT_STATE_TOPIC_NAME, 1).unwrap();
+
+    let (_rx, joint_trajectory_subscriber) =
+        subscribe_with_channel::<trajectory_msgs::JointTrajectory>(TRAJECTORY_TOPIC_NAME, 1);
+
+    std::thread::spawn(move || {
+        // Wait for ros_robot_client to be launched.
+        while rosrust::is_ok() && joint_state_publisher.subscriber_count() == 0 {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        joint_state_publisher
+            .send(sensor_msgs::JointState {
+                header: Default::default(),
+                name: vec![
+                    String::from("joint0"),
+                    String::from("joint1"),
+                    String::from("joint2"),
+                ],
+                position: vec![0f64, 1f64, 2f64],
+                velocity: vec![3f64, 4f64, 5f64],
+                effort: vec![6f64, 7f64, 8f64],
+            })
+            .unwrap();
+
+        while rosrust::is_ok() && joint_trajectory_subscriber.publisher_count() == 0 {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    });
+
+    let client =
+        arci_ros::RosRobotClient::new(joint_names, JOINT_STATE_TOPIC_NAME, TRAJECTORY_TOPIC_NAME);
+
+    assert_eq!(client.joint_names()[0], "joint0");
+    assert_approx_eq!(client.current_joint_positions().unwrap()[1], 1f64);
+
+    assert!(client
+        .send_joint_positions(vec![0.5, 1.5, 2.5], std::time::Duration::from_millis(100),)
+        .is_ok());
+
+    assert!(client
+        .send_joint_trajectory(vec![TrajectoryPoint {
+            positions: vec![1.0, 2.0, 3.0],
+            velocities: Some(vec![3.5, 4.5, 5.5]),
+            time_from_start: std::time::Duration::from_millis(100),
+        }])
+        .is_ok());
+}

--- a/arci-ros/tests/test_speak_client.rs
+++ b/arci-ros/tests/test_speak_client.rs
@@ -1,0 +1,37 @@
+#[cfg(target_os = "linux")]
+use arci::Speaker;
+mod msg {
+    rosrust::rosmsg_include!(std_msgs / String);
+}
+use arci_ros::subscribe_with_channel;
+use msg::std_msgs;
+mod util;
+use util::run_roscore_and_rosrust_init_once;
+
+const MESSAGE: &str = "Good morning!";
+
+#[test]
+fn test_speak_client() {
+    println!("arci ros speak client test");
+
+    // Setup for ROS
+    let _roscore = run_roscore_and_rosrust_init_once("arci_ros_speak_client_test");
+
+    let topic_name = String::from("test_speak");
+    let (rx, _sub) = subscribe_with_channel::<std_msgs::String>(&topic_name, 2);
+
+    let speaker = arci_ros::RosEspeakClient::new(&topic_name);
+
+    std::thread::spawn(move || {
+        // Wait for starting up receiver
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        let _wait_future = speaker.speak(MESSAGE).unwrap();
+        println!("[Speaker]: {MESSAGE:?}");
+    });
+
+    if let Ok(rv) = rx.recv() {
+        assert_eq!(rv.data, MESSAGE);
+        println!("[Receiver]: {:?}", rv.data);
+    }
+}


### PR DESCRIPTION
The purpose is to increase coverage about `arci-ros`. This time, I implement tests for `RosRobotClient` and `RosSpeakClient`, and `RosLocalizationClient`. But a test of `RosLocalizationClient` does not cover all file lines. `~Builder` and `~Config` is not covered.