### PR TITLE
Fix CI failure

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -1,10 +1,6 @@
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-vulnerability = "deny"
-unmaintained = "allow" # TODO
-unsound = "deny"
 yanked = "deny"
-notice = "deny"
 ignore = [
     "RUSTSEC-2020-0027", # traitobject 0.1, transitively dep of rosrust (via xml-rpc)
     "RUSTSEC-2020-0071", # time 0.1, transitively dep of rosrust (via xml-rpc)
@@ -13,6 +9,14 @@ ignore = [
     "RUSTSEC-2022-0006", # thread_local 0.3, transitively dep of rosrust (via xml-rpc)
     "RUSTSEC-2022-0013", # regex 0.2, transitively dep of rosrust (via xml-rpc)
     "RUSTSEC-2022-0022", # hyper 0.10, transitively dep of rosrust (via xml-rpc)
+    "RUSTSEC-2021-0144", # unmaintained (traitobject), transitively dep of rosrust (via xml-rpc)
+    "RUSTSEC-2021-0146", # unmaintained (twoway), transitively dep of rosrust (via xml-rpc)
+    "RUSTSEC-2021-0150", # unmaintained (ncollide3d)
+    "RUSTSEC-2023-0028", # unmaintained (buf_redux), transitively dep of rosrust (via xml-rpc)
+    "RUSTSEC-2023-0050", # unmaintained (multipart), transitively dep of rosrust (via xml-rpc)
+    "RUSTSEC-2023-0081", # unmaintained (safemem), transitively dep of rosrust (via xml-rpc)
+    "RUSTSEC-2024-0014", # unmaintained (generational-arena), dep of abi_stable
+    "RUSTSEC-2024-0320", # unmaintained (yaml-rust), dep of rosrust
 ]
 
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
@@ -23,9 +27,6 @@ skip = []
 
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-default = "deny"
-unlicensed = "deny"
-copyleft = "deny"
 unused-allowed-license = "deny"
 private.ignore = true
 allow = [
@@ -54,4 +55,4 @@ license-files = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = ["https://github.com/smilerobotics/tf_rosrust.git"]
+allow-git = []

--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -65,6 +65,7 @@ RUSTSEC
 rustup
 rviz
 sabi
+safemem
 slerp
 smilerobotics
 srvs
@@ -83,6 +84,7 @@ traj
 trajs
 trimesh
 turtlebot
+twoway
 undock
 unistd
 unparse


### PR DESCRIPTION
```
error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /home/runner/work/openrr/openrr/.deny.toml:3:1
  │
3 │ vulnerability = "deny"
  │ ━━━━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /home/runner/work/openrr/openrr/.deny.toml:4:1
  │
4 │ unmaintained = "allow" # TODO
  │ ━━━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /home/runner/work/openrr/openrr/.deny.toml:5:1
  │
5 │ unsound = "deny"
  │ ━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
  ┌─ /home/runner/work/openrr/openrr/.deny.toml:7:1
  │
7 │ notice = "deny"
  │ ━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /home/runner/work/openrr/openrr/.deny.toml:27:1
   │
27 │ unlicensed = "deny"
   │ ━━━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /home/runner/work/openrr/openrr/.deny.toml:28:1
   │
28 │ copyleft = "deny"
   │ ━━━━━━━━

error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
   ┌─ /home/runner/work/openrr/openrr/.deny.toml:26:1
   │
26 │ default = "deny"
   │ ━━━━━━━
```