### PR TITLE
Enable region coverage on codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,10 +354,10 @@ jobs:
           source /opt/ros/noetic/setup.bash
           # TODO: r2r 0.6.5 doesn't support foxy
           # --no-cfg-coverage due to https://github.com/Smithay/calloop/issues/118
-          cargo llvm-cov --verbose --all-features --workspace --exclude openrr-internal-codegen --exclude arci-ros2 --no-cfg-coverage --lcov --output-path lcov.info
+          cargo llvm-cov --verbose --all-features --workspace --exclude openrr-internal-codegen --exclude arci-ros2 --no-cfg-coverage --codecov --output-path codecov.json
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
+          files: codecov.json
           fail_ci_if_error: true


### PR DESCRIPTION
https://github.com/taiki-e/cargo-llvm-cov/releases/tag/v0.5.12

Catch cases where some regions are covered and others are not covered in the same line. For example, if the case that returns Ok is tested, but the case that returns Err is not, the line is marked as partially covered.

~~Blocked on https://github.com/taiki-e/cargo-llvm-cov/issues/252.~~