### PR TITLE
Revert "Temporary use nightly toolchain in tests"

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -8,7 +8,6 @@ anonymize
 args
 attr
 backend
-backported
 bindgen
 bringup
 buildtool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@protoc
+        # https://github.com/actions/runner-images/pull/7125
+      - run: brew install pkg-config
       - run: cargo build
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
-      # use stable again once https://github.com/rust-lang/rust/pull/107360 is backported
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: ${{ env.nightly }}
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@protoc
       - run: ci/ubuntu-setup-lld.sh


### PR DESCRIPTION
This reverts commit 22ffb6bbf889017c65fba471eecb9df172abbc0c.

Rust 1.67.1 has been released.