### PR TITLE
Use version-less manifests for publish=false crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   RUSTDOCFLAGS: -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  nightly: nightly-2023-01-31
+  nightly: nightly-2024-01-25
 
 defaults:
   run:

--- a/arci-ros/tests/hygiene/Cargo.toml
+++ b/arci-ros/tests/hygiene/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "arci-ros-hygiene-test"
-version = "0.0.0"
 edition.workspace = true
-publish = false
 
 [dependencies]
 arci-ros.workspace = true

--- a/openrr-plugin/benches/proxy.rs
+++ b/openrr-plugin/benches/proxy.rs
@@ -231,9 +231,7 @@ fn test_plugin() -> Result<PathBuf> {
         r#"
 [package]
 name = "test_plugin"
-version = "0.0.0"
 edition = "2021"
-publish = false
 
 [workspace]
 

--- a/openrr-plugin/examples/plugin/Cargo.toml
+++ b/openrr-plugin/examples/plugin/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "openrr-plugin-example"
-version = "0.0.0"
 edition.workspace = true
-publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/tools/codegen/Cargo.toml
+++ b/tools/codegen/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "openrr-internal-codegen"
-version = "0.0.0"
 edition.workspace = true
-publish = false
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
Since Rust 1.75, we can omit it.

https://github.com/rust-lang/cargo/commit/307486ed181ac1455767dac866030ce5b67caf67