### PR TITLE
Use std::sync::{LazyLock,OnceLock} instead of once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ nalgebra = "0.30"
 ncollide3d = "0.33"
 nix = { version = "0.29", features = ["signal"] }
 num-traits = "0.2"
-once_cell = "1"
 paste = "1"
 portpicker = "0.1"
 prettyplease = "=0.2.20"

--- a/arci-ros/Cargo.toml
+++ b/arci-ros/Cargo.toml
@@ -14,7 +14,6 @@ arci.workspace = true
 auto_impl.workspace = true
 flume.workspace = true
 nalgebra.workspace = true
-once_cell.workspace = true
 paste.workspace = true
 ros-nalgebra.workspace = true
 rosrust.workspace = true
@@ -37,7 +36,6 @@ openrr-teleop.workspace = true
 
 [target.'cfg(unix)'.dev-dependencies]
 nix.workspace = true
-once_cell.workspace = true
 portpicker.workspace = true
 
 [lints]

--- a/arci-ros/src/ros_control/ros_control_action_client.rs
+++ b/arci-ros/src/ros_control/ros_control_action_client.rs
@@ -1,5 +1,5 @@
 use std::{
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
     time::Duration,
 };
 
@@ -7,7 +7,6 @@ use arci::{
     CompleteCondition, JointTrajectoryClient, SetCompleteCondition, TotalJointDiffCondition,
     TrajectoryPoint, WaitFuture,
 };
-use once_cell::sync::Lazy;
 
 use crate::{
     create_joint_trajectory_message_for_send_joint_positions,
@@ -81,7 +80,7 @@ impl RosControlActionClient {
         joint_state_topic_name: impl Into<String>,
     ) -> Arc<LazyJointStateProvider> {
         let joint_state_topic_name = joint_state_topic_name.into();
-        Arc::new(Lazy::new(Box::new(move || {
+        Arc::new(LazyLock::new(Box::new(move || {
             Box::new(JointStateProviderFromJointState::new(
                 SubscriberHandler::new(&joint_state_topic_name, 1),
             ))

--- a/arci-ros/src/ros_control/ros_control_client.rs
+++ b/arci-ros/src/ros_control/ros_control_client.rs
@@ -1,5 +1,5 @@
 use std::{
-    sync::{Arc, Mutex},
+    sync::{Arc, LazyLock, Mutex},
     time::Duration,
 };
 
@@ -8,7 +8,6 @@ use arci::{
     TrajectoryPoint, WaitFuture,
 };
 use msg::trajectory_msgs::JointTrajectory;
-use once_cell::sync::Lazy;
 
 use crate::{
     create_joint_trajectory_message_for_send_joint_positions,
@@ -85,7 +84,7 @@ impl RosControlClient {
         joint_state_topic_name: impl Into<String>,
     ) -> Arc<LazyJointStateProvider> {
         let joint_state_topic_name = joint_state_topic_name.into();
-        Arc::new(Lazy::new(Box::new(move || {
+        Arc::new(LazyLock::new(Box::new(move || {
             Box::new(JointStateProviderFromJointTrajectoryControllerState::new(
                 SubscriberHandler::new(&joint_state_topic_name, 1),
             ))

--- a/arci-ros/src/ros_control/traits.rs
+++ b/arci-ros/src/ros_control/traits.rs
@@ -1,8 +1,7 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use arci::JointTrajectoryClient;
 use auto_impl::auto_impl;
-use once_cell::sync::Lazy;
 
 use crate::JointTrajectoryClientWrapperConfig;
 
@@ -26,7 +25,7 @@ pub trait RosControlClientBuilder {
     fn name(&self) -> &str;
 }
 
-pub(crate) type LazyJointStateProvider = Lazy<
+pub(crate) type LazyJointStateProvider = LazyLock<
     Box<dyn JointStateProvider + Send + Sync>,
     Box<dyn FnOnce() -> Box<dyn JointStateProvider + Send + Sync> + Send + Sync>,
 >;

--- a/arci-ros2/Cargo.toml
+++ b/arci-ros2/Cargo.toml
@@ -19,7 +19,6 @@ abi_stable.workspace = true
 anyhow.workspace = true
 arci.workspace = true
 futures.workspace = true
-once_cell.workspace = true
 openrr-plugin.workspace = true
 r2r = { workspace = true, optional = true }
 serde.workspace = true

--- a/arci/Cargo.toml
+++ b/arci/Cargo.toml
@@ -14,7 +14,6 @@ async-trait.workspace = true
 auto_impl.workspace = true
 futures.workspace = true
 nalgebra.workspace = true
-once_cell.workspace = true
 schemars.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/arci/src/clients/lazy.rs
+++ b/arci/src/clients/lazy.rs
@@ -1,5 +1,5 @@
 use std::{
-    sync::Arc,
+    sync::{Arc, LazyLock},
     time::{Duration, SystemTime},
 };
 
@@ -19,7 +19,7 @@ use crate::{
 #[allow(clippy::type_complexity)]
 #[derive(Debug)]
 pub struct Lazy<'a, T> {
-    inner: once_cell::sync::Lazy<
+    inner: LazyLock<
         Result<T, Arc<Error>>,
         Box<dyn FnOnce() -> Result<T, Arc<Error>> + Send + Sync + 'a>,
     >,
@@ -30,7 +30,7 @@ impl<'a, T> Lazy<'a, T> {
     /// Creates a new `Lazy` with the given constructor.
     pub fn new(constructor: impl FnOnce() -> Result<T, Error> + Send + Sync + 'a) -> Self {
         Self {
-            inner: once_cell::sync::Lazy::new(Box::new(|| constructor().map_err(Arc::new))),
+            inner: LazyLock::new(Box::new(|| constructor().map_err(Arc::new))),
             joint_names: None,
         }
     }
@@ -44,7 +44,7 @@ impl<'a, T> Lazy<'a, T> {
         joint_names: Vec<String>,
     ) -> Self {
         Self {
-            inner: once_cell::sync::Lazy::new(Box::new(|| constructor().map_err(Arc::new))),
+            inner: LazyLock::new(Box::new(|| constructor().map_err(Arc::new))),
             joint_names: Some(joint_names),
         }
     }

--- a/openrr-plugin/Cargo.toml
+++ b/openrr-plugin/Cargo.toml
@@ -13,7 +13,6 @@ abi_stable.workspace = true
 anyhow.workspace = true
 arci.workspace = true
 async-ffi.workspace = true
-once_cell.workspace = true
 tokio = { workspace = true, features = ["sync", "rt-multi-thread"] }
 
 [dev-dependencies]

--- a/openrr-plugin/src/lib.rs
+++ b/openrr-plugin/src/lib.rs
@@ -8,10 +8,13 @@ mod proxy;
 #[path = "gen/api.rs"]
 mod api;
 
-use std::{fmt, path::Path, sync::Arc};
+use std::{
+    fmt,
+    path::Path,
+    sync::{Arc, LazyLock},
+};
 
 use abi_stable::library::lib_header_from_path;
-use once_cell::sync::Lazy;
 
 pub use crate::api::*;
 // This is not a public API. Use export_plugin! macro for plugin exporting.
@@ -77,7 +80,7 @@ impl fmt::Debug for PluginProxy {
 }
 
 // Inspired by async-compat.
-static TOKIO: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+static TOKIO: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     std::thread::Builder::new()
         .name("openrr-plugin/tokio".to_owned())
         .spawn(move || TOKIO.block_on(std::future::pending::<()>()))


### PR DESCRIPTION
std::sync::LazyLock has been stabilized in Rust 1.80.

The first to third commits are CI fixes from #920.