### PR TITLE
Run markdownlint in CI

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -40,6 +40,7 @@ libopenrr
 libtest
 libudev
 libxkbcommon
+markdownlint
 nanos
 nanosec
 nomotion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,13 @@ jobs:
         uses: taiki-e/install-action@shellcheck
       - run: shellcheck $(git ls-files '*.sh')
 
+  markdownlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - run: npx markdownlint-cli2 $(git ls-files '*.md')
+
   spell-check:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,6 @@
+# https://github.com/DavidAnson/markdownlint#rules--aliases
+
+MD013: false # line-length
+MD024: false # no-duplicate-heading/no-duplicate-header
+MD033: false # no-inline-html
+MD036: false # no-emphasis-as-heading/no-emphasis-as-header

--- a/README.md
+++ b/README.md
@@ -111,5 +111,5 @@ We appreciate for your any contributions!
 
 You can read the tutorial books at the following links.
 
-- [English](https://openrr.github.io/openrr-tutorial/en/html)
-- [Japanese](https://openrr.github.io/openrr-tutorial/ja/html)
+* [English](https://openrr.github.io/openrr-tutorial/en/html)
+* [Japanese](https://openrr.github.io/openrr-tutorial/ja/html)

--- a/openrr-apps/README.md
+++ b/openrr-apps/README.md
@@ -187,7 +187,6 @@ urdf-viz $(rospack find ur_description)/urdf/ur10_robot.urdf.xacro
 
 Change urdf path and joystick settings (see [here](#joystick)) in [the setting file](./config/ur10_robot_client_config_for_urdf_viz.toml) for your environment.
 
-
 ```bash
 openrr_apps_robot_teleop --config-path=./openrr-apps/config/ur10_teleop_config_urdf_viz.toml
 ```
@@ -203,7 +202,6 @@ roslaunch ur_gazebo ur10.launch
 - Run teleop.
 
 Change urdf path and joystick settings (see [here](#joystick)) in [the setting file](./config/ur10_robot_client_config_for_ros.toml) for your environment.
-
 
 ```bash
 openrr_apps_robot_teleop --config-path=./openrr-apps/config/ur10_teleop_config_ros.toml
@@ -221,7 +219,6 @@ urdf-viz $(rospack find pr2_description)/robots/pr2.urdf.xacro
 
 Change urdf path and joystick settings (see [here](#joystick)) in [the setting file](./config/pr2_robot_client_config_for_urdf_viz.toml) for your environment.
 
-
 ```bash
 openrr_apps_robot_teleop --config-path=./openrr-apps/config/pr2_teleop_config_urdf_viz.toml
 ```
@@ -238,7 +235,6 @@ roslaunch ./pr2.launch wait_time_secs:=10
 - Run teleop.
 
 Change urdf path and joystick settings (see [here](#joystick)) in [the setting file](./config/pr2_robot_client_config_for_ros.toml) for your environment.
-
 
 ```bash
 openrr_apps_robot_teleop --config-path=./openrr-apps/config/pr2_teleop_config_ros.toml


### PR DESCRIPTION
This uses markdownlint-cli2, which is used in [vscode-markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).

```console
$ npx markdownlint-cli2 $(git ls-files '*.md')
markdownlint-cli2 v0.10.0 (markdownlint v0.31.1)
Finding: README.md arci-gamepad-gilrs/README.md arci-gamepad-keyboard/README.md arci-ros/README.md arci-ros2/README.md arci-speak-audio/README.md arci-speak-cmd/README.md arci-urdf-viz/README.md arci/README.md openrr-apps/README.md openrr-client/README.md openrr-command/README.md openrr-config/README.md openrr-gui/README.md openrr-planner/README.md openrr-plugin/README.md openrr-remote/README.md openrr-teleop/README.md openrr-tracing/README.md openrr/README.md
Linting: 20 file(s)
Summary: 8 error(s)
openrr-apps/README.md:190 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
openrr-apps/README.md:207 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
openrr-apps/README.md:224 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
openrr-apps/README.md:242 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
openrr/README.md:114:1 MD004/ul-style Unordered list style [Expected: asterisk; Actual: dash]
openrr/README.md:115:1 MD004/ul-style Unordered list style [Expected: asterisk; Actual: dash]
README.md:114:1 MD004/ul-style Unordered list style [Expected: asterisk; Actual: dash]
README.md:115:1 MD004/ul-style Unordered list style [Expected: asterisk; Actual: dash]
```