### PR TITLE
[arci-ros2] Use Node instead of r2r::Context in API

### DIFF
--- a/arci-ros2/examples/navigation.rs
+++ b/arci-ros2/examples/navigation.rs
@@ -4,10 +4,11 @@ async fn main() -> anyhow::Result<()> {
     use std::time::Duration;
 
     use arci::*;
-    use arci_ros2::{r2r, Ros2Navigation};
+    use arci_ros2::{Node, Ros2Navigation};
 
-    let ctx = r2r::Context::create().unwrap();
-    let nav = Ros2Navigation::new(ctx, "/navigate_to_pose");
+    let node = Node::new("nav2_node", "arci_ros2").unwrap();
+    node.run_spin_thread(Duration::from_millis(100));
+    let nav = Ros2Navigation::new(node, "/navigate_to_pose");
     nav.send_goal_pose(
         Isometry2::new(Vector2::new(-0.6, 0.2), 1.0),
         "map",

--- a/arci-ros2/examples/ros2_cmd_vel.rs
+++ b/arci-ros2/examples/ros2_cmd_vel.rs
@@ -2,10 +2,10 @@
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     use arci::{BaseVelocity, MoveBase};
-    use arci_ros2::{r2r, Ros2CmdVelMoveBase};
+    use arci_ros2::{Node, Ros2CmdVelMoveBase};
 
-    let ctx = r2r::Context::create().unwrap();
-    let c = Ros2CmdVelMoveBase::new(ctx, "/cmd_vel");
+    let node = Node::new("cmd_vel_node", "arci_ros2").unwrap();
+    let c = Ros2CmdVelMoveBase::new(node, "/cmd_vel");
     let mut count = 0;
     let mut vel = BaseVelocity::default();
     while count < 100 {

--- a/arci-ros2/examples/ros2_control.rs
+++ b/arci-ros2/examples/ros2_control.rs
@@ -4,10 +4,11 @@ async fn main() -> anyhow::Result<()> {
     use std::time::Duration;
 
     use arci::*;
-    use arci_ros2::{r2r, Ros2ControlClient};
+    use arci_ros2::{Node, Ros2ControlClient};
 
-    let ctx = r2r::Context::create().unwrap();
-    let client = Ros2ControlClient::new(ctx, "/position_trajectory_controller");
+    let node = Node::new("ros2_control_node", "arci_ros2").unwrap();
+    node.run_spin_thread(Duration::from_millis(100));
+    let client = Ros2ControlClient::new(node, "/position_trajectory_controller");
     dbg!(client.joint_names()); // => ["joint1", "joint2"]
     dbg!(client.current_joint_positions()).unwrap();
     client

--- a/arci-ros2/src/lib.rs
+++ b/arci-ros2/src/lib.rs
@@ -13,6 +13,7 @@
 
 mod cmd_vel_move_base;
 mod navigation;
+mod node;
 mod plugin;
 mod ros2_control;
 mod ros2_laser_scan;
@@ -20,6 +21,7 @@ mod utils;
 
 pub use cmd_vel_move_base::*;
 pub use navigation::*;
+pub use node::*;
 // re-export
 pub use r2r;
 pub use ros2_control::*;

--- a/arci-ros2/src/node.rs
+++ b/arci-ros2/src/node.rs
@@ -1,0 +1,70 @@
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use parking_lot::{Mutex, MutexGuard};
+
+/// ROS2 node. This is a wrapper around `Arc<Mutex<r2r::Node>>`.
+#[derive(Clone)]
+pub struct Node {
+    inner: Arc<NodeInner>,
+}
+
+struct NodeInner {
+    node: Mutex<r2r::Node>,
+    has_spin_thread: AtomicBool,
+}
+
+impl Node {
+    /// Creates a new ROS2 node.
+    pub fn new(name: &str, namespace: &str) -> Result<Self, arci::Error> {
+        let ctx = r2r::Context::create().map_err(anyhow::Error::from)?;
+        Self::with_context(ctx, name, namespace)
+    }
+
+    /// Creates a new ROS2 node with `r2r::Context`.
+    pub fn with_context(
+        ctx: r2r::Context,
+        name: &str,
+        namespace: &str,
+    ) -> Result<Self, arci::Error> {
+        let node = r2r::Node::create(ctx, name, namespace).map_err(anyhow::Error::from)?;
+        Ok(Self {
+            inner: Arc::new(NodeInner {
+                node: Mutex::new(node),
+                has_spin_thread: AtomicBool::new(false),
+            }),
+        })
+    }
+
+    /// Gets underlying `r2r::Node`.
+    pub fn r2r(&self) -> MutexGuard<'_, r2r::Node> {
+        self.inner.node.lock()
+    }
+
+    /// Creates a thread to spin the ROS2 node.
+    pub fn run_spin_thread(&self, interval: Duration) {
+        if self.inner.has_spin_thread.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let node = self.clone();
+        tokio::spawn(async move {
+            while Arc::strong_count(&node.inner) > 1 {
+                node.spin_once(interval).await;
+            }
+        });
+    }
+
+    /// Spins the ROS2 node.
+    pub async fn spin_once(&self, duration: Duration) {
+        let now = std::time::Instant::now();
+        // Sleep with tokio::time::sleep instead of spin_once, since spin_once
+        // blocks the current thread while still holding the lock.
+        self.r2r().spin_once(Duration::ZERO);
+        tokio::time::sleep(duration.saturating_sub(now.elapsed())).await;
+    }
+}

--- a/arci-ros2/src/plugin.rs
+++ b/arci-ros2/src/plugin.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Ros2CmdVelMoveBase, Ros2CmdVelMoveBaseConfig, Ros2ControlClient, Ros2ControlConfig,
+    Node, Ros2CmdVelMoveBase, Ros2CmdVelMoveBaseConfig, Ros2ControlClient, Ros2ControlConfig,
     Ros2LaserScan2D, Ros2LaserScan2DConfig, Ros2Navigation, Ros2NavigationConfig,
 };
 
@@ -13,8 +13,8 @@ impl openrr_plugin::Plugin for Ros2Plugin {
         args: String,
     ) -> Result<Option<Box<dyn arci::JointTrajectoryClient>>, arci::Error> {
         let config: Ros2ControlConfig = toml::from_str(&args).map_err(anyhow::Error::from)?;
-        let ctx = r2r::Context::create().unwrap();
-        let all_client = Ros2ControlClient::new(ctx, &config.action_name);
+        let node = Node::new("plugin_ros2_control_node", "arci_ros2").unwrap();
+        let all_client = Ros2ControlClient::new(node, &config.action_name);
         if config.joint_names.is_empty() {
             Ok(Some(Box::new(all_client)))
         } else {
@@ -28,8 +28,8 @@ impl openrr_plugin::Plugin for Ros2Plugin {
     fn new_move_base(&self, args: String) -> Result<Option<Box<dyn arci::MoveBase>>, arci::Error> {
         let config: Ros2CmdVelMoveBaseConfig =
             toml::from_str(&args).map_err(anyhow::Error::from)?;
-        let ctx = r2r::Context::create().unwrap();
-        Ok(Some(Box::new(Ros2CmdVelMoveBase::new(ctx, &config.topic))))
+        let node = Node::new("plugin_cmd_vel_node", "arci_ros2").unwrap();
+        Ok(Some(Box::new(Ros2CmdVelMoveBase::new(node, &config.topic))))
     }
 
     fn new_navigation(
@@ -37,9 +37,9 @@ impl openrr_plugin::Plugin for Ros2Plugin {
         args: String,
     ) -> Result<Option<Box<dyn arci::Navigation>>, arci::Error> {
         let config: Ros2NavigationConfig = toml::from_str(&args).map_err(anyhow::Error::from)?;
-        let ctx = r2r::Context::create().unwrap();
+        let node = Node::new("plugin_nav2_node", "arci_ros2").unwrap();
         Ok(Some(Box::new(Ros2Navigation::new(
-            ctx,
+            node,
             &config.action_name,
         ))))
     }
@@ -49,7 +49,7 @@ impl openrr_plugin::Plugin for Ros2Plugin {
         args: String,
     ) -> Result<Option<Box<dyn arci::LaserScan2D>>, arci::Error> {
         let config: Ros2LaserScan2DConfig = toml::from_str(&args).map_err(anyhow::Error::from)?;
-        let ctx = r2r::Context::create().unwrap();
-        Ok(Some(Box::new(Ros2LaserScan2D::new(ctx, &config.topic))))
+        let node = Node::new("plugin_ros2_laser_scan_node", "arci_ros2").unwrap();
+        Ok(Some(Box::new(Ros2LaserScan2D::new(node, &config.topic))))
     }
 }

--- a/arci-ros2/tests/shared/mod.rs
+++ b/arci-ros2/tests/shared/mod.rs
@@ -1,0 +1,10 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use arci_ros2::*;
+
+pub fn test_node() -> Node {
+    static COUNT: AtomicUsize = AtomicUsize::new(0);
+    let n = COUNT.fetch_add(1, Ordering::Relaxed);
+    let node_name = format!("test_arci_ros2_node_{n}");
+    Node::new(&node_name, "arci_ros2_test").unwrap()
+}

--- a/arci-ros2/tests/test_cmd_vel.rs
+++ b/arci-ros2/tests/test_cmd_vel.rs
@@ -1,18 +1,21 @@
 #![cfg(feature = "ros2")]
 
+mod shared;
+
 use arci::{BaseVelocity, MoveBase};
 use arci_ros2::{r2r, Ros2CmdVelMoveBase};
 use assert_approx_eq::assert_approx_eq;
 use futures::stream::StreamExt;
 use r2r::geometry_msgs::msg::Twist;
+use shared::*;
 
 #[tokio::test]
 async fn test_pub() {
-    let ctx = r2r::Context::create().unwrap();
-    let c = Ros2CmdVelMoveBase::new(ctx.clone(), "/cmd_vel_test");
-    let mut node = r2r::Node::create(ctx, "recv", "arci_ros2_test").unwrap();
+    let node = test_node();
+    let c = Ros2CmdVelMoveBase::new(node.clone(), "/cmd_vel_test");
 
     let mut sub = node
+        .r2r()
         .subscribe::<Twist>("/cmd_vel_test", r2r::QosProfile::default())
         .unwrap();
 
@@ -21,7 +24,7 @@ async fn test_pub() {
     while count < 10 {
         vel.x = 0.001 * (count as f64);
         c.send_velocity(&vel).unwrap();
-        node.spin_once(std::time::Duration::from_millis(10));
+        node.spin_once(std::time::Duration::from_millis(10)).await;
         let v = sub.next().await.unwrap();
         assert_approx_eq!(v.linear.x, vel.x);
         assert_approx_eq!(v.linear.y, vel.y);
@@ -38,7 +41,7 @@ async fn test_pub() {
         vel.y = 0.002 * (count as f64);
         vel.theta = -0.003 * (count as f64);
         c.send_velocity(&vel).unwrap();
-        node.spin_once(std::time::Duration::from_millis(10));
+        node.spin_once(std::time::Duration::from_millis(10)).await;
         let v = sub.next().await.unwrap();
         assert_approx_eq!(v.linear.x, vel.x);
         assert_approx_eq!(v.linear.y, vel.y);


### PR DESCRIPTION
This also unifies the documentation style.

Split from #863.