### PR TITLE
Remove ROS1 melodic from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - melodic
           - noetic
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -116,7 +115,6 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - melodic
           - noetic
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
This will be EoL at the end of this month.
https://wiki.ros.org/Distributions