### PR TITLE
Fix inactive links to tutorial books

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,5 @@ We appreciate for your any contributions!
 
 You can read the tutorial books at the following links.
 
-- [English](https://openrr.github.io/openrr-tutorial/en)
-- [Japanese](https://openrr.github.io/openrr-tutorial/ja)
+- [English](https://openrr.github.io/openrr-tutorial/en/html)
+- [Japanese](https://openrr.github.io/openrr-tutorial/ja/html)


### PR DESCRIPTION
Solve the issue reported in https://github.com/openrr/openrr/issues/814