### PR TITLE
Use std::sync::Mutex instead of parking_lot

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -6,8 +6,4 @@ disallowed-methods = [
 ]
 # https://rust-lang.github.io/rust-clippy/master/#disallowed_types
 disallowed-types = [
-    # use faster `parking_lot` instead
-    { path = "std::sync::Mutex", reason = "use faster `parking_lot::Mutex` instead" },
-    { path = "std::sync::RwLock", reason = "use faster `parking_lot::RwLock` instead" },
-    { path = "std::sync::Condvar", reason = "use faster `parking_lot::Condvar` instead" },
 ]

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -9,7 +9,6 @@ cdylib
 codecov
 codegen
 collada
-Condvar
 costmap
 costmaps
 DISTRO

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,6 @@ ncollide3d = "0.33"
 nix = { version = "0.27", features = ["signal"] }
 num-traits = "0.2"
 once_cell = "1"
-parking_lot = "0.12"
 paste = "1"
 portpicker = "0.1"
 prettyplease = "=0.2.15"

--- a/arci-ros/Cargo.toml
+++ b/arci-ros/Cargo.toml
@@ -15,7 +15,6 @@ auto_impl.workspace = true
 flume.workspace = true
 nalgebra.workspace = true
 once_cell.workspace = true
-parking_lot.workspace = true
 paste.workspace = true
 ros-nalgebra.workspace = true
 rosrust.workspace = true

--- a/arci-ros/src/joy_gamepad.rs
+++ b/arci-ros/src/joy_gamepad.rs
@@ -1,7 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use arci::{gamepad::*, *};
-use parking_lot::Mutex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -32,7 +34,7 @@ impl RosJoyGamepad {
 
         let last_joy_msg_clone = last_joy_msg.clone();
         let _sub = rosrust::subscribe(topic_name, TOPIC_BUFFER_SIZE, move |joy_msg: Joy| {
-            let mut last_joy = last_joy_msg_clone.lock();
+            let mut last_joy = last_joy_msg_clone.lock().unwrap();
             // initialize last_joy_msg
             if last_joy.buttons.len() < joy_msg.buttons.len() {
                 last_joy.buttons.resize(joy_msg.buttons.len(), 0);

--- a/arci-ros/src/lib.rs
+++ b/arci-ros/src/lib.rs
@@ -20,8 +20,6 @@ pub mod rosrust_utils;
 #[doc(hidden)] // re-export for macros
 pub use flume;
 #[doc(hidden)] // re-export for macros
-pub use parking_lot;
-#[doc(hidden)] // re-export for macros
 pub use paste;
 pub use rosrust::{self, init, is_ok, name, rate};
 

--- a/arci-ros/src/ros_control/joint_velocity_controller.rs
+++ b/arci-ros/src/ros_control/joint_velocity_controller.rs
@@ -1,8 +1,7 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arci::MotorDriveVelocity;
 use msg::{sensor_msgs::JointState, std_msgs::Float64};
-use parking_lot::Mutex;
 
 use crate::msg;
 
@@ -28,7 +27,7 @@ impl JointVelocityController {
         let callback_motor_velocity_state = motor_velocity_state.clone();
 
         let _subscriber = rosrust::subscribe(joint_state_topic, 1, move |msg: JointState| {
-            let mut vel = callback_motor_velocity_state.lock();
+            let mut vel = callback_motor_velocity_state.lock().unwrap();
             *vel = msg.velocity[joint_index];
         })
         .unwrap();
@@ -59,7 +58,7 @@ impl MotorDriveVelocity for JointVelocityController {
     }
 
     fn get_motor_velocity(&self) -> Result<f64, arci::Error> {
-        let vel = self.0.motor_velocity_state.lock();
+        let vel = self.0.motor_velocity_state.lock().unwrap();
         Ok(if self.0.is_reverse_direction {
             -(*vel)
         } else {

--- a/arci-ros/src/ros_control/ros_control_action_client.rs
+++ b/arci-ros/src/ros_control/ros_control_action_client.rs
@@ -1,11 +1,13 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use arci::{
     CompleteCondition, JointTrajectoryClient, SetCompleteCondition, TotalJointDiffCondition,
     TrajectoryPoint, WaitFuture,
 };
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 
 use crate::{
     create_joint_trajectory_message_for_send_joint_positions,
@@ -133,7 +135,7 @@ impl JointTrajectoryClient for RosControlActionClient {
             .await
             .map_err(|e| arci::Error::Other(e.into()))??;
             // Clone to avoid holding the lock for a long time.
-            let complete_condition = this.0.complete_condition.lock().clone();
+            let complete_condition = this.0.complete_condition.lock().unwrap().clone();
             complete_condition
                 .wait(&this, &positions, duration.as_secs_f64())
                 .await
@@ -174,7 +176,7 @@ impl JointTrajectoryClient for RosControlActionClient {
             .await
             .map_err(|e| arci::Error::Other(e.into()))??;
             // Clone to avoid holding the lock for a long time.
-            let complete_condition = this.0.complete_condition.lock().clone();
+            let complete_condition = this.0.complete_condition.lock().unwrap().clone();
             complete_condition
                 .wait(
                     &this,
@@ -188,6 +190,6 @@ impl JointTrajectoryClient for RosControlActionClient {
 
 impl SetCompleteCondition for RosControlActionClient {
     fn set_complete_condition(&mut self, condition: Box<dyn CompleteCondition>) {
-        *self.0.complete_condition.lock() = condition.into();
+        *self.0.complete_condition.lock().unwrap() = condition.into();
     }
 }

--- a/arci-ros/src/ros_control/ros_control_client.rs
+++ b/arci-ros/src/ros_control/ros_control_client.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use arci::{
     CompleteCondition, JointTrajectoryClient, SetCompleteCondition, TotalJointDiffCondition,
@@ -6,7 +9,6 @@ use arci::{
 };
 use msg::trajectory_msgs::JointTrajectory;
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 
 use crate::{
     create_joint_trajectory_message_for_send_joint_positions,
@@ -137,7 +139,7 @@ impl JointTrajectoryClient for RosControlClient {
         let this = self.clone();
         Ok(WaitFuture::new(async move {
             // Clone to avoid holding the lock for a long time.
-            let complete_condition = this.0.complete_condition.lock().clone();
+            let complete_condition = this.0.complete_condition.lock().unwrap().clone();
             complete_condition
                 .wait(&this, &positions, duration.as_secs_f64())
                 .await
@@ -158,7 +160,7 @@ impl JointTrajectoryClient for RosControlClient {
         let this = self.clone();
         Ok(WaitFuture::new(async move {
             // Clone to avoid holding the lock for a long time.
-            let complete_condition = this.0.complete_condition.lock().clone();
+            let complete_condition = this.0.complete_condition.lock().unwrap().clone();
             complete_condition
                 .wait(
                     &this,
@@ -172,6 +174,6 @@ impl JointTrajectoryClient for RosControlClient {
 
 impl SetCompleteCondition for RosControlClient {
     fn set_complete_condition(&mut self, condition: Box<dyn CompleteCondition>) {
-        *self.0.complete_condition.lock() = condition.into();
+        *self.0.complete_condition.lock().unwrap() = condition.into();
     }
 }

--- a/arci-ros/src/ros_robot_client.rs
+++ b/arci-ros/src/ros_robot_client.rs
@@ -1,7 +1,6 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use arci::*;
-use parking_lot::Mutex;
 
 use crate::msg;
 
@@ -40,12 +39,12 @@ impl RosRobotClient {
             joint_state_topic_name,
             1,
             move |joint_state: msg::sensor_msgs::JointState| {
-                let mut aaa = joint_state_message_for_sub.lock();
+                let mut aaa = joint_state_message_for_sub.lock().unwrap();
                 *aaa = joint_state;
             },
         )
         .unwrap();
-        while joint_state_message.lock().name.is_empty() {
+        while joint_state_message.lock().unwrap().name.is_empty() {
             rosrust::ros_info!("waiting joint state publisher");
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
@@ -79,7 +78,7 @@ impl JointTrajectoryClient for RosRobotClient {
     }
 
     fn current_joint_positions(&self) -> Result<Vec<f64>, Error> {
-        let message = self.0.joint_state_message.lock();
+        let message = self.0.joint_state_message.lock().unwrap();
         Ok(message.position.clone())
     }
 
@@ -109,7 +108,7 @@ impl JointTrajectoryClient for RosRobotClient {
             let this = self.clone();
             Ok(WaitFuture::new(async move {
                 // Clone to avoid holding the lock for a long time.
-                let complete_condition = this.0.complete_condition.lock().clone();
+                let complete_condition = this.0.complete_condition.lock().unwrap().clone();
                 complete_condition
                     .wait(&this, &positions, duration.as_secs_f64())
                     .await
@@ -130,7 +129,7 @@ impl JointTrajectoryClient for RosRobotClient {
             let this = self.clone();
             Ok(WaitFuture::new(async move {
                 // Clone to avoid holding the lock for a long time.
-                let complete_condition = this.0.complete_condition.lock().clone();
+                let complete_condition = this.0.complete_condition.lock().unwrap().clone();
                 complete_condition
                     .wait(
                         &this,
@@ -147,6 +146,6 @@ impl JointTrajectoryClient for RosRobotClient {
 
 impl SetCompleteCondition for RosRobotClient {
     fn set_complete_condition(&mut self, condition: Box<dyn CompleteCondition>) {
-        *self.0.complete_condition.lock() = condition.into();
+        *self.0.complete_condition.lock().unwrap() = condition.into();
     }
 }

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -21,7 +21,6 @@ arci.workspace = true
 futures.workspace = true
 once_cell.workspace = true
 openrr-plugin.workspace = true
-parking_lot.workspace = true
 r2r = { workspace = true, optional = true }
 serde.workspace = true
 thiserror.workspace = true

--- a/arci-ros2/src/cmd_vel_move_base.rs
+++ b/arci-ros2/src/cmd_vel_move_base.rs
@@ -1,5 +1,6 @@
+use std::sync::Mutex;
+
 use arci::*;
-use parking_lot::Mutex;
 use r2r::geometry_msgs::msg::Twist;
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +36,7 @@ impl MoveBase for Ros2CmdVelMoveBase {
         twist_msg.angular.z = velocity.theta;
         self.vel_publisher
             .lock()
+            .unwrap()
             .publish(&twist_msg)
             .map_err(|e| arci::Error::Connection {
                 message: format!("r2r publish error: {e:?}"),

--- a/arci-ros2/src/node.rs
+++ b/arci-ros2/src/node.rs
@@ -1,12 +1,10 @@
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        Arc, Mutex, MutexGuard,
     },
     time::Duration,
 };
-
-use parking_lot::{Mutex, MutexGuard};
 
 /// ROS2 node. This is a wrapper around `Arc<Mutex<r2r::Node>>`.
 #[derive(Clone)]
@@ -43,7 +41,7 @@ impl Node {
 
     /// Gets underlying `r2r::Node`.
     pub fn r2r(&self) -> MutexGuard<'_, r2r::Node> {
-        self.inner.node.lock()
+        self.inner.node.lock().unwrap()
     }
 
     /// Creates a thread to spin the ROS2 node.

--- a/arci-ros2/tests/test_ros2_control.rs
+++ b/arci-ros2/tests/test_ros2_control.rs
@@ -5,7 +5,7 @@ mod shared;
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Mutex,
     },
     time::Duration,
 };
@@ -16,7 +16,6 @@ use futures::{
     future::{self, Either},
     stream::{Stream, StreamExt},
 };
-use parking_lot::Mutex;
 use r2r::{
     control_msgs::{action::FollowJointTrajectory, msg::JointTrajectoryControllerState},
     trajectory_msgs::msg as trajectory_msg,
@@ -61,7 +60,7 @@ async fn test_control() {
     ));
     tokio::spawn(async move {
         loop {
-            publisher.publish(&state.lock()).unwrap();
+            publisher.publish(&state.lock().unwrap()).unwrap();
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
     });
@@ -88,7 +87,7 @@ async fn run_goal(
         .create_wall_timer(Duration::from_millis(800))
         .expect("could not create timer");
 
-    state.lock().actual.positions = goal
+    state.lock().unwrap().actual.positions = goal
         .goal
         .trajectory
         .points

--- a/arci-speak-audio/Cargo.toml
+++ b/arci-speak-audio/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science::robotics"]
 arci.workspace = true
 rodio.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync", "parking_lot"] }
+tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/arci-speak-cmd/Cargo.toml
+++ b/arci-speak-cmd/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science::robotics"]
 [dependencies]
 arci.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["sync", "parking_lot"] }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 clap.workspace = true

--- a/arci-urdf-viz/Cargo.toml
+++ b/arci-urdf-viz/Cargo.toml
@@ -12,12 +12,11 @@ categories = ["science::robotics"]
 anyhow.workspace = true
 arci.workspace = true
 openrr-planner.workspace = true
-parking_lot.workspace = true
 schemars.workspace = true
 scoped-sleep.workspace = true
 serde_json.workspace = true
 serde.workspace = true
-tokio = { workspace = true, features = ["sync", "parking_lot"] }
+tokio = { workspace = true, features = ["sync"] }
 tracing.workspace = true
 urdf-rs.workspace = true
 ureq.workspace = true

--- a/arci-urdf-viz/src/client.rs
+++ b/arci-urdf-viz/src/client.rs
@@ -1,11 +1,17 @@
-use std::{borrow::Cow, collections::HashMap, mem, sync::Arc, thread::sleep, time::Duration};
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    mem,
+    sync::{Arc, Mutex},
+    thread::sleep,
+    time::Duration,
+};
 
 use anyhow::format_err;
 use arci::{
     nalgebra as na, BaseVelocity, JointPositionLimit, JointPositionLimiter, JointTrajectoryClient,
     JointVelocityLimiter, Localization, MoveBase, Navigation, TrajectoryPoint, WaitFuture,
 };
-use parking_lot::Mutex;
 use schemars::JsonSchema;
 use scoped_sleep::ScopedSleep;
 use serde::{Deserialize, Serialize};
@@ -225,7 +231,7 @@ struct UrdfVizWebClientInner {
 
 impl UrdfVizWebClientInner {
     fn is_dropping(self: &Arc<Self>) -> bool {
-        let state = self.threads.lock();
+        let state = self.threads.lock().unwrap();
         Arc::strong_count(self)
             <= state.has_send_joint_positions_thread as usize
                 + state.has_send_velocity_thread as usize
@@ -245,7 +251,10 @@ impl UrdfVizWebClient {
     }
 
     pub fn run_send_velocity_thread(&self) {
-        if mem::replace(&mut self.0.threads.lock().has_send_velocity_thread, true) {
+        if mem::replace(
+            &mut self.0.threads.lock().unwrap().has_send_velocity_thread,
+            true,
+        ) {
             panic!("send_velocity_thread is running");
         }
 
@@ -254,7 +263,7 @@ impl UrdfVizWebClient {
             struct Bomb(Arc<UrdfVizWebClientInner>);
             impl Drop for Bomb {
                 fn drop(&mut self) {
-                    self.0.threads.lock().has_send_velocity_thread = false;
+                    self.0.threads.lock().unwrap().has_send_velocity_thread = false;
                     debug!("terminating send_velocity_thread");
                 }
             }
@@ -275,7 +284,7 @@ impl UrdfVizWebClient {
                 }
 
                 let _guard = ScopedSleep::from_secs(DT);
-                let velocity = bomb.0.velocity.lock();
+                let velocity = bomb.0.velocity.lock().unwrap();
                 let mut pose = continue_on_err!(get_robot_origin(&bomb.0.base_url));
                 let mut rpy = euler_angles_from_quaternion(&pose.quaternion);
                 let yaw = rpy.2;
@@ -290,7 +299,12 @@ impl UrdfVizWebClient {
 
     pub fn run_send_joint_positions_thread(&self) {
         if mem::replace(
-            &mut self.0.threads.lock().has_send_joint_positions_thread,
+            &mut self
+                .0
+                .threads
+                .lock()
+                .unwrap()
+                .has_send_joint_positions_thread,
             true,
         ) {
             panic!("send_joint_positions_thread is running");
@@ -301,7 +315,11 @@ impl UrdfVizWebClient {
             struct Bomb(Arc<UrdfVizWebClientInner>);
             impl Drop for Bomb {
                 fn drop(&mut self) {
-                    self.0.threads.lock().has_send_joint_positions_thread = false;
+                    self.0
+                        .threads
+                        .lock()
+                        .unwrap()
+                        .has_send_joint_positions_thread = false;
                     debug!("terminating send_joint_positions_thread");
                 }
             }
@@ -309,7 +327,7 @@ impl UrdfVizWebClient {
             let bomb = Bomb(inner);
             'outer: while !bomb.0.is_dropping() {
                 const UNIT_DURATION: Duration = Duration::from_millis(10);
-                let prev = mem::take(&mut *bomb.0.send_joint_positions_target.lock());
+                let prev = mem::take(&mut *bomb.0.send_joint_positions_target.lock().unwrap());
                 let (trajectory, sender) = match prev {
                     SendJointPositionsTarget::Some { trajectory, sender } => (trajectory, sender),
                     SendJointPositionsTarget::None | SendJointPositionsTarget::Abort => {
@@ -363,7 +381,7 @@ impl UrdfVizWebClient {
 
                     for traj in trajectories {
                         if matches!(
-                            *bomb.0.send_joint_positions_target.lock(),
+                            *bomb.0.send_joint_positions_target.lock().unwrap(),
                             SendJointPositionsTarget::Some { .. } | SendJointPositionsTarget::Abort
                         ) {
                             debug!("Abort old target");
@@ -391,7 +409,7 @@ impl UrdfVizWebClient {
     }
 
     pub fn abort(&self) {
-        *self.0.send_joint_positions_target.lock() = SendJointPositionsTarget::Abort;
+        *self.0.send_joint_positions_target.lock().unwrap() = SendJointPositionsTarget::Abort;
     }
 
     pub fn get_urdf(&self) -> Result<urdf_rs::Robot, arci::Error> {
@@ -419,7 +437,13 @@ impl JointTrajectoryClient for UrdfVizWebClient {
         positions: Vec<f64>,
         duration: Duration,
     ) -> Result<WaitFuture, arci::Error> {
-        if !self.0.threads.lock().has_send_joint_positions_thread {
+        if !self
+            .0
+            .threads
+            .lock()
+            .unwrap()
+            .has_send_joint_positions_thread
+        {
             panic!("send_joint_positions called without run_send_joint_positions_thread being called first");
         }
 
@@ -427,6 +451,7 @@ impl JointTrajectoryClient for UrdfVizWebClient {
             .0
             .send_joint_positions_target
             .lock()
+            .unwrap()
             .set_positions(positions, duration))
     }
 
@@ -442,6 +467,7 @@ impl JointTrajectoryClient for UrdfVizWebClient {
             .0
             .send_joint_positions_target
             .lock()
+            .unwrap()
             .set_trajectory(trajectory))
     }
 }
@@ -477,7 +503,7 @@ impl Navigation for UrdfVizWebClient {
 
 impl MoveBase for UrdfVizWebClient {
     fn send_velocity(&self, velocity: &arci::BaseVelocity) -> Result<(), arci::Error> {
-        if !self.0.threads.lock().has_send_velocity_thread {
+        if !self.0.threads.lock().unwrap().has_send_velocity_thread {
             panic!("send_velocity called without run_send_velocity_thread being called first");
         }
 
@@ -486,11 +512,11 @@ impl MoveBase for UrdfVizWebClient {
         // main thread when an error has occurred in send_velocity_thread.
         get_robot_origin(&self.0.base_url)?;
 
-        *self.0.velocity.lock() = velocity.to_owned();
+        *self.0.velocity.lock().unwrap() = velocity.to_owned();
         Ok(())
     }
 
     fn current_velocity(&self) -> Result<arci::BaseVelocity, arci::Error> {
-        Ok(self.0.velocity.lock().to_owned())
+        Ok(self.0.velocity.lock().unwrap().to_owned())
     }
 }

--- a/arci/Cargo.toml
+++ b/arci/Cargo.toml
@@ -15,11 +15,10 @@ auto_impl.workspace = true
 futures.workspace = true
 nalgebra.workspace = true
 once_cell.workspace = true
-parking_lot.workspace = true
 schemars.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["time", "parking_lot"] }
+tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 urdf-rs.workspace = true
 

--- a/arci/src/clients/dummy_gamepad.rs
+++ b/arci/src/clients/dummy_gamepad.rs
@@ -1,7 +1,6 @@
-use std::future;
+use std::{future, sync::Mutex};
 
 use async_trait::async_trait;
-use parking_lot::Mutex;
 
 use crate::gamepad::{Axis, Button, Gamepad, GamepadEvent};
 
@@ -74,16 +73,16 @@ impl DummyGamepad {
     }
 
     pub fn is_stopped(&self) -> bool {
-        *self.stopped.lock()
+        *self.stopped.lock().unwrap()
     }
 }
 
 #[async_trait]
 impl Gamepad for DummyGamepad {
     async fn next_event(&self) -> GamepadEvent {
-        *self.stopped.lock() = false;
+        *self.stopped.lock().unwrap() = false;
         {
-            let mut index = self.index.lock();
+            let mut index = self.index.lock().unwrap();
             if let Some(event) = self.events.get(*index).cloned() {
                 *index += 1;
                 return event;
@@ -94,6 +93,6 @@ impl Gamepad for DummyGamepad {
     }
 
     fn stop(&self) {
-        *self.stopped.lock() = true;
+        *self.stopped.lock().unwrap() = true;
     }
 }

--- a/arci/src/clients/dummy_laser_scan.rs
+++ b/arci/src/clients/dummy_laser_scan.rs
@@ -1,4 +1,4 @@
-use parking_lot::Mutex;
+use std::sync::Mutex;
 
 use crate::{Error, LaserScan2D, Scan2D};
 
@@ -13,13 +13,13 @@ impl DummyLaserScan2D {
     }
 
     pub fn set_scan(&self, scan: Scan2D) {
-        *self.scan.lock() = scan;
+        *self.scan.lock().unwrap() = scan;
     }
 }
 
 impl LaserScan2D for DummyLaserScan2D {
     fn current_scan(&self) -> Result<Scan2D, Error> {
-        Ok(self.scan.lock().clone())
+        Ok(self.scan.lock().unwrap().clone())
     }
 }
 

--- a/arci/src/clients/dummy_motor_drive.rs
+++ b/arci/src/clients/dummy_motor_drive.rs
@@ -1,4 +1,4 @@
-use parking_lot::Mutex;
+use std::sync::Mutex;
 
 use crate::{
     error::Error,
@@ -26,12 +26,12 @@ impl Default for DummyMotorDrivePosition {
 
 impl MotorDrivePosition for DummyMotorDrivePosition {
     fn set_motor_position(&self, position: f64) -> Result<(), Error> {
-        *self.current_position.lock() = position;
+        *self.current_position.lock().unwrap() = position;
         Ok(())
     }
 
     fn get_motor_position(&self) -> Result<f64, Error> {
-        Ok(*self.current_position.lock())
+        Ok(*self.current_position.lock().unwrap())
     }
 }
 
@@ -56,12 +56,12 @@ impl Default for DummyMotorDriveVelocity {
 
 impl MotorDriveVelocity for DummyMotorDriveVelocity {
     fn set_motor_velocity(&self, velocity: f64) -> Result<(), Error> {
-        *self.current_velocity.lock() = velocity;
+        *self.current_velocity.lock().unwrap() = velocity;
         Ok(())
     }
 
     fn get_motor_velocity(&self) -> Result<f64, Error> {
-        Ok(*self.current_velocity.lock())
+        Ok(*self.current_velocity.lock().unwrap())
     }
 }
 
@@ -86,11 +86,11 @@ impl Default for DummyMotorDriveEffort {
 
 impl MotorDriveEffort for DummyMotorDriveEffort {
     fn set_motor_effort(&self, effort: f64) -> Result<(), Error> {
-        *self.current_effort.lock() = effort;
+        *self.current_effort.lock().unwrap() = effort;
         Ok(())
     }
 
     fn get_motor_effort(&self) -> Result<f64, Error> {
-        Ok(*self.current_effort.lock())
+        Ok(*self.current_effort.lock().unwrap())
     }
 }

--- a/arci/src/clients/dummy_move_base.rs
+++ b/arci/src/clients/dummy_move_base.rs
@@ -1,4 +1,4 @@
-use parking_lot::Mutex;
+use std::sync::Mutex;
 
 use crate::{
     error::Error,
@@ -22,12 +22,12 @@ impl DummyMoveBase {
 
 impl MoveBase for DummyMoveBase {
     fn send_velocity(&self, velocity: &BaseVelocity) -> Result<(), Error> {
-        *self.current_velocity.lock() = *velocity;
+        *self.current_velocity.lock().unwrap() = *velocity;
         Ok(())
     }
 
     fn current_velocity(&self) -> Result<BaseVelocity, Error> {
-        Ok(self.current_velocity.lock().to_owned())
+        Ok(self.current_velocity.lock().unwrap().to_owned())
     }
 }
 

--- a/arci/src/clients/dummy_navigation.rs
+++ b/arci/src/clients/dummy_navigation.rs
@@ -1,5 +1,6 @@
+use std::sync::Mutex;
+
 use nalgebra::{Isometry2, Vector2};
-use parking_lot::Mutex;
 
 use crate::{error::Error, traits::Navigation, WaitFuture};
 
@@ -20,11 +21,11 @@ impl DummyNavigation {
     }
 
     pub fn current_goal_pose(&self) -> Result<Isometry2<f64>, Error> {
-        Ok(self.goal_pose.lock().to_owned())
+        Ok(self.goal_pose.lock().unwrap().to_owned())
     }
 
     pub fn is_canceled(&self) -> bool {
-        *self.canceled.lock()
+        *self.canceled.lock().unwrap()
     }
 }
 
@@ -41,13 +42,13 @@ impl Navigation for DummyNavigation {
         _frame_id: &str,
         _timeout: std::time::Duration,
     ) -> Result<WaitFuture, Error> {
-        *self.canceled.lock() = false;
-        *self.goal_pose.lock() = goal;
+        *self.canceled.lock().unwrap() = false;
+        *self.goal_pose.lock().unwrap() = goal;
         Ok(WaitFuture::ready())
     }
 
     fn cancel(&self) -> Result<(), Error> {
-        *self.canceled.lock() = true;
+        *self.canceled.lock().unwrap() = true;
         Ok(())
     }
 }

--- a/arci/src/clients/dummy_speaker.rs
+++ b/arci/src/clients/dummy_speaker.rs
@@ -1,4 +1,4 @@
-use parking_lot::Mutex;
+use std::sync::Mutex;
 
 use crate::{error::Error, traits::Speaker, WaitFuture};
 
@@ -15,13 +15,13 @@ impl DummySpeaker {
     }
 
     pub fn current_message(&self) -> String {
-        self.message.lock().clone()
+        self.message.lock().unwrap().clone()
     }
 }
 
 impl Speaker for DummySpeaker {
     fn speak(&self, message: &str) -> Result<WaitFuture, Error> {
-        *self.message.lock() = message.to_string();
+        *self.message.lock().unwrap() = message.to_string();
         Ok(WaitFuture::ready())
     }
 }

--- a/arci/src/clients/joint_position_difference_limiter.rs
+++ b/arci/src/clients/joint_position_difference_limiter.rs
@@ -313,10 +313,14 @@ mod test {
         assert!(
             tokio_test::block_on(client.send_joint_trajectory(trajectory.clone()).unwrap()).is_ok()
         );
-        for (c, w) in trajectory
-            .iter()
-            .zip(wrapped_client.last_trajectory.lock().clone().iter())
-        {
+        for (c, w) in trajectory.iter().zip(
+            wrapped_client
+                .last_trajectory
+                .lock()
+                .unwrap()
+                .clone()
+                .iter(),
+        ) {
             assert_eq!(c.positions, w.positions);
             assert_eq!(c.velocities, w.velocities);
             assert_eq!(c.time_from_start, w.time_from_start);
@@ -346,14 +350,14 @@ mod test {
         {
             assert_eq!(c, w);
         }
-        *wrapped_client.positions.lock() = vec![0.0, 1.0];
+        *wrapped_client.positions.lock().unwrap() = vec![0.0, 1.0];
         assert!(tokio_test::block_on(
             client
                 .send_joint_positions(vec![-1.0, 2.0], Duration::from_secs(1))
                 .unwrap()
         )
         .is_ok());
-        assert!(wrapped_client.last_trajectory.lock().is_empty());
+        assert!(wrapped_client.last_trajectory.lock().unwrap().is_empty());
         assert_eq!(
             wrapped_client.current_joint_positions().unwrap(),
             vec![-1.0, 2.0]
@@ -379,14 +383,14 @@ mod test {
         {
             assert_eq!(c, w);
         }
-        *wrapped_client.positions.lock() = vec![0.0, 1.0];
+        *wrapped_client.positions.lock().unwrap() = vec![0.0, 1.0];
         assert!(tokio_test::block_on(
             client
                 .send_joint_positions(vec![-1.0, 2.0], Duration::from_secs(1))
                 .unwrap()
         )
         .is_ok());
-        let actual_trajectory = wrapped_client.last_trajectory.lock().clone();
+        let actual_trajectory = wrapped_client.last_trajectory.lock().unwrap().clone();
         assert_eq!(actual_trajectory.len(), 2);
         assert_eq!(actual_trajectory[0].positions, vec![-0.5, 1.5]);
         assert_eq!(actual_trajectory[1].positions, vec![-1.0, 2.0]);

--- a/arci/src/clients/joint_trajectory_clients_container.rs
+++ b/arci/src/clients/joint_trajectory_clients_container.rs
@@ -109,9 +109,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use parking_lot::Mutex;
+    use std::sync::{Arc, Mutex};
 
     use super::*;
     #[derive(Debug, Clone)]
@@ -126,7 +124,7 @@ mod tests {
         }
 
         fn current_joint_positions(&self) -> Result<Vec<f64>, Error> {
-            Ok(self.pos.lock().clone())
+            Ok(self.pos.lock().unwrap().clone())
         }
 
         fn send_joint_positions(
@@ -134,7 +132,7 @@ mod tests {
             positions: Vec<f64>,
             _duration: std::time::Duration,
         ) -> Result<WaitFuture, Error> {
-            *self.pos.lock() = positions;
+            *self.pos.lock().unwrap() = positions;
             Ok(WaitFuture::ready())
         }
 
@@ -143,9 +141,9 @@ mod tests {
             full_trajectory: Vec<TrajectoryPoint>,
         ) -> Result<WaitFuture, Error> {
             if let Some(last_point) = full_trajectory.last() {
-                *self.pos.lock() = last_point.positions.to_owned();
+                *self.pos.lock().unwrap() = last_point.positions.to_owned();
             }
-            *self.last_trajectory.lock() = full_trajectory;
+            *self.last_trajectory.lock().unwrap() = full_trajectory;
             Ok(WaitFuture::ready())
         }
     }

--- a/arci/src/clients/joint_velocity_limiter.rs
+++ b/arci/src/clients/joint_velocity_limiter.rs
@@ -178,7 +178,7 @@ mod tests {
         assert_eq!(joint_positions.len(), 2);
         assert_approx_eq!(joint_positions[0], 1.0);
         assert_approx_eq!(joint_positions[1], 2.0);
-        let trajectory = client.last_trajectory.lock();
+        let trajectory = client.last_trajectory.lock().unwrap();
         assert_eq!(trajectory.len(), 1);
         assert_eq!(trajectory[0].positions.len(), 2);
         assert_approx_eq!(trajectory[0].positions[0], 1.0);
@@ -235,7 +235,7 @@ mod tests {
         assert_approx_eq!(joint_positions[0], 3.0);
         assert_approx_eq!(joint_positions[1], 6.0);
 
-        let trajectory = client.last_trajectory.lock();
+        let trajectory = client.last_trajectory.lock().unwrap();
         assert_eq!(trajectory.len(), 2);
         assert_eq!(trajectory[0].positions.len(), 2);
         assert_approx_eq!(trajectory[0].positions[0], 1.0);

--- a/arci/src/clients/partial_joint_trajectory_client.rs
+++ b/arci/src/clients/partial_joint_trajectory_client.rs
@@ -191,10 +191,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use assert_approx_eq::assert_approx_eq;
-    use parking_lot::Mutex;
 
     use super::*;
 
@@ -210,7 +209,7 @@ mod tests {
         }
 
         fn current_joint_positions(&self) -> Result<Vec<f64>, Error> {
-            Ok(self.pos.lock().clone())
+            Ok(self.pos.lock().unwrap().clone())
         }
 
         fn send_joint_positions(
@@ -218,7 +217,7 @@ mod tests {
             positions: Vec<f64>,
             _duration: std::time::Duration,
         ) -> Result<WaitFuture, Error> {
-            *self.pos.lock() = positions;
+            *self.pos.lock().unwrap() = positions;
             Ok(WaitFuture::ready())
         }
 
@@ -227,9 +226,9 @@ mod tests {
             full_trajectory: Vec<TrajectoryPoint>,
         ) -> Result<WaitFuture, Error> {
             if let Some(last_point) = full_trajectory.last() {
-                *self.pos.lock() = last_point.positions.to_owned();
+                *self.pos.lock().unwrap() = last_point.positions.to_owned();
             }
-            *self.last_trajectory.lock() = full_trajectory;
+            *self.last_trajectory.lock().unwrap() = full_trajectory;
             Ok(WaitFuture::ready())
         }
     }

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -39,7 +39,7 @@ schemars.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "parking_lot"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 toml.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber = { workspace = true, features = ["json"] }

--- a/openrr-base/Cargo.toml
+++ b/openrr-base/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 
 [dependencies]
 arci.workspace = true
-parking_lot.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/openrr-base/src/odometry.rs
+++ b/openrr-base/src/odometry.rs
@@ -1,5 +1,6 @@
+use std::sync::Mutex;
+
 use arci::{BaseVelocity, Isometry2, Vector2};
-use parking_lot::Mutex;
 
 use crate::Error;
 
@@ -24,9 +25,9 @@ impl Odometry {
     }
 
     pub fn update_by_velocity(&self, velocity: &BaseVelocity) -> Result<(), Error> {
-        let mut position = self.position.lock();
-        let mut locked_update_time = self.last_update_timestamp.lock();
-        let timeout_millis = *self.timeout_millis.lock();
+        let mut position = self.position.lock().unwrap();
+        let mut locked_update_time = self.last_update_timestamp.lock().unwrap();
+        let timeout_millis = *self.timeout_millis.lock().unwrap();
 
         let last_update_time = match *locked_update_time {
             Some(t) => t,
@@ -58,20 +59,20 @@ impl Odometry {
 
     /// Recover or update odometry
     pub fn resolve_lost(&self, current_pose: Isometry2<f64>) {
-        let mut pose = self.position.lock();
-        let mut update_time = self.last_update_timestamp.lock();
+        let mut pose = self.position.lock().unwrap();
+        let mut update_time = self.last_update_timestamp.lock().unwrap();
 
         *pose = Some(current_pose);
         *update_time = Some(std::time::Instant::now());
     }
 
     pub fn set_timeout_millis(&self, millis: u128) {
-        let mut timeout_millis = self.timeout_millis.lock();
+        let mut timeout_millis = self.timeout_millis.lock().unwrap();
         *timeout_millis = millis;
     }
 
     pub fn current_pose(&self) -> Result<Isometry2<f64>, Error> {
-        match self.position.lock().to_owned() {
+        match self.position.lock().unwrap().to_owned() {
             Some(pose) => Ok(pose),
             None => Err(Error::CurrentPositionUnknown),
         }

--- a/openrr-base/src/robot_velocity_status.rs
+++ b/openrr-base/src/robot_velocity_status.rs
@@ -1,5 +1,6 @@
+use std::sync::Mutex;
+
 use arci::BaseVelocity;
-use parking_lot::Mutex;
 
 use crate::*;
 
@@ -42,17 +43,18 @@ impl RobotVelocityStatus {
     }
 
     pub fn velocity(&self) -> BaseVelocity {
-        self.velocity.lock().to_owned()
+        self.velocity.lock().unwrap().to_owned()
     }
 
     pub fn set_velocity(&self, velocity: &BaseVelocity) {
-        let mut vel = self.velocity.lock();
+        let mut vel = self.velocity.lock().unwrap();
         *vel = *velocity;
     }
 
     pub fn time_since_last_sent(&self) -> f64 {
         self.last_sent_log
             .lock()
+            .unwrap()
             .to_owned()
             .timestamp
             .elapsed()
@@ -60,7 +62,7 @@ impl RobotVelocityStatus {
     }
 
     pub fn set_log(&self, velocity_log: &BaseVelocity) {
-        let mut log = self.last_sent_log.lock();
+        let mut log = self.last_sent_log.lock().unwrap();
         *log = BaseVelocityTimestamped {
             base_velocity: *velocity_log,
             timestamp: std::time::Instant::now(),
@@ -68,7 +70,7 @@ impl RobotVelocityStatus {
     }
 
     pub fn set_velocity_state(&self, velocity: BaseVelocity) {
-        let mut velocity_state = self.velocity_state.lock();
+        let mut velocity_state = self.velocity_state.lock().unwrap();
         *velocity_state = velocity;
     }
 
@@ -89,7 +91,7 @@ impl RobotVelocityStatus {
 
     fn limit_acceleration(&self, velocity: &BaseVelocity) -> BaseVelocity {
         let dt = self.time_since_last_sent();
-        let vel = self.velocity.lock().to_owned();
+        let vel = self.velocity.lock().unwrap().to_owned();
         BaseVelocity {
             x: velocity.x.clamp(
                 vel.x + self.min_acceleration.x * dt,
@@ -154,7 +156,7 @@ mod test {
 
         status.set_velocity_state(velocity_state);
 
-        let velocity_state_x = status.velocity_state.lock().x;
+        let velocity_state_x = status.velocity_state.lock().unwrap().x;
         assert_approx_eq!(velocity_state_x, DUMMY_VELOCITY_STATE_X);
     }
 }

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -17,7 +17,6 @@ k.workspace = true
 mesh-loader.workspace = true
 ncollide3d.workspace = true
 num-traits.workspace = true
-parking_lot.workspace = true
 rand.workspace = true
 rayon.workspace = true
 rrt.workspace = true

--- a/openrr-planner/src/ik.rs
+++ b/openrr-planner/src/ik.rs
@@ -15,9 +15,10 @@ limitations under the License.
 */
 #![allow(clippy::trivially_copy_pass_by_ref)]
 
+use std::sync::Mutex;
+
 use k::{nalgebra as na, InverseKinematicsSolver, SubsetOf};
 use na::RealField;
-use parking_lot::Mutex;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::funcs::*;
@@ -126,14 +127,14 @@ where
                     .solve_with_constraints(&arm, &target_pose, constraints)
                     .is_ok()
                 {
-                    solved_poses.lock().push(target_pose);
+                    solved_poses.lock().unwrap().push(target_pose);
                 }
                 x += unit_check_length;
             }
             y += unit_check_length;
         }
     });
-    solved_poses.into_inner()
+    solved_poses.into_inner().unwrap()
 }
 
 #[cfg(test)]

--- a/openrr-plugin/Cargo.toml
+++ b/openrr-plugin/Cargo.toml
@@ -14,7 +14,7 @@ anyhow.workspace = true
 arci.workspace = true
 async-ffi.workspace = true
 once_cell.workspace = true
-tokio = { workspace = true, features = ["sync", "rt-multi-thread", "parking_lot"] }
+tokio = { workspace = true, features = ["sync", "rt-multi-thread"] }
 
 [dev-dependencies]
 assert_approx_eq.workspace = true

--- a/openrr-plugin/examples/plugin/Cargo.toml
+++ b/openrr-plugin/examples/plugin/Cargo.toml
@@ -13,6 +13,5 @@ arci-gamepad-keyboard.workspace = true
 arci.workspace = true
 openrr-client.workspace = true
 openrr-plugin.workspace = true
-parking_lot.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/openrr-plugin/examples/plugin/src/lib.rs
+++ b/openrr-plugin/examples/plugin/src/lib.rs
@@ -1,9 +1,8 @@
-use std::time::Duration;
+use std::{sync::Mutex, time::Duration};
 
 use arci::{DummyLocalization, DummyMoveBase, DummyNavigation, Error, TrajectoryPoint, WaitFuture};
 use openrr_client::PrintSpeaker;
 use openrr_plugin::Plugin;
-use parking_lot::Mutex;
 use serde::Deserialize;
 
 openrr_plugin::export_plugin!(MyPlugin);
@@ -70,7 +69,7 @@ impl arci::JointTrajectoryClient for MyJointTrajectoryClient {
     }
 
     fn current_joint_positions(&self) -> Result<Vec<f64>, Error> {
-        Ok(self.joint_positions.lock().clone())
+        Ok(self.joint_positions.lock().unwrap().clone())
     }
 
     fn send_joint_positions(
@@ -79,7 +78,7 @@ impl arci::JointTrajectoryClient for MyJointTrajectoryClient {
         duration: Duration,
     ) -> Result<WaitFuture, Error> {
         println!("positions = {positions:?}, duration = {duration:?}");
-        *self.joint_positions.lock() = positions;
+        *self.joint_positions.lock().unwrap() = positions;
         Ok(WaitFuture::new(async { Ok(()) }))
     }
 

--- a/openrr-plugin/tests/test.rs
+++ b/openrr-plugin/tests/test.rs
@@ -54,7 +54,7 @@ async fn joint_trajectory_client() {
         .unwrap()
         .await
         .unwrap();
-    assert_eq!(client.last_trajectory.lock().len(), 2);
+    assert_eq!(client.last_trajectory.lock().unwrap().len(), 2);
     let pos = client.current_joint_positions().unwrap();
     assert_eq!(pos.len(), 2);
     assert_approx_eq!(pos[0], 2.0);

--- a/openrr-remote/Cargo.toml
+++ b/openrr-remote/Cargo.toml
@@ -15,7 +15,7 @@ tonic-build.workspace = true
 arci.workspace = true
 prost-types.workspace = true
 prost.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "parking_lot"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tonic.workspace = true
 tracing.workspace = true
 

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -20,10 +20,9 @@ clap.workspace = true
 k.workspace = true
 openrr-client.workspace = true
 openrr-command.workspace = true
-parking_lot.workspace = true
 schemars.workspace = true
 serde.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time", "parking_lot"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "sync", "time"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/openrr-teleop/src/ik.rs
+++ b/openrr-teleop/src/ik.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use arci::{
     gamepad::{Axis, Button, GamepadEvent},
@@ -7,7 +10,6 @@ use arci::{
 use async_trait::async_trait;
 use k::{Translation3, Vector3};
 use openrr_client::IkSolverWithChain;
-use parking_lot::Mutex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -179,12 +181,12 @@ where
     S: Speaker,
 {
     fn handle_event(&self, event: GamepadEvent) {
-        self.inner.lock().handle_event(event);
+        self.inner.lock().unwrap().handle_event(event);
     }
 
     async fn proc(&self) {
         let (is_sending, angular_velocity, linear_velocity) = {
-            let inner = self.inner.lock();
+            let inner = self.inner.lock().unwrap();
             (
                 inner.is_sending,
                 inner.angular_velocity,

--- a/openrr-teleop/src/joints.rs
+++ b/openrr-teleop/src/joints.rs
@@ -1,11 +1,10 @@
-use std::time::Duration;
+use std::{sync::Mutex, time::Duration};
 
 use arci::{
     gamepad::{Axis, Button, GamepadEvent},
     JointTrajectoryClient, Speaker,
 };
 use async_trait::async_trait;
-use parking_lot::Mutex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -149,7 +148,7 @@ where
     S: Speaker,
 {
     fn handle_event(&self, event: GamepadEvent) {
-        if let Some(submode) = self.inner.lock().handle_event(event) {
+        if let Some(submode) = self.inner.lock().unwrap().handle_event(event) {
             // do not wait
             drop(
                 self.speaker
@@ -160,7 +159,7 @@ where
     }
 
     async fn proc(&self) {
-        let inner = self.inner.lock();
+        let inner = self.inner.lock().unwrap();
         if inner.is_sending {
             let pos = self
                 .joint_trajectory_client
@@ -181,7 +180,7 @@ where
     }
 
     fn submode(&self) -> String {
-        self.inner.lock().submode.to_owned()
+        self.inner.lock().unwrap().submode.to_owned()
     }
 }
 

--- a/openrr-teleop/src/move_base.rs
+++ b/openrr-teleop/src/move_base.rs
@@ -1,9 +1,10 @@
+use std::sync::Mutex;
+
 use arci::{
     gamepad::{Axis, Button, GamepadEvent},
     BaseVelocity, MoveBase,
 };
 use async_trait::async_trait;
-use parking_lot::Mutex;
 
 use super::control_mode::ControlMode;
 
@@ -104,7 +105,7 @@ where
     T: MoveBase,
 {
     fn handle_event(&self, ev: GamepadEvent) {
-        if self.inner.lock().handle_event(ev) {
+        if self.inner.lock().unwrap().handle_event(ev) {
             // stop immediately
             self.move_base
                 .send_velocity(&BaseVelocity::default())
@@ -113,7 +114,7 @@ where
     }
 
     async fn proc(&self) {
-        if let Some(v) = self.inner.lock().get_target_velocity() {
+        if let Some(v) = self.inner.lock().unwrap().get_target_velocity() {
             self.move_base.send_velocity(&v).unwrap();
         }
     }
@@ -147,11 +148,11 @@ mod tests {
         assert_eq!(mode.mode, mode_name);
         assert_eq!(mode.submode, String::from(""));
         assert_eq!(
-            format!("{:?}", mode.inner.lock().vel),
+            format!("{:?}", mode.inner.lock().unwrap().vel),
             format!("{:?}", BaseVelocity::default())
         );
-        assert!(!mode.inner.lock().is_enabled);
-        assert!(!mode.inner.lock().is_turbo);
+        assert!(!mode.inner.lock().unwrap().is_enabled);
+        assert!(!mode.inner.lock().unwrap().is_turbo);
     }
 
     #[test]
@@ -191,7 +192,7 @@ mod tests {
         assert_approx_eq!(current.x, 0.0);
         assert_approx_eq!(current.y, 0.0);
         assert_approx_eq!(current.theta, 0.0);
-        println!("{:?} {current:?}", mode.inner.lock().vel);
+        println!("{:?} {current:?}", mode.inner.lock().unwrap().vel);
 
         let mode = MoveBaseMode {
             move_base: DummyMoveBase::new(),
@@ -212,7 +213,7 @@ mod tests {
         assert_approx_eq!(current.x, 0.0);
         assert_approx_eq!(current.y, 0.0);
         assert_approx_eq!(current.theta, 0.0);
-        println!("{:?} {current:?}", mode.inner.lock().vel);
+        println!("{:?} {current:?}", mode.inner.lock().unwrap().vel);
 
         let mode = MoveBaseMode {
             move_base: DummyMoveBase::new(),
@@ -233,7 +234,7 @@ mod tests {
         assert_approx_eq!(current.x, X);
         assert_approx_eq!(current.y, Y);
         assert_approx_eq!(current.theta, THETA);
-        println!("{:?} {current:?}", mode.inner.lock().vel);
+        println!("{:?} {current:?}", mode.inner.lock().unwrap().vel);
 
         let mode = MoveBaseMode {
             move_base: DummyMoveBase::new(),
@@ -254,6 +255,6 @@ mod tests {
         assert_approx_eq!(current.x, X * 2.0);
         assert_approx_eq!(current.y, Y * 2.0);
         assert_approx_eq!(current.theta, THETA * 2.0);
-        println!("{:?} {current:?}", mode.inner.lock().vel);
+        println!("{:?} {current:?}", mode.inner.lock().unwrap().vel);
     }
 }


### PR DESCRIPTION
- Since 1.62 std::sync::Mutex is fast enough except for macOS
  https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html#thinner-faster-mutexes-on-linux
- Our dependency enables the send_guard feature of parking_lot, so it is harder to detect cases of accidentally holding the guard across the await point.
  Hang in #860 was actually caused by that.
https://github.com/openrr/openrr/pull/860/commits/28c87281184387391d4d152b396539c987ab750e#diff-9ead8cee15ef7265d758660ee884b3d3ebb983818586413f8236528dffa16b2aL67-L72