### PR TITLE
Fix unused_doc_comments warning

### DIFF
--- a/openrr-base/src/odometry.rs
+++ b/openrr-base/src/odometry.rs
@@ -18,7 +18,7 @@ impl Odometry {
         Self {
             position: Mutex::new(Some(position)),
             last_update_timestamp: Mutex::new(None),
-            /// If `0`, timeout is invalid
+            // If `0`, timeout is invalid
             timeout_millis: Mutex::new(DEFAULT_TIMEOUT_MILLIS),
         }
     }


### PR DESCRIPTION
```
error: unused doc comment
  --> openrr-base/src/odometry.rs:21:13
   |
21 |             /// If `0`, timeout is invalid
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
22 |             timeout_millis: Mutex::new(DEFAULT_TIMEOUT_MILLIS),
   |             -------------------------------------------------- rustdoc does not generate documentation for expression fields
   |
   = help: use `//` for a plain comment
```