### PR TITLE
Use basedir when loading from urdf file

### DIFF
--- a/openrr-planner/src/collision/robot_collision_detector.rs
+++ b/openrr-planner/src/collision/robot_collision_detector.rs
@@ -137,9 +137,13 @@ pub fn create_robot_collision_detector<P: AsRef<Path>>(
     config: RobotCollisionDetectorConfig,
     self_collision_pairs: Vec<(String, String)>,
 ) -> RobotCollisionDetector<f64> {
-    let urdf_robot = urdf_rs::read_file(urdf_path).unwrap();
+    let urdf_robot = urdf_rs::read_file(&urdf_path).unwrap();
     let robot = k::Chain::<f64>::from(&urdf_robot);
-    let collision_detector = CollisionDetector::from_urdf_robot(&urdf_robot, config.prediction);
+    let collision_detector = CollisionDetector::from_urdf_robot_with_base_dir(
+        &urdf_robot,
+        urdf_path.as_ref().parent(),
+        config.prediction,
+    );
 
     RobotCollisionDetector::new(robot, collision_detector, self_collision_pairs)
 }

--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -195,8 +195,9 @@ pub fn create_self_collision_checker<P: AsRef<Path>>(
     config: &SelfCollisionCheckerConfig,
     robot: Arc<k::Chain<f64>>,
 ) -> SelfCollisionChecker<f64> {
-    let collision_detector = CollisionDetector::from_urdf_robot(
+    let collision_detector = CollisionDetector::from_urdf_robot_with_base_dir(
         &urdf_rs::utils::read_urdf_or_xacro(urdf_path.as_ref()).unwrap(),
+        urdf_path.as_ref().parent(),
         config.prediction,
     );
     let robot_collision_detector = RobotCollisionDetector::new(

--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -352,14 +352,24 @@ where
         P: AsRef<Path>,
     {
         let urdf_robot = urdf_rs::utils::read_urdf_or_xacro(file.as_ref())?;
-        Ok(JointPathPlannerBuilder::from_urdf_robot(urdf_robot))
+        Ok(JointPathPlannerBuilder::from_urdf_robot_with_base_dir(
+            urdf_robot,
+            file.as_ref().parent(),
+        ))
     }
 
     /// Try to create `JointPathPlannerBuilder` instance from `urdf_rs::Robot` instance
-    pub fn from_urdf_robot(urdf_robot: urdf_rs::Robot) -> JointPathPlannerBuilder<N> {
+    pub fn from_urdf_robot_with_base_dir(
+        urdf_robot: urdf_rs::Robot,
+        base_path: Option<&Path>,
+    ) -> JointPathPlannerBuilder<N> {
         let robot = k::Chain::from(&urdf_robot);
         let default_margin = na::convert(0.0);
-        let collision_detector = CollisionDetector::from_urdf_robot(&urdf_robot, default_margin);
+        let collision_detector = CollisionDetector::from_urdf_robot_with_base_dir(
+            &urdf_robot,
+            base_path,
+            default_margin,
+        );
         let robot_collision_detector =
             RobotCollisionDetector::new(robot, collision_detector, vec![]);
         JointPathPlannerBuilder::new(robot_collision_detector)


### PR DESCRIPTION
Use the `_with_base_dir` variant when loading from the file, otherwise, it will receive error like
```sh
2024-09-04T01:49:24.666406Z ERROR openrr_planner::collision::urdf: ../meshes/collision/link0.stl not found
2024-09-04T01:49:24.666437Z ERROR openrr_planner::collision::urdf: ../meshes/collision/link1.stl not found
2024-09-04T01:49:24.666442Z ERROR openrr_planner::collision::urdf: ../meshes/collision/link2.stl not found
2024-09-04T01:49:24.666447Z ERROR openrr_planner::collision::urdf: ../meshes/collision/link3.stl not found
2024-09-04T01:49:24.666451Z ERROR openrr_planner::collision::urdf: ../meshes/collision/link4.stl not found
2024-09-04T01:49:24.666456Z ERROR openrr_planner::collision::urdf: ../meshes/collision/link5.stl not found
2024-09-04T01:49:24.666461Z ERROR openrr_planner::collision::urdf: ../meshes/collision/link6.stl not found
```
if the urdf has relative path