### PR TITLE
[openrr-tracing] Fix deprecated warning from chrono

### DIFF
--- a/openrr-tracing/examples/influxdb.rs
+++ b/openrr-tracing/examples/influxdb.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
         use influxdb::InfluxDbWriteable;
         let d = log[1].timestamp.signed_duration_since(log[0].timestamp);
         v.push(
-            influxdb::Timestamp::Nanoseconds(log[0].timestamp.timestamp_nanos() as _)
+            influxdb::Timestamp::Nanoseconds(log[0].timestamp.timestamp_nanos_opt().unwrap() as _)
                 .into_query("send_velocity")
                 .add_field("duration", d.num_nanoseconds().unwrap())
                 .add_field("velocity_x", log[0].velocity.x)


### PR DESCRIPTION
```
error: use of deprecated method `chrono::datetime::DateTime::<Tz>::timestamp_nanos`: use `timestamp_nanos_opt()` instead
  --> openrr-tracing/examples/influxdb.rs:57:63
   |
57 |             influxdb::Timestamp::Nanoseconds(log[0].timestamp.timestamp_nanos() as _)
   |                                                               ^^^^^^^^^^^^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`
```