### PR TITLE
[openrr-planner] Fix to create SelfCollisionChecker from a xacro file

### DIFF
--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -196,7 +196,7 @@ pub fn create_self_collision_checker<P: AsRef<Path>>(
     robot: Arc<k::Chain<f64>>,
 ) -> SelfCollisionChecker<f64> {
     let collision_detector = CollisionDetector::from_urdf_robot(
-        &urdf_rs::read_file(urdf_path).unwrap(),
+        &urdf_rs::utils::read_urdf_or_xacro(urdf_path.as_ref()).unwrap(),
         config.prediction,
     );
     let robot_collision_detector = RobotCollisionDetector::new(


### PR DESCRIPTION
The currently used `read_file()` function can read URDF files only.