### PR TITLE
Fix CI failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ proc-macro2 = "1"
 prost = "0.11"
 prost-types = "0.11"
 quote = "1"
-r2r = "0.7"
+r2r = "=0.7.0" # 0.7.1 is broken: https://github.com/openrr/openrr/pull/828
 rand = "0.8"
 rayon = "1.5"
 rodio = "0.17"

--- a/arci-ros/src/ros_control/ros_control_action_client.rs
+++ b/arci-ros/src/ros_control/ros_control_action_client.rs
@@ -16,7 +16,11 @@ use crate::{
 
 const ACTION_TIMEOUT_DURATION_RATIO: u32 = 10;
 
-define_action_client!(SimpleActionClient, msg::control_msgs, FollowJointTrajectory);
+define_action_client!(
+    ControlActionClient,
+    msg::control_msgs,
+    FollowJointTrajectory
+);
 
 #[derive(Clone)]
 pub struct RosControlActionClient(Arc<RosControlActionClientInner>);
@@ -26,7 +30,7 @@ struct RosControlActionClientInner {
     send_partial_joints_goal: bool,
     joint_state_provider: Arc<LazyJointStateProvider>,
     complete_condition: Mutex<Arc<dyn CompleteCondition>>,
-    action_client: SimpleActionClient,
+    action_client: ControlActionClient,
 }
 
 impl RosControlActionClient {
@@ -46,7 +50,7 @@ impl RosControlActionClient {
         }
 
         let action_client =
-            SimpleActionClient::new(&format!("{controller_name}/follow_joint_trajectory"), 1);
+            ControlActionClient::new(&format!("{controller_name}/follow_joint_trajectory"), 1);
 
         Self(Arc::new(RosControlActionClientInner {
             joint_names,

--- a/arci-ros/src/ros_localization_client.rs
+++ b/arci-ros/src/ros_localization_client.rs
@@ -1,5 +1,3 @@
-use std::borrow::Borrow;
-
 use arci::*;
 use nalgebra as na;
 use schemars::JsonSchema;
@@ -129,7 +127,6 @@ impl RosLocalizationClient {
 
     pub fn request_nomotion_update(&self) {
         self.nomotion_update_client
-            .borrow()
             .as_ref()
             .unwrap()
             .req(&msg::std_srvs::EmptyReq {})

--- a/arci-ros/src/ros_localization_client.rs
+++ b/arci-ros/src/ros_localization_client.rs
@@ -5,10 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{msg, rosrust_utils::*};
 
-rosrust::rosmsg_include! {
-    std_srvs / Empty
-}
-
 const AMCL_POSE_TOPIC: &str = "/amcl_pose";
 const NO_MOTION_UPDATE_SERVICE: &str = "request_nomotion_update";
 

--- a/arci-ros/src/ros_nav_client.rs
+++ b/arci-ros/src/ros_nav_client.rs
@@ -6,7 +6,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{define_action_client, msg, ActionResultWait};
-define_action_client!(SimpleActionClient, msg::move_base_msgs, MoveBase);
+define_action_client!(MoveBaseActionClient, msg::move_base_msgs, MoveBase);
 
 impl From<na::Isometry2<f64>> for msg::geometry_msgs::Pose {
     fn from(goal: na::Isometry2<f64>) -> Self {
@@ -111,7 +111,7 @@ impl Default for RosNavClientBuilder {
 #[derive(Clone)]
 pub struct RosNavClient {
     pub clear_costmap_before_start: bool,
-    action_client: Arc<SimpleActionClient>,
+    action_client: Arc<MoveBaseActionClient>,
     nomotion_update_client: Option<rosrust::Client<msg::std_srvs::Empty>>,
     nomotion_update_service_name: String,
     clear_costmap_service_name: String,
@@ -124,7 +124,7 @@ impl RosNavClient {
         nomotion_update_service_name: String,
         clear_costmap_service_name: String,
     ) -> Self {
-        let action_client = SimpleActionClient::new(&move_base_action_base_name, 1);
+        let action_client = MoveBaseActionClient::new(&move_base_action_base_name, 1);
 
         let nomotion_update_client = if request_final_nomotion_update_hack {
             rosrust::wait_for_service(

--- a/arci-ros/src/ros_nav_client.rs
+++ b/arci-ros/src/ros_nav_client.rs
@@ -8,10 +8,6 @@ use serde::{Deserialize, Serialize};
 use crate::{define_action_client, msg, ActionResultWait};
 define_action_client!(SimpleActionClient, msg::move_base_msgs, MoveBase);
 
-rosrust::rosmsg_include! {
-    std_srvs / Empty
-}
-
 impl From<na::Isometry2<f64>> for msg::geometry_msgs::Pose {
     fn from(goal: na::Isometry2<f64>) -> Self {
         let iso_pose = na::Isometry3::from_parts(
@@ -116,7 +112,7 @@ impl Default for RosNavClientBuilder {
 pub struct RosNavClient {
     pub clear_costmap_before_start: bool,
     action_client: Arc<SimpleActionClient>,
-    nomotion_update_client: Option<rosrust::Client<std_srvs::Empty>>,
+    nomotion_update_client: Option<rosrust::Client<msg::std_srvs::Empty>>,
     nomotion_update_service_name: String,
     clear_costmap_service_name: String,
 }
@@ -136,7 +132,7 @@ impl RosNavClient {
                 Some(std::time::Duration::from_secs(10)),
             )
             .unwrap();
-            Some(rosrust::client::<std_srvs::Empty>(&nomotion_update_service_name).unwrap())
+            Some(rosrust::client::<msg::std_srvs::Empty>(&nomotion_update_service_name).unwrap())
         } else {
             None
         };
@@ -184,7 +180,7 @@ impl RosNavClient {
             Ok(_) => {
                 rosrust::ros_info!("Action succeeds");
                 if let Some(client) = self.nomotion_update_client.as_ref() {
-                    client.req(&std_srvs::EmptyReq {}).unwrap().unwrap();
+                    client.req(&msg::std_srvs::EmptyReq {}).unwrap().unwrap();
                     rosrust::ros_info!("Called {}", self.nomotion_update_service_name);
                 }
                 Ok(())

--- a/arci/src/traits/joint_trajectory_client.rs
+++ b/arci/src/traits/joint_trajectory_client.rs
@@ -99,6 +99,7 @@ mod tests {
         );
     }
 
+    #[allow(clippy::redundant_clone)] // This is intentional.
     #[test]
     fn test_trajectory_point_clone() {
         let tp1 = TrajectoryPoint::new(vec![1.0, -1.0], std::time::Duration::from_secs(1));

--- a/arci/tests/test_waits.rs
+++ b/arci/tests/test_waits.rs
@@ -42,6 +42,7 @@ fn test_total_condition_debug() {
     );
 }
 
+#[allow(clippy::redundant_clone)] // This is intentional.
 #[test]
 fn test_total_condition_clone() {
     let c1 = TotalJointDiffCondition::new(1.0, 0.1);
@@ -130,6 +131,7 @@ fn test_each_condition_debug() {
     );
 }
 
+#[allow(clippy::redundant_clone)] // This is intentional.
 #[test]
 fn test_each_condition_clone() {
     let c1 = EachJointDiffCondition::new(vec![1.0, 0.1], 0.1);

--- a/ci/ubuntu-setup-lld.sh
+++ b/ci/ubuntu-setup-lld.sh
@@ -3,24 +3,21 @@ set -euo pipefail
 IFS=$'\n\t'
 
 codename="$(grep '^VERSION_CODENAME=' /etc/os-release | sed 's/^VERSION_CODENAME=//')"
-case "${codename}" in
-    bionic) LLVM_VERSION=13 ;;
-    *) LLVM_VERSION=15 ;;
-esac
-echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${LLVM_VERSION} main" |
-    sudo tee "/etc/apt/sources.list.d/llvm-toolchain-${codename}-${LLVM_VERSION}.list" >/dev/null
+llvm_version=16
+echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${llvm_version} main" |
+    sudo tee "/etc/apt/sources.list.d/llvm-toolchain-${codename}-${llvm_version}.list" >/dev/null
 curl https://apt.llvm.org/llvm-snapshot.gpg.key |
     gpg --dearmor |
     sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.gpg >/dev/null
 
 sudo apt-get -qq update
 sudo apt-get -o Dpkg::Use-Pty=0 install -y --no-install-recommends \
-    clang-"${LLVM_VERSION}" \
-    lld-"${LLVM_VERSION}"
+    clang-"${llvm_version}" \
+    lld-"${llvm_version}"
 
-for tool in /usr/bin/clang*-"${LLVM_VERSION}" /usr/bin/*lld*-"${LLVM_VERSION}"; do
-    link="${tool%"-${LLVM_VERSION}"}"
+for tool in /usr/bin/clang*-"${llvm_version}" /usr/bin/*lld*-"${llvm_version}"; do
+    link="${tool%"-${llvm_version}"}"
     sudo update-alternatives --install "${link}" "${link##*/}" "${tool}" 10
 done
 
-echo "RUSTFLAGS=${RUSTFLAGS} -C linker=clang-${LLVM_VERSION} -C link-arg=-fuse-ld=lld-${LLVM_VERSION}" >>"${GITHUB_ENV}"
+echo "RUSTFLAGS=${RUSTFLAGS} -C linker=clang-${llvm_version} -C link-arg=-fuse-ld=lld-${llvm_version}" >>"${GITHUB_ENV}"

--- a/openrr-plugin/examples/plugin/src/lib.rs
+++ b/openrr-plugin/examples/plugin/src/lib.rs
@@ -80,7 +80,7 @@ impl arci::JointTrajectoryClient for MyJointTrajectoryClient {
     ) -> Result<WaitFuture, Error> {
         println!("positions = {positions:?}, duration = {duration:?}");
         *self.joint_positions.lock() = positions;
-        Ok(WaitFuture::new(async move { async { Ok(()) }.await }))
+        Ok(WaitFuture::new(async { Ok(()) }))
     }
 
     fn send_joint_trajectory(


### PR DESCRIPTION
The latest version (0.7.1) is broken.

https://github.com/openrr/openrr/actions/runs/5070455346/jobs/9105512752

<details><summary>log</summary>

```
error[E0599]: no associated item named `ERROR_NONE` found for struct `CancelGoal::Response` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_clients.rs:253:75
    |
253 |                         e if e == action_msgs::srv::CancelGoal::Response::ERROR_NONE as i8 => Ok(()),
    |                                                                           ^^^^^^^^^^ associated item not found in `Response`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:80:27
    |
80  |                           pub struct Response {
    |                           ------------------- associated item `ERROR_NONE` not found for this struct

error[E0599]: no associated item named `ERROR_REJECTED` found for struct `CancelGoal::Response` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_clients.rs:254:75
    |
254 |                         e if e == action_msgs::srv::CancelGoal::Response::ERROR_REJECTED as i8 => Err(Error::GoalCancelRejected),
    |                                                                           ^^^^^^^^^^^^^^ associated item not found in `Response`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:80:27
    |
80  |                           pub struct Response {
    |                           ------------------- associated item `ERROR_REJECTED` not found for this struct

error[E0599]: no associated item named `ERROR_UNKNOWN_GOAL_ID` found for struct `CancelGoal::Response` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_clients.rs:255:75
    |
255 | ...   e if e == action_msgs::srv::CancelGoal::Response::ERROR_UNKNOWN_GOAL_ID as i8 => Err(Error::GoalCancelUnknownGoalID),
    |                                                         ^^^^^^^^^^^^^^^^^^^^^ associated item not found in `Response`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:80:27
    |
80  |                           pub struct Response {
    |                           ------------------- associated item `ERROR_UNKNOWN_GOAL_ID` not found for this struct

error[E0599]: no associated item named `ERROR_GOAL_TERMINATED` found for struct `CancelGoal::Response` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_clients.rs:256:75
    |
256 | ...   e if e == action_msgs::srv::CancelGoal::Response::ERROR_GOAL_TERMINATED as i8 => Err(Error::GoalCancelAlreadyTerminated),
    |                                                         ^^^^^^^^^^^^^^^^^^^^^ associated item not found in `Response`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:80:27
    |
80  |                           pub struct Response {
    |                           ------------------- associated item `ERROR_GOAL_TERMINATED` not found for this struct

error[E0599]: no associated item named `ERROR_NONE` found for struct `CancelGoal::Response` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_clients_untyped.rs:220:75
    |
220 |                         e if e == action_msgs::srv::CancelGoal::Response::ERROR_NONE as i8 => Ok(()),
    |                                                                           ^^^^^^^^^^ associated item not found in `Response`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:80:27
    |
80  |                           pub struct Response {
    |                           ------------------- associated item `ERROR_NONE` not found for this struct

error[E0599]: no associated item named `ERROR_REJECTED` found for struct `CancelGoal::Response` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_clients_untyped.rs:221:75
    |
221 |                         e if e == action_msgs::srv::CancelGoal::Response::ERROR_REJECTED as i8 => Err(Error::GoalCancelRejected),
    |                                                                           ^^^^^^^^^^^^^^ associated item not found in `Response`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:80:27
    |
80  |                           pub struct Response {
    |                           ------------------- associated item `ERROR_REJECTED` not found for this struct

error[E0599]: no associated item named `ERROR_UNKNOWN_GOAL_ID` found for struct `CancelGoal::Response` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_clients_untyped.rs:222:75
    |
222 | ...   e if e == action_msgs::srv::CancelGoal::Response::ERROR_UNKNOWN_GOAL_ID as i8 => Err(Error::GoalCancelUnknownGoalID),
    |                                                         ^^^^^^^^^^^^^^^^^^^^^ associated item not found in `Response`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:80:27
    |
80  |                           pub struct Response {
    |                           ------------------- associated item `ERROR_UNKNOWN_GOAL_ID` not found for this struct

error[E0599]: no associated item named `ERROR_GOAL_TERMINATED` found for struct `CancelGoal::Response` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_clients_untyped.rs:223:75
    |
223 | ...   e if e == action_msgs::srv::CancelGoal::Response::ERROR_GOAL_TERMINATED as i8 => Err(Error::GoalCancelAlreadyTerminated),
    |                                                         ^^^^^^^^^^^^^^^^^^^^^ associated item not found in `Response`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:80:27
    |
80  |                           pub struct Response {
    |                           ------------------- associated item `ERROR_GOAL_TERMINATED` not found for this struct

error[E0599]: no associated item named `STATUS_UNKNOWN` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:17:73
    |
17  |             GoalStatus::Unknown => crate::action_msgs::msg::GoalStatus::STATUS_UNKNOWN as i8,
    |                                                                         ^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_UNKNOWN` not found for this struct

error[E0599]: no associated item named `STATUS_ACCEPTED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:18:74
    |
18  |             GoalStatus::Accepted => crate::action_msgs::msg::GoalStatus::STATUS_ACCEPTED as i8,
    |                                                                          ^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_ACCEPTED` not found for this struct

error[E0599]: no associated item named `STATUS_EXECUTING` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:19:75
    |
19  |             GoalStatus::Executing => crate::action_msgs::msg::GoalStatus::STATUS_EXECUTING as i8,
    |                                                                           ^^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_EXECUTING` not found for this struct

error[E0599]: no associated item named `STATUS_CANCELING` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:20:75
    |
20  |             GoalStatus::Canceling => crate::action_msgs::msg::GoalStatus::STATUS_CANCELING as i8,
    |                                                                           ^^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_CANCELING` not found for this struct

error[E0599]: no associated item named `STATUS_SUCCEEDED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:21:75
    |
21  |             GoalStatus::Succeeded => crate::action_msgs::msg::GoalStatus::STATUS_SUCCEEDED as i8,
    |                                                                           ^^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_SUCCEEDED` not found for this struct

error[E0599]: no associated item named `STATUS_CANCELED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:22:74
    |
22  |             GoalStatus::Canceled => crate::action_msgs::msg::GoalStatus::STATUS_CANCELED as i8,
    |                                                                          ^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_CANCELED` not found for this struct

error[E0599]: no associated item named `STATUS_ABORTED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:23:73
    |
23  |             GoalStatus::Aborted => crate::action_msgs::msg::GoalStatus::STATUS_ABORTED as i8,
    |                                                                         ^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_ABORTED` not found for this struct

error[E0599]: no associated item named `STATUS_UNKNOWN` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:29:60
    |
29  |             s if s == crate::action_msgs::msg::GoalStatus::STATUS_UNKNOWN as i8 => GoalStatus::Unknown,
    |                                                            ^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_UNKNOWN` not found for this struct

error[E0599]: no associated item named `STATUS_ACCEPTED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:30:60
    |
30  |             s if s == crate::action_msgs::msg::GoalStatus::STATUS_ACCEPTED as i8 => GoalStatus::Accepted,
    |                                                            ^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_ACCEPTED` not found for this struct

error[E0599]: no associated item named `STATUS_EXECUTING` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:31:60
    |
31  |             s if s == crate::action_msgs::msg::GoalStatus::STATUS_EXECUTING as i8 => GoalStatus::Executing,
    |                                                            ^^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_EXECUTING` not found for this struct

error[E0599]: no associated item named `STATUS_CANCELING` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:32:60
    |
32  |             s if s == crate::action_msgs::msg::GoalStatus::STATUS_CANCELING as i8 => GoalStatus::Canceling,
    |                                                            ^^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_CANCELING` not found for this struct

error[E0599]: no associated item named `STATUS_SUCCEEDED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:33:60
    |
33  |             s if s == crate::action_msgs::msg::GoalStatus::STATUS_SUCCEEDED as i8 => GoalStatus::Succeeded,
    |                                                            ^^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_SUCCEEDED` not found for this struct

error[E0599]: no associated item named `STATUS_CANCELED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:34:60
    |
34  |             s if s == crate::action_msgs::msg::GoalStatus::STATUS_CANCELED as i8 => GoalStatus::Canceled,
    |                                                            ^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_CANCELED` not found for this struct

error[E0599]: no associated item named `STATUS_ABORTED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_common.rs:35:60
    |
35  |             s if s == crate::action_msgs::msg::GoalStatus::STATUS_ABORTED as i8 => GoalStatus::Aborted,
    |                                                            ^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_ABORTED` not found for this struct

error[E0599]: no associated item named `STATUS_UNKNOWN` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_servers.rs:194:59
    |
194 |             let mut state = action_msgs::msg::GoalStatus::STATUS_UNKNOWN as u8;
    |                                                           ^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_UNKNOWN` not found for this struct

error[E0599]: no associated item named `STATUS_CANCELING` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_servers.rs:201:62
    |
201 |             return Ok(state == action_msgs::msg::GoalStatus::STATUS_CANCELING as u8);
    |                                                              ^^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_CANCELING` not found for this struct

error[E0599]: no associated item named `ERROR_REJECTED` found for struct `CancelGoal::Response` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_servers.rs:[297](https://github.com/openrr/openrr/actions/runs/5070455346/jobs/9105512752#step:8:298):92
    |
297 |                         response_msg.return_code = action_msgs::srv::CancelGoal::Response::ERROR_REJECTED as i8;
    |                                                                                            ^^^^^^^^^^^^^^ associated item not found in `Response`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:80:27
    |
80  |                           pub struct Response {
    |                           ------------------- associated item `ERROR_REJECTED` not found for this struct

error[E0599]: no associated item named `STATUS_UNKNOWN` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_servers.rs:536:81
    |
536 |             let msg = T::make_result_response_msg(action_msgs::msg::GoalStatus::STATUS_UNKNOWN as i8, T::Result::default());
    |                                                                                 ^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_UNKNOWN` not found for this struct

error[E0599]: no associated item named `STATUS_CANCELED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_servers.rs:667:84
    |
667 |         let result_msg = T::make_result_response_msg(action_msgs::msg::GoalStatus::STATUS_CANCELED as i8, msg);
    |                                                                                    ^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_CANCELED` not found for this struct

error[E0599]: no associated item named `STATUS_ABORTED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_servers.rs:687:84
    |
687 |         let result_msg = T::make_result_response_msg(action_msgs::msg::GoalStatus::STATUS_ABORTED as i8, msg);
    |                                                                                    ^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_ABORTED` not found for this struct

error[E0599]: no associated item named `STATUS_SUCCEEDED` found for struct `generated_msgs::action_msgs::msg::GoalStatus` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/r2r-0.7.1/src/action_servers.rs:710:84
    |
710 |         let result_msg = T::make_result_response_msg(action_msgs::msg::GoalStatus::STATUS_SUCCEEDED as i8, msg);
    |                                                                                    ^^^^^^^^^^^^^^^^ associated item not found in `GoalStatus`
    |
   ::: /__w/openrr/openrr/target/debug/build/r2r-6f08caf23bc2c702/out/action_msgs.rs:217:27
    |
217 |                           pub struct GoalStatus {
    |                           --------------------- associated item `STATUS_SUCCEEDED` not found for this struct

For more information about this error, try `rustc --explain E0599`.
```

</details>

coverage test also failed due to a linker error (bug in old llvm).

https://github.com/openrr/openrr/actions/runs/5117527713/jobs/9200803011

<details><summary>log</summary>

```
  = note: PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
          Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
          /lib/x86_64-linux-gnu/libLLVM-15.so.1(_ZN4llvm3sys15PrintStackTraceERNS_11raw_ostreamEi+0x31)[0x7f7b0d835e91]
          /lib/x86_64-linux-gnu/libLLVM-15.so.1(_ZN4llvm3sys17RunSignalHandlersEv+0xee)[0x7f7b0d833bde]
          /lib/x86_64-linux-gnu/libLLVM-15.so.1(+0xf023bb)[0x7f7b0d8363bb]
          /lib/x86_64-linux-gnu/libpthread.so.0(+0x14420)[0x7f7b138f6420]
          /lib/x86_64-linux-gnu/libc.so.6(+0x18b7e4)[0x7f7b0c57f7e4]
          /lib/x86_64-linux-gnu/libLLVM-15.so.1(_ZNK4llvm18StringTableBuilder5writeEPh+0x86)[0x7f7b0ee67206]
          /lib/x86_64-linux-gnu/libLLVM-15.so.1(+0xe7577c)[0x7f7b0d7a977c]
          /lib/x86_64-linux-gnu/libLLVM-15.so.1(+0xe75635)[0x7f7b0d7a9635]
          /lib/x86_64-linux-gnu/libLLVM-15.so.1(+0xe74a98)[0x7f7b0d7a8a98]
          /lib/x86_64-linux-gnu/libLLVM-15.so.1(+0xe74751)[0x7f7b0d7a8751]
          /lib/x86_64-linux-gnu/libstdc++.so.6(+0xd6de4)[0x7f7b0c828de4]
          /lib/x86_64-linux-gnu/libpthread.so.0(+0x8609)[0x7f7b138ea609]
          /lib/x86_64-linux-gnu/libc.so.6(clone+0x43)[0x7f7b0c513133]
          clang: error: unable to execute command: Bus error (core dumped)
          clang: error: linker command failed due to signal (use -v to see invocation)
```

</details>

This also addresses some warnings added in Rust 1.70. 