### PR TITLE
Use grouped update and re-enable Github Actions update of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,11 @@ updates:
       - dependency-name: k
       - dependency-name: nalgebra
       - dependency-name: ncollide3d
-      # These dependencies need to be updated at the same time with tonic.
-      - dependency-name: prost
-      - dependency-name: prost-types
-      - dependency-name: tonic-build
-      # These dependencies need to be updated at the same time with eframe.
-      - dependency-name: egui_extras
     labels: []
+    groups:
+      cargo:
+        patterns:
+          - '*'
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -26,3 +24,7 @@ updates:
     commit-message:
       prefix: ''
     labels: []
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,10 @@ updates:
       # These dependencies need to be updated at the same time with eframe.
       - dependency-name: egui_extras
     labels: []
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: ''
+    labels: []


### PR DESCRIPTION
This includes two improvements about dependabot:
- Use grouped update: https://github.blog/changelog/2023-08-10-group-dependabot-version-updates-by-development-or-production-dependencies/
  This will reduce the number of cases where manual work is required when updating egui or tonic.
- Previously there were various issues with GitHub Actions updates, but perhaps the last major issue was fixed in https://github.com/dependabot/dependabot-core/pull/6743, and now it seems to be working fine (at least to the extent that it was used in github.com/taiki-e and mesh-loader.).