### PR TITLE
Remove assimp feature

### DIFF
--- a/.github/.cspell/rust-dependencies.txt
+++ b/.github/.cspell/rust-dependencies.txt
@@ -3,7 +3,6 @@
 
 appender
 arci
-assimp
 chrono
 eframe
 egui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - run: cargo test --workspace --exclude arci-ros --exclude arci-ros2 --exclude openrr-apps
       - name: cargo test (openrr-apps without ros)
         working-directory: openrr-apps
-        run: cargo test --no-default-features --features gui,assimp
+        run: cargo test --no-default-features --features gui
 
   ros1_arci_ros:
     strategy:
@@ -130,7 +130,7 @@ jobs:
         run: |
           source /opt/ros/${{ matrix.distro }}/setup.bash
           rosdep install -y -i --from-paths .
-          cargo test --no-default-features --features ros,assimp
+          cargo test --no-default-features --features ros
 
   ros2_arci_ros2:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ openrr-tracing = { version = "0.1.0", default-features = false }
 abi_stable = "0.11"
 anyhow = "1"
 assert_approx_eq = "1.1"
-assimp = "0.3"
 async-ffi = { version = "0.5", features = ["abi_stable"] }
 async-recursion = "1"
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ OpenRR (pronounced like "opener") is Open Rust Robotics platform.
 sudo apt install cmake build-essential libudev-dev xorg-dev libglu1-mesa-dev libasound2-dev libxkbcommon-dev protobuf-compiler
 ```
 
-* cmake build-essential (openrr-planner (assimp-sys))
 * libudev-dev (arci-gamepad-gilrs)
-* xorg-dev libglu1-mesa-dev libxkbcommon-dev (openrr-gui (egui))
+* cmake build-essential xorg-dev libglu1-mesa-dev libxkbcommon-dev (openrr-gui (egui))
 * libasound2-dev (arci-speak-audio)
 * protobuf-compiler (openrr-remote)
 

--- a/openrr-apps/Cargo.toml
+++ b/openrr-apps/Cargo.toml
@@ -10,11 +10,6 @@ categories = ["science::robotics"]
 
 [features]
 default = ["gui", "ros"]
-assimp = [
-    "openrr-client/assimp",
-    "openrr-command/assimp",
-    "openrr-teleop/assimp",
-]
 ros = ["arci-ros"]
 gui = ["openrr-gui"]
 

--- a/openrr-apps/README.md
+++ b/openrr-apps/README.md
@@ -20,7 +20,7 @@ If you are Windows user, ROS is not supported.
 So remove it.
 
 ```bash
-cargo install openrr-apps --no-default-features --features gui,assimp
+cargo install openrr-apps --no-default-features --features gui
 ```
 
 ### Option: For UR10 sample

--- a/openrr-client/Cargo.toml
+++ b/openrr-client/Cargo.toml
@@ -10,7 +10,6 @@ categories = ["science::robotics"]
 
 [features]
 default = []
-assimp = ["openrr-planner/assimp"]
 
 [dependencies]
 anyhow.workspace = true

--- a/openrr-command/Cargo.toml
+++ b/openrr-command/Cargo.toml
@@ -10,7 +10,6 @@ categories = ["science::robotics"]
 
 [features]
 default = []
-assimp = ["openrr-client/assimp"]
 
 [dependencies]
 arci.workspace = true

--- a/openrr-gui/Cargo.toml
+++ b/openrr-gui/Cargo.toml
@@ -10,7 +10,6 @@ categories = ["science::robotics", "gui"]
 
 [features]
 default = []
-assimp = ["openrr-client/assimp"]
 
 [dependencies]
 arci.workspace = true

--- a/openrr-planner/Cargo.toml
+++ b/openrr-planner/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["algorithms", "science::robotics"]
 default = []
 
 [dependencies]
-assimp = { workspace = true, optional = true }
 k.workspace = true
 mesh-loader.workspace = true
 ncollide3d.workspace = true

--- a/openrr-planner/src/collision/mesh.rs
+++ b/openrr-planner/src/collision/mesh.rs
@@ -1,35 +1,11 @@
-use std::{io, path::Path};
+use std::path::Path;
 
 use k::{nalgebra as na, RealField};
 use ncollide3d::shape::TriMesh;
 
 use crate::errors::*;
 
-#[cfg(feature = "assimp")]
 pub(crate) fn load_mesh<P, T>(filename: P, scale: &[f64; 3]) -> Result<TriMesh<T>>
-where
-    P: AsRef<Path>,
-    T: RealField + Copy,
-{
-    let filename = filename.as_ref();
-    let mut importer = assimp::Importer::new();
-    importer.pre_transform_vertices(|x| x.enable = true);
-    importer.collada_ignore_up_direction(true);
-    importer.triangulate(true);
-    if let Some(file_string) = filename.to_str() {
-        match importer.read_file(file_string) {
-            Ok(assimp_scene) => Ok(assimp_scene_to_ncollide_mesh(assimp_scene, scale)),
-            Err(err) => Err(Error::MeshError(err.to_owned())),
-        }
-    } else {
-        // assimp crate only supports UTF-8 path
-        load_mesh_with_mesh_loader(filename, scale)
-    }
-}
-
-#[cfg(not(feature = "assimp"))]
-pub(crate) use load_mesh_with_mesh_loader as load_mesh;
-pub(crate) fn load_mesh_with_mesh_loader<P, T>(filename: P, scale: &[f64; 3]) -> Result<TriMesh<T>>
 where
     P: AsRef<Path>,
     T: RealField + Copy,
@@ -37,22 +13,7 @@ where
     let filename = filename.as_ref();
     let mesh = mesh_loader::Loader::default()
         .merge_meshes(true)
-        .load(filename)
-        .map_err(|e| {
-            if e.kind() == io::ErrorKind::Unsupported {
-                if cfg!(feature = "assimp") {
-                    Error::MeshError(format!(
-                        "assimp feature is enabled but filename is not UTF-8: could not parse {filename:?}"
-                    ))
-                } else {
-                    Error::MeshError(format!(
-                        "assimp feature is disabled: could not parse {filename:?}"
-                    ))
-                }
-            } else {
-                e.into()
-            }
-        })?
+        .load(filename)?
         .meshes
         .pop()
         .unwrap(); // merge_meshes(true) merges all meshes into one
@@ -75,36 +36,4 @@ where
         .collect();
 
     Ok(TriMesh::new(vertices, indices, None))
-}
-
-#[cfg(feature = "assimp")]
-fn assimp_scene_to_ncollide_mesh<T>(scene: assimp::Scene<'_>, scale: &[f64; 3]) -> TriMesh<T>
-where
-    T: RealField + Copy,
-{
-    let mut vertices = Vec::new();
-    let mut indices = Vec::new();
-    let mut last_index: usize = 0;
-    for mesh in scene.mesh_iter() {
-        vertices.extend(mesh.vertex_iter().map(|v| {
-            na::Point3::<T>::new(
-                na::convert(v.x as f64 * scale[0]),
-                na::convert(v.y as f64 * scale[1]),
-                na::convert(v.z as f64 * scale[2]),
-            )
-        }));
-        indices.extend(mesh.face_iter().filter_map(|f| {
-            if f.num_indices == 3 {
-                Some(na::Point3::new(
-                    f[0] as usize + last_index,
-                    f[1] as usize + last_index,
-                    f[2] as usize + last_index,
-                ))
-            } else {
-                None
-            }
-        }));
-        last_index = vertices.len();
-    }
-    TriMesh::new(vertices, indices, None)
 }

--- a/openrr-teleop/Cargo.toml
+++ b/openrr-teleop/Cargo.toml
@@ -10,7 +10,6 @@ categories = ["algorithms", "science::robotics"]
 
 [features]
 default = []
-assimp = ["openrr-client/assimp"]
 
 [dependencies]
 arci.workspace = true

--- a/openrr/Cargo.toml
+++ b/openrr/Cargo.toml
@@ -11,13 +11,6 @@ categories = ["science::robotics"]
 
 [features]
 default = []
-assimp = [
-    "openrr-client/assimp",
-    "openrr-command/assimp",
-    "openrr-planner/assimp",
-    "openrr-teleop/assimp",
-    "openrr-apps/assimp",
-]
 gui = ["openrr-apps/gui"]
 ros = ["openrr-apps/ros"]
 


### PR DESCRIPTION
This is disabled by default since over half year ago in openrr (https://github.com/openrr/openrr/pull/898) and urdf-viz (https://github.com/openrr/urdf-viz/pull/240).

> If there are no problems (or even if there are problems, they are fixed) I plan to eventually remove the dependence on assimp.

Closes #148