### PR TITLE
Fix Windows CI device space issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        if: (!startsWith(matrix.os, 'windows'))
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ./ -> C:\target-dir
+        if: startsWith(matrix.os, 'windows')
       - uses: taiki-e/install-action@protoc
       - run: ci/free-device-space.sh
+      - run: |
+          New-Item -ItemType Directory -Force -Path C:\target-dir
+          New-Item -Path target -ItemType Junction -Value C:\target-dir
+        shell: powershell
+        if: startsWith(matrix.os, 'windows')
       - run: ci/ubuntu-setup-lld.sh
         if: startsWith(matrix.os, 'ubuntu')
       - run: ci/ubuntu-install-dependencies.sh
@@ -68,6 +78,7 @@ jobs:
       - name: cargo test (openrr-apps without ros)
         working-directory: openrr-apps
         run: cargo test --no-default-features --features gui,assimp
+      - run: df -h
 
   ros1_arci_ros:
     strategy:


### PR DESCRIPTION
GitHub-hosted Windows runners have a lot of free space in C drive, but D drive which is used as a workspace has only 14GB of free space.

Current status of PR: The device space issue has been solved, but the cache is not working yet.