### PR TITLE
Remove max size for GUI

### DIFF
--- a/openrr-gui/src/joint_position_sender.rs
+++ b/openrr-gui/src/joint_position_sender.rs
@@ -24,7 +24,7 @@ where
     validate_joints(&joints, &robot_client)?;
 
     let native_options = eframe::NativeOptions {
-        max_window_size: Some(egui::vec2(400.0, 400.0)),
+        initial_window_size: Some(egui::vec2(400.0, 400.0)),
         icon_data: Some(
             IconData::try_from_png_bytes(include_bytes!("../assets/icon/openrr.png")).unwrap(),
         ),

--- a/openrr-gui/src/velocity_sender.rs
+++ b/openrr-gui/src/velocity_sender.rs
@@ -12,7 +12,7 @@ where
     M: MoveBase + 'static,
 {
     let native_options = eframe::NativeOptions {
-        max_window_size: Some(egui::vec2(400.0, 400.0)),
+        initial_window_size: Some(egui::vec2(400.0, 400.0)),
         icon_data: Some(
             IconData::try_from_png_bytes(include_bytes!("../assets/icon/openrr.png")).unwrap(),
         ),


### PR DESCRIPTION
In current GUI, we cannot access slide bar in the bottom

<img width="512" alt="Screenshot 2023-08-01 at 1 40 01" src="https://github.com/openrr/openrr/assets/44460592/24ad3345-5d32-4f18-aaea-b6df21846ffa">
