### PR TITLE
Remove strip from profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,4 +162,3 @@ openrr-tracing = { path = "openrr-tracing" }
 [profile.release]
 lto = true
 codegen-units = 1
-strip = "symbols"


### PR DESCRIPTION
strip is now enabled by default since Rust 1.77. https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html#enable-strip-in-release-profiles-by-default