### PR TITLE
Disable assimp feature of urdf-viz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter"] }
 trajectory = "0.1"
 urdf-rs = "0.8"
-urdf-viz = "0.44"
+urdf-viz = { version = "0.44", default-features = false } # TODO: remove default-features = false once https://github.com/openrr/urdf-viz/pull/240 released
 ureq = { version = "2", features = ["json"] }
 url = "2"
 


### PR DESCRIPTION
https://github.com/openrr/openrr/pull/898 removed assimp from the default features, but still depends by default on assimp for dev-dependencies.

Eventually this should be default by https://github.com/openrr/urdf-viz/pull/240, but I think it will take a little more time.

cc https://github.com/openrr/openrr/issues/148