### PR TITLE
Update .deny.toml to fix CI failure

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -32,8 +32,7 @@ private.ignore = true
 allow = [
     "Apache-2.0",
     "MIT",
-    "Unicode-DFS-2016", # unicode-ident
-    "Unicode-3.0",
+    "Unicode-3.0", # unicode-ident
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",


### PR DESCRIPTION
```
error[license-not-encountered]: license was not encountered
   ┌─ /home/runner/work/openrr/openrr/.deny.toml:35:6
   │
35 │     "Unicode-DFS-2016", # unicode-ident
   │      ━━━━━━━━━━━━━━━━ unmatched license allowance
```