### PR TITLE
Fix newly added clippy warning & Migrate to Rust 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   RUSTDOCFLAGS: -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  nightly: nightly-2024-01-25
+  nightly: nightly-2025-09-01
 
 defaults:
   run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 # ci/publish.sh locally to publish the remaining crates.
 # NOTE: when updating this, reminder to update arci-speak-cmd's Cargo.toml.
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/openrr/openrr"
 homepage = "https://openrr.github.io"

--- a/arci-gamepad-gilrs/src/lib.rs
+++ b/arci-gamepad-gilrs/src/lib.rs
@@ -306,10 +306,10 @@ impl GilGamepad {
             Some(gilrs::Event {
                 id: recv_id, event, ..
             }) => {
-                if id == Into::<usize>::into(recv_id) {
-                    if let Some(e) = map.convert_event(event) {
-                        tx.send(e).unwrap();
-                    }
+                if id == Into::<usize>::into(recv_id)
+                    && let Some(e) = map.convert_event(event)
+                {
+                    tx.send(e).unwrap();
                 }
             }
             None => {
@@ -331,11 +331,11 @@ impl GilGamepad {
             Some(gilrs::Event {
                 id: recv_id, event, ..
             }) => {
-                if id == Into::<usize>::into(recv_id) {
-                    if let Some(e) = map.convert_event(event) {
-                        tx.send(e.clone()).unwrap();
-                        msg = e;
-                    }
+                if id == Into::<usize>::into(recv_id)
+                    && let Some(e) = map.convert_event(event)
+                {
+                    tx.send(e.clone()).unwrap();
+                    msg = e;
                 }
             }
             None => tx.send(msg.clone()).unwrap(),

--- a/arci-gamepad-gilrs/src/lib.rs
+++ b/arci-gamepad-gilrs/src/lib.rs
@@ -2,15 +2,15 @@
 
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
 
 use arci::{gamepad::*, *};
 use indexmap::IndexMap;
-use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
+use schemars::{JsonSchema, r#gen::SchemaGenerator, schema::Schema};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use tracing::{debug, error, info};
@@ -117,7 +117,7 @@ impl JsonSchema for Map {
         "Map".to_string()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         // https://docs.rs/gilrs/0.8/gilrs/ev/enum.Button.html
         #[allow(dead_code)]
         #[derive(JsonSchema)]
@@ -165,7 +165,7 @@ impl JsonSchema for Map {
             axis_value_map: Vec<(Axis, f64)>,
         }
 
-        MapRepr::json_schema(gen)
+        MapRepr::json_schema(generator)
     }
 }
 

--- a/arci-gamepad-keyboard/src/lib.rs
+++ b/arci-gamepad-keyboard/src/lib.rs
@@ -6,13 +6,13 @@ use std::{
     collections::HashMap,
     io::{self, Read, Write},
     sync::{
-        atomic::{AtomicBool, Ordering::Relaxed},
         Arc,
+        atomic::{AtomicBool, Ordering::Relaxed},
     },
 };
 
 use arci::{gamepad::*, *};
-use termios::{tcsetattr, Termios};
+use termios::{Termios, tcsetattr};
 use tracing::{debug, error};
 
 #[derive(Debug)]
@@ -213,11 +213,11 @@ impl KeyboardGamepad {
         let is_running_cloned = is_running.clone();
 
         // Based on https://stackoverflow.com/questions/26321592/how-can-i-read-one-character-from-stdin-without-having-to-hit-enter
-        let stdin = 0; // couldn't get std::os::unix::io::FromRawFd to work
-                       // on /dev/stdin or /dev/tty
+        // couldn't get std::os::unix::io::FromRawFd to work on /dev/stdin or /dev/tty
+        let stdin = 0;
         let termios = Termios::from_fd(stdin).unwrap();
-        let mut new_termios = termios; // make a mutable copy of termios
-                                       // that we will modify
+        // make a mutable copy of termios that we will modify
+        let mut new_termios = termios;
         new_termios.c_lflag &= !(termios::ICANON | termios::ECHO); // no echo and canonical mode
         tcsetattr(stdin, termios::TCSANOW, &new_termios).unwrap();
         let mut reader = io::stdin();

--- a/arci-ros/examples/resolve_transformation.rs
+++ b/arci-ros/examples/resolve_transformation.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use arci::TransformResolver;
 use arci_ros::RosTransformResolver;
 

--- a/arci-ros/examples/ros1_diff_drive.rs
+++ b/arci-ros/examples/ros1_diff_drive.rs
@@ -3,7 +3,7 @@ async fn main() -> Result<(), anyhow::Error> {
     use arci::{BaseVelocity, Gamepad};
     use arci_gamepad_gilrs::*;
     use arci_ros::JointVelocityController;
-    use openrr_base::{differential_drive::*, BaseAcceleration};
+    use openrr_base::{BaseAcceleration, differential_drive::*};
     use openrr_teleop::{ControlMode, MoveBaseMode};
 
     arci_ros::init("diff_drive");

--- a/arci-ros/src/ros_control/joint_state_provider_from_joint_state.rs
+++ b/arci-ros/src/ros_control/joint_state_provider_from_joint_state.rs
@@ -1,4 +1,4 @@
-use crate::{error::Error, msg::sensor_msgs::JointState, JointStateProvider, SubscriberHandler};
+use crate::{JointStateProvider, SubscriberHandler, error::Error, msg::sensor_msgs::JointState};
 
 pub(crate) struct JointStateProviderFromJointState(SubscriberHandler<JointState>);
 

--- a/arci-ros/src/ros_control/joint_state_provider_from_joint_trajectory_controller_state.rs
+++ b/arci-ros/src/ros_control/joint_state_provider_from_joint_trajectory_controller_state.rs
@@ -1,6 +1,6 @@
 use msg::control_msgs::JointTrajectoryControllerState;
 
-use crate::{error::Error, msg, JointStateProvider, SubscriberHandler};
+use crate::{JointStateProvider, SubscriberHandler, error::Error, msg};
 
 pub(crate) struct JointStateProviderFromJointTrajectoryControllerState(
     SubscriberHandler<JointTrajectoryControllerState>,

--- a/arci-ros/src/ros_control/ros_control_action_client.rs
+++ b/arci-ros/src/ros_control/ros_control_action_client.rs
@@ -9,10 +9,10 @@ use arci::{
 };
 
 use crate::{
-    create_joint_trajectory_message_for_send_joint_positions,
+    JointStateProvider, JointStateProviderFromJointState, LazyJointStateProvider,
+    SubscriberHandler, create_joint_trajectory_message_for_send_joint_positions,
     create_joint_trajectory_message_for_send_joint_trajectory, define_action_client,
-    extract_current_joint_positions_from_state, msg, JointStateProvider,
-    JointStateProviderFromJointState, LazyJointStateProvider, SubscriberHandler,
+    extract_current_joint_positions_from_state, msg,
 };
 
 const ACTION_TIMEOUT_DURATION_RATIO: u32 = 10;

--- a/arci-ros/src/ros_control/ros_control_client.rs
+++ b/arci-ros/src/ros_control/ros_control_client.rs
@@ -10,11 +10,11 @@ use arci::{
 use msg::trajectory_msgs::JointTrajectory;
 
 use crate::{
+    JointStateProvider, JointStateProviderFromJointTrajectoryControllerState,
+    LazyJointStateProvider, SubscriberHandler,
     create_joint_trajectory_message_for_send_joint_positions,
     create_joint_trajectory_message_for_send_joint_trajectory,
-    extract_current_joint_positions_from_state, msg, JointStateProvider,
-    JointStateProviderFromJointTrajectoryControllerState, LazyJointStateProvider,
-    SubscriberHandler,
+    extract_current_joint_positions_from_state, msg,
 };
 
 #[derive(Clone)]

--- a/arci-ros/src/ros_control/utils.rs
+++ b/arci-ros/src/ros_control/utils.rs
@@ -1,12 +1,12 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::format_err;
-use arci::{copy_joint_positions, Error, JointTrajectoryClient, TrajectoryPoint};
+use arci::{Error, JointTrajectoryClient, TrajectoryPoint, copy_joint_positions};
 
 use crate::{
+    JointStateProvider, LazyJointStateProvider, RosControlClientBuilder,
     msg::trajectory_msgs::{JointTrajectory, JointTrajectoryPoint},
-    wrap_joint_trajectory_client, JointStateProvider, LazyJointStateProvider,
-    RosControlClientBuilder,
+    wrap_joint_trajectory_client,
 };
 
 pub(crate) fn extract_current_joint_positions_from_state(

--- a/arci-ros/src/ros_nav_client.rs
+++ b/arci-ros/src/ros_nav_client.rs
@@ -5,7 +5,7 @@ use nalgebra as na;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{define_action_client, msg, ActionResultWait};
+use crate::{ActionResultWait, define_action_client, msg};
 define_action_client!(MoveBaseActionClient, msg::move_base_msgs, MoveBase);
 
 impl From<na::Isometry2<f64>> for msg::geometry_msgs::Pose {

--- a/arci-ros/tests/test_joy.rs
+++ b/arci-ros/tests/test_joy.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use arci::{gamepad::GamepadEvent, Gamepad};
+use arci::{Gamepad, gamepad::GamepadEvent};
 use arci_ros::RosJoyGamepad;
 
 mod util;

--- a/arci-ros/tests/test_robot_client.rs
+++ b/arci-ros/tests/test_robot_client.rs
@@ -63,15 +63,19 @@ fn test_robot_client() {
     assert_eq!(client.joint_names()[0], "joint0");
     assert_approx_eq!(client.current_joint_positions().unwrap()[1], 1f64);
 
-    assert!(client
-        .send_joint_positions(vec![0.5, 1.5, 2.5], std::time::Duration::from_millis(100),)
-        .is_ok());
+    assert!(
+        client
+            .send_joint_positions(vec![0.5, 1.5, 2.5], std::time::Duration::from_millis(100),)
+            .is_ok()
+    );
 
-    assert!(client
-        .send_joint_trajectory(vec![TrajectoryPoint {
-            positions: vec![1.0, 2.0, 3.0],
-            velocities: Some(vec![3.5, 4.5, 5.5]),
-            time_from_start: std::time::Duration::from_millis(100),
-        }])
-        .is_ok());
+    assert!(
+        client
+            .send_joint_trajectory(vec![TrajectoryPoint {
+                positions: vec![1.0, 2.0, 3.0],
+                velocities: Some(vec![3.5, 4.5, 5.5]),
+                time_from_start: std::time::Duration::from_millis(100),
+            }])
+            .is_ok()
+    );
 }

--- a/arci-ros/tests/test_rosrust_utils.rs
+++ b/arci-ros/tests/test_rosrust_utils.rs
@@ -79,7 +79,7 @@ fn test_convert_system_time_to_ros_time() {
 #[flaky_test::flaky_test]
 fn test_subscribe_with_channel() {
     use arci::{BaseVelocity, MoveBase};
-    use arci_ros::{msg::geometry_msgs::Twist, RosCmdVelMoveBase};
+    use arci_ros::{RosCmdVelMoveBase, msg::geometry_msgs::Twist};
     use assert_approx_eq::assert_approx_eq;
 
     println!("test subscriber helper is running!");

--- a/arci-ros/tests/util/child_process_terminator.rs
+++ b/arci-ros/tests/util/child_process_terminator.rs
@@ -1,7 +1,7 @@
 use std::process::{Child, Command, Stdio};
 
 use nix::{
-    sys::signal::{kill, Signal},
+    sys::signal::{Signal, kill},
     unistd::Pid,
 };
 
@@ -21,27 +21,31 @@ impl ChildProcessTerminator {
 
     #[allow(dead_code)]
     pub(crate) fn spawn_example(command: &mut Command) -> ChildProcessTerminator {
-        assert!(Command::new("cargo")
-            .arg("build")
-            .arg("--all-targets")
-            .output()
-            .unwrap()
-            .status
-            .success());
+        assert!(
+            Command::new("cargo")
+                .arg("build")
+                .arg("--all-targets")
+                .output()
+                .unwrap()
+                .status
+                .success()
+        );
 
         Self::spawn(command)
     }
 
     #[allow(dead_code)]
     pub(crate) fn spawn_example_bench(command: &mut Command) -> ChildProcessTerminator {
-        assert!(Command::new("cargo")
-            .arg("build")
-            .arg("--all-targets")
-            .arg("--release")
-            .output()
-            .unwrap()
-            .status
-            .success());
+        assert!(
+            Command::new("cargo")
+                .arg("build")
+                .arg("--all-targets")
+                .arg("--release")
+                .output()
+                .unwrap()
+                .status
+                .success()
+        );
 
         Self::spawn(command)
     }

--- a/arci-ros/tests/util/mod.rs
+++ b/arci-ros/tests/util/mod.rs
@@ -28,7 +28,7 @@ fn await_roscore() {
 
 pub(crate) fn run_roscore(port: u32) -> ChildProcessTerminator {
     println!("Running roscore on port: {port}");
-    env::set_var("ROS_MASTER_URI", format!("http://localhost:{port}"));
+    unsafe { env::set_var("ROS_MASTER_URI", format!("http://localhost:{port}")) }
     while !portpicker::is_free(port as u16) {
         println!("Waiting port={port}");
         sleep(Duration::from_millis(100));

--- a/arci-ros2/src/cmd_vel_move_base.rs
+++ b/arci-ros2/src/cmd_vel_move_base.rs
@@ -7,7 +7,7 @@ use arci::*;
 use r2r::{geometry_msgs::msg::Twist, nav_msgs::msg::Odometry};
 use serde::{Deserialize, Serialize};
 
-use crate::{utils, Node};
+use crate::{Node, utils};
 
 /// `arci::MoveBase` implementation for ROS2.
 pub struct Ros2CmdVelMoveBase {

--- a/arci-ros2/src/navigation.rs
+++ b/arci-ros2/src/navigation.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
@@ -15,7 +15,7 @@ use r2r::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{utils, Node};
+use crate::{Node, utils};
 
 /// `arci::Navigation` implementation for ROS2.
 pub struct Ros2Navigation {

--- a/arci-ros2/src/node.rs
+++ b/arci-ros2/src/node.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex, MutexGuard,
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };

--- a/arci-ros2/src/ros2_control.rs
+++ b/arci-ros2/src/ros2_control.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, RwLock,
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
@@ -16,7 +16,7 @@ use r2r::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{utils, Node};
+use crate::{Node, utils};
 
 /// `arci::JointTrajectoryClient` implementation for ROS2.
 pub struct Ros2ControlClient {

--- a/arci-ros2/src/ros2_laser_scan.rs
+++ b/arci-ros2/src/ros2_laser_scan.rs
@@ -4,10 +4,10 @@ use std::{
 };
 
 use arci::*;
-use r2r::{sensor_msgs::msg::LaserScan, QosProfile};
+use r2r::{QosProfile, sensor_msgs::msg::LaserScan};
 use serde::{Deserialize, Serialize};
 
-use crate::{utils, Node};
+use crate::{Node, utils};
 
 /// `arci::LaserScan2D` implementation for ROS2.
 pub struct Ros2LaserScan2D {

--- a/arci-ros2/src/ros2_localization_client.rs
+++ b/arci-ros2/src/ros2_localization_client.rs
@@ -5,13 +5,13 @@ use std::{
 
 use arci::{nalgebra as na, *};
 use r2r::{
-    geometry_msgs::msg::{PoseWithCovariance, PoseWithCovarianceStamped},
     QosProfile,
+    geometry_msgs::msg::{PoseWithCovariance, PoseWithCovarianceStamped},
 };
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use crate::{utils, Node};
+use crate::{Node, utils};
 
 /// `arci::Localization` implementation for ROS2.
 pub struct Ros2LocalizationClient {

--- a/arci-ros2/src/ros2_transform_resolver.rs
+++ b/arci-ros2/src/ros2_transform_resolver.rs
@@ -1,14 +1,14 @@
 use std::time::Duration;
 
 use arci::{
-    nalgebra::{Quaternion, Translation3},
     Isometry3, TransformResolver, UnitQuaternion,
+    nalgebra::{Quaternion, Translation3},
 };
 use r2r::builtin_interfaces::msg as builtin_msg;
 use tf_r2r::{TfBuffer, TfListener};
 use tracing::{debug, warn};
 
-use crate::{utils::convert_system_time_to_ros2_time, Node};
+use crate::{Node, utils::convert_system_time_to_ros2_time};
 
 /// `arci::TransformResolver` implementation for ROS2.
 pub struct Ros2TransformResolver {

--- a/arci-ros2/src/utils.rs
+++ b/arci-ros2/src/utils.rs
@@ -1,7 +1,7 @@
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, RwLock,
+        atomic::{AtomicBool, Ordering},
     },
     time::{Duration, Instant, SystemTime},
 };

--- a/arci-ros2/tests/test_cmd_vel.rs
+++ b/arci-ros2/tests/test_cmd_vel.rs
@@ -3,7 +3,7 @@
 mod shared;
 
 use arci::{BaseVelocity, MoveBase};
-use arci_ros2::{r2r, Ros2CmdVelMoveBase};
+use arci_ros2::{Ros2CmdVelMoveBase, r2r};
 use assert_approx_eq::assert_approx_eq;
 use futures::stream::StreamExt;
 use r2r::geometry_msgs::msg::Twist;

--- a/arci-ros2/tests/test_cmd_vel_with_odom.rs
+++ b/arci-ros2/tests/test_cmd_vel_with_odom.rs
@@ -5,9 +5,9 @@ mod shared;
 use std::time::Duration;
 
 use arci::MoveBase;
-use arci_ros2::{r2r, Ros2CmdVelMoveBase};
+use arci_ros2::{Ros2CmdVelMoveBase, r2r};
 use assert_approx_eq::assert_approx_eq;
-use r2r::{nav_msgs::msg::Odometry, QosProfile};
+use r2r::{QosProfile, nav_msgs::msg::Odometry};
 use shared::*;
 
 const ODOMETRY_TOPIC: &str = "/odom";

--- a/arci-ros2/tests/test_navigation.rs
+++ b/arci-ros2/tests/test_navigation.rs
@@ -4,14 +4,14 @@ mod shared;
 
 use std::{
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
 use arci::*;
-use arci_ros2::{r2r, Node, Ros2Navigation};
+use arci_ros2::{Node, Ros2Navigation, r2r};
 use assert_approx_eq::assert_approx_eq;
 use futures::{
     future::{self, Either},
@@ -67,8 +67,8 @@ async fn test_nav_timeout() {
 
     node.run_spin_thread(Duration::from_millis(100));
 
-    assert!(nav
-        .send_goal_pose(
+    assert!(
+        nav.send_goal_pose(
             Isometry2::new(Vector2::new(-0.6, 0.2), 1.0),
             "map",
             Duration::from_secs(1),
@@ -77,7 +77,8 @@ async fn test_nav_timeout() {
         .await
         .unwrap_err()
         .to_string()
-        .contains("timeout"));
+        .contains("timeout")
+    );
 }
 
 #[flaky_test::flaky_test(tokio(flavor = "multi_thread"))]

--- a/arci-ros2/tests/test_ros2_control.rs
+++ b/arci-ros2/tests/test_ros2_control.rs
@@ -4,14 +4,14 @@ mod shared;
 
 use std::{
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
 use arci::*;
-use arci_ros2::{r2r, Node, Ros2ControlClient};
+use arci_ros2::{Node, Ros2ControlClient, r2r};
 use futures::{
     future::{self, Either},
     stream::{Stream, StreamExt},
@@ -102,7 +102,7 @@ async fn run_goal(
 async fn test_control_server(
     node: Node,
     mut requests: impl Stream<Item = r2r::ActionServerGoalRequest<FollowJointTrajectory::Action>>
-        + Unpin,
+    + Unpin,
     state: Arc<Mutex<JointTrajectoryControllerState>>,
 ) {
     while let Some(req) = requests.next().await {

--- a/arci-ros2/tests/test_ros2_laser_scan.rs
+++ b/arci-ros2/tests/test_ros2_laser_scan.rs
@@ -5,8 +5,8 @@ mod shared;
 use std::time::Duration;
 
 use arci::{LaserScan2D, Scan2D};
-use arci_ros2::{r2r, Ros2LaserScan2D};
-use r2r::{sensor_msgs::msg::LaserScan, std_msgs::msg::Header, QosProfile};
+use arci_ros2::{Ros2LaserScan2D, r2r};
+use r2r::{QosProfile, sensor_msgs::msg::LaserScan, std_msgs::msg::Header};
 use shared::*;
 
 const LASER_SCAN_TOPIC: &str = "/scan";

--- a/arci-ros2/tests/test_ros2_localization_client.rs
+++ b/arci-ros2/tests/test_ros2_localization_client.rs
@@ -5,13 +5,13 @@ mod shared;
 use std::time::Duration;
 
 use arci::Localization;
-use arci_ros2::{r2r, Ros2LocalizationClient};
+use arci_ros2::{Ros2LocalizationClient, r2r};
 use assert_approx_eq::assert_approx_eq;
 use futures::StreamExt;
 use r2r::{
+    QosProfile,
     geometry_msgs::msg::{Point, Pose, PoseWithCovariance, PoseWithCovarianceStamped, Quaternion},
     std_msgs::msg::Header,
-    QosProfile,
 };
 use shared::*;
 

--- a/arci-ros2/tests/test_ros2_transform_resolver.rs
+++ b/arci-ros2/tests/test_ros2_transform_resolver.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use arci::TransformResolver;
 use arci_ros2::{
     r2r::{
-        builtin_interfaces::msg::Time, geometry_msgs::msg::TransformStamped,
-        tf2_msgs::msg::TFMessage, QosProfile,
+        QosProfile, builtin_interfaces::msg::Time, geometry_msgs::msg::TransformStamped,
+        tf2_msgs::msg::TFMessage,
     },
     utils::convert_ros2_time_to_system_time,
 };

--- a/arci-speak-cmd/src/lib.rs
+++ b/arci-speak-cmd/src/lib.rs
@@ -66,7 +66,9 @@ fn run_local_command(message: &str) -> io::Result<()> {
 fn run_local_command(message: &str) -> io::Result<()> {
     // TODO: Ideally, it would be more efficient to use SAPI directly via winapi or something.
     // https://stackoverflow.com/questions/1040655/ms-speech-from-command-line
-    let cmd = format!("PowerShell -Command \"Add-Type –AssemblyName System.Speech; (New-Object System.Speech.Synthesis.SpeechSynthesizer).Speak('{message}');\"");
+    let cmd = format!(
+        "PowerShell -Command \"Add-Type –AssemblyName System.Speech; (New-Object System.Speech.Synthesis.SpeechSynthesizer).Speak('{message}');\""
+    );
     let status = Command::new("powershell").arg(cmd).status()?;
 
     if status.success() {

--- a/arci-urdf-viz/src/client.rs
+++ b/arci-urdf-viz/src/client.rs
@@ -9,8 +9,9 @@ use std::{
 
 use anyhow::format_err;
 use arci::{
-    nalgebra as na, BaseVelocity, JointPositionLimit, JointPositionLimiter, JointTrajectoryClient,
+    BaseVelocity, JointPositionLimit, JointPositionLimiter, JointTrajectoryClient,
     JointVelocityLimiter, Localization, MoveBase, Navigation, TrajectoryPoint, WaitFuture,
+    nalgebra as na,
 };
 use schemars::JsonSchema;
 use scoped_sleep::ScopedSleep;
@@ -373,12 +374,14 @@ impl UrdfVizWebClient {
                     let current = continue_on_err!(get_joint_positions(&bomb.0.base_url)).positions;
                     let duration_sec = duration.as_secs_f64();
                     let unit_sec = UNIT_DURATION.as_secs_f64();
-                    let trajectories = continue_on_err!(openrr_planner::interpolate(
-                        &[current, target.positions.to_vec()],
-                        duration_sec,
-                        unit_sec,
-                    )
-                    .ok_or_else(|| arci::Error::InterpolationError("".to_owned())));
+                    let trajectories = continue_on_err!(
+                        openrr_planner::interpolate(
+                            &[current, target.positions.to_vec()],
+                            duration_sec,
+                            unit_sec,
+                        )
+                        .ok_or_else(|| arci::Error::InterpolationError("".to_owned()))
+                    );
 
                     for traj in trajectories {
                         if matches!(
@@ -445,7 +448,9 @@ impl JointTrajectoryClient for UrdfVizWebClient {
             .unwrap()
             .has_send_joint_positions_thread
         {
-            panic!("send_joint_positions called without run_send_joint_positions_thread being called first");
+            panic!(
+                "send_joint_positions called without run_send_joint_positions_thread being called first"
+            );
         }
 
         Ok(self

--- a/arci-urdf-viz/src/client.rs
+++ b/arci-urdf-viz/src/client.rs
@@ -80,8 +80,7 @@ fn create_joint_trajectory_clients_inner(
         all_client.run_send_joint_positions_thread();
         Ok(all_client)
     };
-    let all_client: Arc<dyn JointTrajectoryClient> = if lazy && urdf_robot.is_some() {
-        let urdf_robot = urdf_robot.as_ref().unwrap();
+    let all_client: Arc<dyn JointTrajectoryClient> = if lazy && let Some(urdf_robot) = &urdf_robot {
         Arc::new(arci::Lazy::with_joint_names(
             create_all_client,
             urdf_robot

--- a/arci-urdf-viz/src/utils.rs
+++ b/arci-urdf-viz/src/utils.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use arci::nalgebra as na;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use url::Url;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/arci-urdf-viz/tests/test_client.rs
+++ b/arci-urdf-viz/tests/test_client.rs
@@ -98,9 +98,11 @@ fn test_create_joint_trajectory_clients() {
     const DEFAULT_PORT: u16 = 7777;
 
     // empty config is no-op. it also does not connect to the server.
-    assert!(arci_urdf_viz::create_joint_trajectory_clients(vec![], None)
-        .unwrap()
-        .is_empty());
+    assert!(
+        arci_urdf_viz::create_joint_trajectory_clients(vec![], None)
+            .unwrap()
+            .is_empty()
+    );
     assert!(
         arci_urdf_viz::create_joint_trajectory_clients_lazy(vec![], None)
             .unwrap()
@@ -140,22 +142,26 @@ fn test_create_joint_trajectory_clients() {
         arci_urdf_viz::create_joint_trajectory_clients_lazy(configs.clone(), None).unwrap();
 
     // error when client name conflict
-    assert!(arci_urdf_viz::create_joint_trajectory_clients(
-        vec![configs[0].clone(), configs[0].clone()],
-        None
-    )
-    .err()
-    .unwrap()
-    .to_string()
-    .contains("client named 'c1' has already been specified"));
-    assert!(arci_urdf_viz::create_joint_trajectory_clients_lazy(
-        vec![configs[0].clone(), configs[0].clone()],
-        None
-    )
-    .err()
-    .unwrap()
-    .to_string()
-    .contains("client named 'c1' has already been specified"));
+    assert!(
+        arci_urdf_viz::create_joint_trajectory_clients(
+            vec![configs[0].clone(), configs[0].clone()],
+            None
+        )
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("client named 'c1' has already been specified")
+    );
+    assert!(
+        arci_urdf_viz::create_joint_trajectory_clients_lazy(
+            vec![configs[0].clone(), configs[0].clone()],
+            None
+        )
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("client named 'c1' has already been specified")
+    );
 }
 
 #[test]

--- a/arci-urdf-viz/tests/test_web.rs
+++ b/arci-urdf-viz/tests/test_web.rs
@@ -2,7 +2,7 @@ mod util;
 
 use std::{f64, time::Duration};
 
-use arci::{nalgebra, Localization, MoveBase, Navigation};
+use arci::{Localization, MoveBase, Navigation, nalgebra};
 use arci_urdf_viz::*;
 use assert_approx_eq::assert_approx_eq;
 use urdf_viz::WebServer;

--- a/arci-urdf-viz/tests/util/mod.rs
+++ b/arci-urdf-viz/tests/util/mod.rs
@@ -20,16 +20,18 @@ pub(crate) impl WebServer {
                 .unwrap()
                 .block_on(async move { self.bind().unwrap().await.unwrap() })
         });
-        std::thread::spawn(move || loop {
-            if let Some(positions) = handle.take_target_joint_positions() {
-                *handle.current_joint_positions() = positions;
-            }
-            if let Some(origin) = handle.pop_target_object_origin() {
-                if origin.id == urdf_viz::ROBOT_OBJECT_ID {
-                    *handle.current_robot_origin() = urdf_viz::RobotOrigin {
-                        position: origin.position,
-                        quaternion: origin.quaternion,
-                    };
+        std::thread::spawn(move || {
+            loop {
+                if let Some(positions) = handle.take_target_joint_positions() {
+                    *handle.current_joint_positions() = positions;
+                }
+                if let Some(origin) = handle.pop_target_object_origin() {
+                    if origin.id == urdf_viz::ROBOT_OBJECT_ID {
+                        *handle.current_robot_origin() = urdf_viz::RobotOrigin {
+                            position: origin.position,
+                            quaternion: origin.quaternion,
+                        };
+                    }
                 }
             }
         });

--- a/arci-urdf-viz/tests/util/mod.rs
+++ b/arci-urdf-viz/tests/util/mod.rs
@@ -25,13 +25,13 @@ pub(crate) impl WebServer {
                 if let Some(positions) = handle.take_target_joint_positions() {
                     *handle.current_joint_positions() = positions;
                 }
-                if let Some(origin) = handle.pop_target_object_origin() {
-                    if origin.id == urdf_viz::ROBOT_OBJECT_ID {
-                        *handle.current_robot_origin() = urdf_viz::RobotOrigin {
-                            position: origin.position,
-                            quaternion: origin.quaternion,
-                        };
-                    }
+                if let Some(origin) = handle.pop_target_object_origin()
+                    && origin.id == urdf_viz::ROBOT_OBJECT_ID
+                {
+                    *handle.current_robot_origin() = urdf_viz::RobotOrigin {
+                        position: origin.position,
+                        quaternion: origin.quaternion,
+                    };
                 }
             }
         });

--- a/arci/src/clients/dummy_navigation.rs
+++ b/arci/src/clients/dummy_navigation.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 
 use nalgebra::{Isometry2, Vector2};
 
-use crate::{error::Error, traits::Navigation, WaitFuture};
+use crate::{WaitFuture, error::Error, traits::Navigation};
 
 /// Dummy Navigation for debug or tests.
 #[derive(Debug)]
@@ -62,15 +62,16 @@ mod tests {
     #[tokio::test]
     async fn test_set() {
         let nav = DummyNavigation::new();
-        assert!(nav
-            .send_goal_pose(
+        assert!(
+            nav.send_goal_pose(
                 Isometry2::new(Vector2::new(1.0, 2.0), 3.0),
                 "",
                 std::time::Duration::default(),
             )
             .unwrap()
             .await
-            .is_ok());
+            .is_ok()
+        );
 
         let current_goal_pose = nav.current_goal_pose().unwrap();
         assert_approx_eq!(current_goal_pose.translation.x, 1.0);

--- a/arci/src/clients/dummy_speaker.rs
+++ b/arci/src/clients/dummy_speaker.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use crate::{error::Error, traits::Speaker, WaitFuture};
+use crate::{WaitFuture, error::Error, traits::Speaker};
 
 /// Dummy Speaker for debug or tests.
 #[derive(Debug, Default)]

--- a/arci/src/clients/dummy_trajectory_client.rs
+++ b/arci/src/clients/dummy_trajectory_client.rs
@@ -75,11 +75,13 @@ mod tests {
         assert_eq!(pos.len(), 2);
         assert_approx_eq!(pos[0], 0.0);
         assert_approx_eq!(pos[1], 0.0);
-        assert!(client
-            .send_joint_positions(vec![1.0, 2.0], std::time::Duration::from_secs(1))
-            .unwrap()
-            .await
-            .is_ok());
+        assert!(
+            client
+                .send_joint_positions(vec![1.0, 2.0], std::time::Duration::from_secs(1))
+                .unwrap()
+                .await
+                .is_ok()
+        );
         let pos2 = client.current_joint_positions().unwrap();
         assert_eq!(pos2.len(), 2);
         assert_approx_eq!(pos2[0], 1.0);

--- a/arci/src/clients/joint_position_difference_limiter.rs
+++ b/arci/src/clients/joint_position_difference_limiter.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::{error::Error, traits::JointTrajectoryClient, TrajectoryPoint, WaitFuture};
+use crate::{TrajectoryPoint, WaitFuture, error::Error, traits::JointTrajectoryClient};
 
 const ZERO_VELOCITY_THRESHOLD: f64 = 1.0e-6;
 
@@ -218,8 +218,8 @@ mod test {
     use assert_approx_eq::assert_approx_eq;
 
     use super::{
-        interpolate, interpolate_joint_trajectory, should_interpolate_joint_trajectory,
-        JointPositionDifferenceLimiter, JointTrajectoryClient, TrajectoryPoint,
+        JointPositionDifferenceLimiter, JointTrajectoryClient, TrajectoryPoint, interpolate,
+        interpolate_joint_trajectory, should_interpolate_joint_trajectory,
     };
     use crate::DummyJointTrajectoryClient;
 
@@ -234,14 +234,16 @@ mod test {
         );
         assert!(interpolated.is_ok());
         assert!(interpolated.unwrap().is_none());
-        assert!(interpolate(
-            vec![0.0, 1.0],
-            &[0.0, 0.0],
-            &[-1.0, 2.0],
-            &Duration::from_secs(0),
-            &Duration::from_secs(1),
-        )
-        .is_err());
+        assert!(
+            interpolate(
+                vec![0.0, 1.0],
+                &[0.0, 0.0],
+                &[-1.0, 2.0],
+                &Duration::from_secs(0),
+                &Duration::from_secs(1),
+            )
+            .is_err()
+        );
     }
     #[test]
     fn interpolate_interpolated() {
@@ -352,12 +354,14 @@ mod test {
             assert_eq!(c, w);
         }
         *wrapped_client.positions.lock().unwrap() = vec![0.0, 1.0];
-        assert!(tokio_test::block_on(
-            client
-                .send_joint_positions(vec![-1.0, 2.0], Duration::from_secs(1))
-                .unwrap()
-        )
-        .is_ok());
+        assert!(
+            tokio_test::block_on(
+                client
+                    .send_joint_positions(vec![-1.0, 2.0], Duration::from_secs(1))
+                    .unwrap()
+            )
+            .is_ok()
+        );
         assert!(wrapped_client.last_trajectory.lock().unwrap().is_empty());
         assert_eq!(
             wrapped_client.current_joint_positions().unwrap(),
@@ -385,12 +389,14 @@ mod test {
             assert_eq!(c, w);
         }
         *wrapped_client.positions.lock().unwrap() = vec![0.0, 1.0];
-        assert!(tokio_test::block_on(
-            client
-                .send_joint_positions(vec![-1.0, 2.0], Duration::from_secs(1))
-                .unwrap()
-        )
-        .is_ok());
+        assert!(
+            tokio_test::block_on(
+                client
+                    .send_joint_positions(vec![-1.0, 2.0], Duration::from_secs(1))
+                    .unwrap()
+            )
+            .is_ok()
+        );
         let actual_trajectory = wrapped_client.last_trajectory.lock().unwrap().clone();
         assert_eq!(actual_trajectory.len(), 2);
         assert_eq!(actual_trajectory[0].positions, vec![-0.5, 1.5]);

--- a/arci/src/clients/joint_position_limiter.rs
+++ b/arci/src/clients/joint_position_limiter.rs
@@ -1,6 +1,6 @@
 use std::{f64, ops::RangeInclusive};
 
-use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
+use schemars::{JsonSchema, r#gen::SchemaGenerator, schema::Schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tracing::{debug, warn};
 use urdf_rs::JointType;
@@ -247,7 +247,7 @@ impl JsonSchema for JointPositionLimit {
         "JointPositionLimit".into()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
         // As workaround for https://github.com/tamasfe/taplo/issues/57,
         // use struct with option value instead of enum.
         #[allow(dead_code)]
@@ -257,7 +257,7 @@ impl JsonSchema for JointPositionLimit {
             upper: Option<f64>,
         }
 
-        JointPositionLimitRepr::json_schema(gen)
+        JointPositionLimitRepr::json_schema(generator)
     }
 }
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, JsonSchema, Serialize, Deserialize)]

--- a/arci/src/clients/joint_velocity_limiter.rs
+++ b/arci/src/clients/joint_velocity_limiter.rs
@@ -169,12 +169,14 @@ mod tests {
             "b".to_owned(),
         ]));
         let limiter = JointVelocityLimiter::new(client.clone(), limits);
-        assert!(tokio_test::block_on(
-            limiter
-                .send_joint_positions(vec![1.0, 2.0], std::time::Duration::from_secs_f64(4.0))
-                .unwrap()
-        )
-        .is_ok());
+        assert!(
+            tokio_test::block_on(
+                limiter
+                    .send_joint_positions(vec![1.0, 2.0], std::time::Duration::from_secs_f64(4.0))
+                    .unwrap()
+            )
+            .is_ok()
+        );
         let joint_positions = limiter.current_joint_positions().unwrap();
         assert_eq!(joint_positions.len(), 2);
         assert_approx_eq!(joint_positions[0], 1.0);
@@ -214,23 +216,25 @@ mod tests {
             "b".to_owned(),
         ]));
         let limiter = JointVelocityLimiter::new(client.clone(), limits);
-        assert!(tokio_test::block_on(
-            limiter
-                .send_joint_trajectory(vec![
-                    TrajectoryPoint {
-                        positions: vec![1.0, 2.0],
-                        velocities: Some(vec![3.0, 4.0]),
-                        time_from_start: std::time::Duration::from_secs_f64(4.0)
-                    },
-                    TrajectoryPoint {
-                        positions: vec![3.0, 6.0],
-                        velocities: Some(vec![3.0, 4.0]),
-                        time_from_start: std::time::Duration::from_secs_f64(8.0)
-                    }
-                ])
-                .unwrap()
-        )
-        .is_ok());
+        assert!(
+            tokio_test::block_on(
+                limiter
+                    .send_joint_trajectory(vec![
+                        TrajectoryPoint {
+                            positions: vec![1.0, 2.0],
+                            velocities: Some(vec![3.0, 4.0]),
+                            time_from_start: std::time::Duration::from_secs_f64(4.0)
+                        },
+                        TrajectoryPoint {
+                            positions: vec![3.0, 6.0],
+                            velocities: Some(vec![3.0, 4.0]),
+                            time_from_start: std::time::Duration::from_secs_f64(8.0)
+                        }
+                    ])
+                    .unwrap()
+            )
+            .is_ok()
+        );
         let joint_positions = limiter.current_joint_positions().unwrap();
         assert_eq!(joint_positions.len(), 2);
         assert_approx_eq!(joint_positions[0], 3.0);

--- a/arci/src/traits/navigation.rs
+++ b/arci/src/traits/navigation.rs
@@ -1,6 +1,6 @@
 use auto_impl::auto_impl;
 
-use crate::{error::Error, Isometry2, WaitFuture};
+use crate::{Isometry2, WaitFuture, error::Error};
 
 #[auto_impl(Box, Arc)]
 pub trait Navigation: Send + Sync {

--- a/arci/src/traits/transform_resolver.rs
+++ b/arci/src/traits/transform_resolver.rs
@@ -1,6 +1,6 @@
 use auto_impl::auto_impl;
 
-use crate::{error::Error, Isometry3};
+use crate::{Isometry3, error::Error};
 
 #[auto_impl(Box, Arc)]
 pub trait TransformResolver: Send + Sync {

--- a/arci/tests/test_utils.rs
+++ b/arci/tests/test_utils.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use arci::{
-    utils::{get_joint_index, move_joint_until_stop},
     DummyJointTrajectoryClient, Error, JointTrajectoryClient, TrajectoryPoint, WaitFuture,
+    utils::{get_joint_index, move_joint_until_stop},
 };
 use assert_approx_eq::assert_approx_eq;
 

--- a/openrr-apps/src/bin/robot_command.rs
+++ b/openrr-apps/src/bin/robot_command.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use clap_complete::Shell;
 use openrr_apps::{
-    utils::{init_tracing, init_tracing_with_file_appender, LogConfig},
     Error, RobotConfig,
+    utils::{LogConfig, init_tracing, init_tracing_with_file_appender},
 };
 use openrr_client::BoxRobotClient;
 use openrr_command::{RobotCommand, RobotCommandExecutor};
@@ -120,13 +120,15 @@ mod tests {
         assert!(RobotCommandArgs::try_parse_from([bin]).is_ok());
         assert!(RobotCommandArgs::try_parse_from([bin, "--show-default-config"]).is_ok());
         assert!(RobotCommandArgs::try_parse_from([bin, "--config-path", "path", "list"]).is_ok());
-        assert!(RobotCommandArgs::try_parse_from([
-            bin,
-            "--show-default-config",
-            "--config-path",
-            "path"
-        ])
-        .is_ok());
+        assert!(
+            RobotCommandArgs::try_parse_from([
+                bin,
+                "--show-default-config",
+                "--config-path",
+                "path"
+            ])
+            .is_ok()
+        );
     }
 
     #[test]

--- a/openrr-apps/src/bin/robot_teleop.rs
+++ b/openrr-apps/src/bin/robot_teleop.rs
@@ -2,12 +2,12 @@
 use std::thread;
 use std::{fs, path::PathBuf, sync::Arc};
 
-use anyhow::{format_err, Result};
+use anyhow::{Result, format_err};
 use arci_gamepad_gilrs::GilGamepad;
 use clap::Parser;
 use openrr_apps::{
-    utils::{init_tracing, init_tracing_with_file_appender, LogConfig},
     BuiltinGamepad, Error, GamepadKind, RobotTeleopConfig,
+    utils::{LogConfig, init_tracing, init_tracing_with_file_appender},
 };
 use openrr_client::ArcRobotClient;
 use openrr_plugin::PluginProxy;
@@ -218,13 +218,15 @@ mod tests {
         assert!(RobotTeleopArgs::try_parse_from([bin]).is_ok());
         assert!(RobotTeleopArgs::try_parse_from([bin, "--show-default-config"]).is_ok());
         assert!(RobotTeleopArgs::try_parse_from([bin, "--config-path", "path"]).is_ok());
-        assert!(RobotTeleopArgs::try_parse_from([
-            bin,
-            "--show-default-config",
-            "--config-path",
-            "path"
-        ])
-        .is_ok());
+        assert!(
+            RobotTeleopArgs::try_parse_from([
+                bin,
+                "--show-default-config",
+                "--config-path",
+                "path"
+            ])
+            .is_ok()
+        );
     }
 
     #[test]

--- a/openrr-apps/src/robot_config.rs
+++ b/openrr-apps/src/robot_config.rs
@@ -836,10 +836,8 @@ impl RobotConfig {
         let use_urdf = !urdf_viz_clients_configs.is_empty()
             || !ros_clients_configs.is_empty()
             || !ros_action_clients_configs.is_empty();
-        if use_urdf {
-            if let Some(urdf_path) = self.openrr_clients_config.urdf_full_path() {
-                urdf_robot = Some(urdf_rs::utils::read_urdf_or_xacro(urdf_path)?);
-            }
+        if use_urdf && let Some(urdf_path) = self.openrr_clients_config.urdf_full_path() {
+            urdf_robot = Some(urdf_rs::utils::read_urdf_or_xacro(urdf_path)?);
         }
 
         let mut clients = arci_urdf_viz::create_joint_trajectory_clients_lazy(

--- a/openrr-apps/src/robot_config.rs
+++ b/openrr-apps/src/robot_config.rs
@@ -444,7 +444,9 @@ pub struct OpenrrTracingConfig {
 
 // Creates dummy schema for dummy fields.
 #[cfg(not(feature = "ros"))]
-fn unimplemented_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+fn unimplemented_schema(
+    _generator: &mut schemars::r#gen::SchemaGenerator,
+) -> schemars::schema::Schema {
     unimplemented!()
 }
 

--- a/openrr-apps/src/robot_teleop_config.rs
+++ b/openrr-apps/src/robot_teleop_config.rs
@@ -11,7 +11,7 @@ use openrr_teleop::ControlModesConfig;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{resolve_plugin_path, Error};
+use crate::{Error, resolve_plugin_path};
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename_all = "kebab-case")]

--- a/openrr-apps/src/utils.rs
+++ b/openrr-apps/src/utils.rs
@@ -7,19 +7,19 @@ use std::{
 use anyhow::Result;
 use rand::prelude::*;
 use serde::Deserialize;
-use tracing::{debug, warn, Event, Level, Subscriber};
+use tracing::{Event, Level, Subscriber, debug, warn};
 use tracing_appender::{
     non_blocking::WorkerGuard,
     rolling::{RollingFileAppender, Rotation},
 };
 use tracing_subscriber::{
+    EnvFilter,
     fmt::{
-        format::{Format, Writer},
         FmtContext, FormatEvent, FormatFields, Layer,
+        format::{Format, Writer},
     },
     layer::SubscriberExt,
     registry::LookupSpan,
-    EnvFilter,
 };
 
 use crate::{RobotConfig, RobotTeleopConfig};
@@ -145,20 +145,20 @@ mod test {
         assert!(path.is_some());
         assert_eq!(path.unwrap(), PathBuf::from("a.toml"));
         //
-        std::env::set_var(OPENRR_APPS_CONFIG_ENV_NAME, "b.yaml");
+        unsafe { std::env::set_var(OPENRR_APPS_CONFIG_ENV_NAME, "b.yaml") }
         let path = get_apps_robot_config(Some(PathBuf::from("a.toml")));
         assert!(path.is_some());
         assert_eq!(path.unwrap(), PathBuf::from("a.toml"));
-        std::env::remove_var(OPENRR_APPS_CONFIG_ENV_NAME);
+        unsafe { std::env::remove_var(OPENRR_APPS_CONFIG_ENV_NAME) }
 
         let path = get_apps_robot_config(None);
         assert!(path.is_none());
 
-        std::env::set_var(OPENRR_APPS_CONFIG_ENV_NAME, "b.yaml");
+        unsafe { std::env::set_var(OPENRR_APPS_CONFIG_ENV_NAME, "b.yaml") }
         let path = get_apps_robot_config(None);
         assert!(path.is_some());
         assert_eq!(path.unwrap(), PathBuf::from("b.yaml"));
-        std::env::remove_var(OPENRR_APPS_CONFIG_ENV_NAME);
+        unsafe { std::env::remove_var(OPENRR_APPS_CONFIG_ENV_NAME) }
     }
     #[test]
     fn test_log_config_default() {
@@ -196,7 +196,7 @@ pub fn init(name: &str, config: &RobotConfig) {
 
 /// Do something needed to start the program for multiple
 pub fn init_with_anonymize(name: &str, config: &RobotConfig) {
-    let suffix: u64 = rand::thread_rng().gen();
+    let suffix: u64 = rand::thread_rng().r#gen();
     let anon_name = format!("{name}_{suffix}");
     init(&anon_name, config);
 }

--- a/openrr-apps/src/utils.rs
+++ b/openrr-apps/src/utils.rs
@@ -42,14 +42,14 @@ pub fn get_apps_robot_config(config: Option<PathBuf>) -> Option<PathBuf> {
 }
 
 fn evaluate_overwrite_str(doc: &str, scripts: &str, path: Option<&Path>) -> Result<String> {
-    if path.and_then(Path::extension).and_then(OsStr::to_str) == Some("toml") {
-        if let Err(e) = toml::from_str::<toml::Value>(doc) {
-            warn!(
-                "config {} is not valid toml: {}",
-                path.unwrap().display(),
-                e
-            );
-        }
+    if path.and_then(Path::extension).and_then(OsStr::to_str) == Some("toml")
+        && let Err(e) = toml::from_str::<toml::Value>(doc)
+    {
+        warn!(
+            "config {} is not valid toml: {}",
+            path.unwrap().display(),
+            e
+        );
     }
     openrr_config::overwrite_str(
         &openrr_config::evaluate(doc, None)?,
@@ -58,14 +58,14 @@ fn evaluate_overwrite_str(doc: &str, scripts: &str, path: Option<&Path>) -> Resu
 }
 
 fn evaluate(doc: &str, path: Option<&Path>) -> Result<String> {
-    if path.and_then(Path::extension).and_then(OsStr::to_str) == Some("toml") {
-        if let Err(e) = toml::from_str::<toml::Value>(doc) {
-            warn!(
-                "config {} is not valid toml: {}",
-                path.unwrap().display(),
-                e
-            );
-        }
+    if path.and_then(Path::extension).and_then(OsStr::to_str) == Some("toml")
+        && let Err(e) = toml::from_str::<toml::Value>(doc)
+    {
+        warn!(
+            "config {} is not valid toml: {}",
+            path.unwrap().display(),
+            e
+        );
     }
     openrr_config::evaluate(doc, None)
 }

--- a/openrr-base/tests/test_differential_drive.rs
+++ b/openrr-base/tests/test_differential_drive.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use arci::{BaseVelocity, DummyMotorDriveVelocity, MotorDriveVelocity, MoveBase};
 use assert_approx_eq::assert_approx_eq;
-use openrr_base::{differential_drive::*, BaseAcceleration};
+use openrr_base::{BaseAcceleration, differential_drive::*};
 
 #[test]
 fn test_diff_drive() {

--- a/openrr-client/src/clients/collision_avoidance_client.rs
+++ b/openrr-client/src/clients/collision_avoidance_client.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use arci::{Error, JointTrajectoryClient, TrajectoryPoint, WaitFuture};
-use openrr_planner::{create_joint_path_planner, JointPathPlannerConfig};
+use openrr_planner::{JointPathPlannerConfig, create_joint_path_planner};
 
 // TODO: speed limit
 fn trajectory_from_positions(
@@ -152,15 +152,19 @@ mod tests {
         );
 
         // No collision case
-        assert!(collision_avoidance_client
-            .send_joint_positions(vec![0.0; 8], std::time::Duration::new(1, 0),)
-            .is_ok());
+        assert!(
+            collision_avoidance_client
+                .send_joint_positions(vec![0.0; 8], std::time::Duration::new(1, 0),)
+                .is_ok()
+        );
         // Collision occurs in the reference position
-        assert!(collision_avoidance_client
-            .send_joint_positions(
-                vec![1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-                std::time::Duration::new(1, 0),
-            )
-            .is_err());
+        assert!(
+            collision_avoidance_client
+                .send_joint_positions(
+                    vec![1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    std::time::Duration::new(1, 0),
+                )
+                .is_err()
+        );
     }
 }

--- a/openrr-client/src/clients/collision_check_client.rs
+++ b/openrr-client/src/clients/collision_check_client.rs
@@ -2,7 +2,7 @@ use std::{path::Path, sync::Arc};
 
 use arci::{Error, JointTrajectoryClient, TrajectoryPoint, WaitFuture};
 use openrr_planner::{
-    collision::create_self_collision_checker, SelfCollisionChecker, SelfCollisionCheckerConfig,
+    SelfCollisionChecker, SelfCollisionCheckerConfig, collision::create_self_collision_checker,
 };
 
 pub struct CollisionCheckClient<T>
@@ -118,15 +118,19 @@ mod tests {
             vec![0.0; 8]
         );
 
-        assert!(collision_check_client
-            .send_joint_positions(vec![0.0; 8], std::time::Duration::new(1, 0),)
-            .is_ok());
-        assert!(collision_check_client
-            .send_joint_positions(
-                vec![1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-                std::time::Duration::new(1, 0),
-            )
-            .is_err());
+        assert!(
+            collision_check_client
+                .send_joint_positions(vec![0.0; 8], std::time::Duration::new(1, 0),)
+                .is_ok()
+        );
+        assert!(
+            collision_check_client
+                .send_joint_positions(
+                    vec![1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    std::time::Duration::new(1, 0),
+                )
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -160,23 +164,31 @@ mod tests {
             vec![0.0; 2]
         );
 
-        assert!(collision_check_client
-            .send_joint_positions(vec![0.0; 2], std::time::Duration::new(1, 0),)
-            .is_ok());
-        assert!(collision_check_client
-            .send_joint_positions(vec![1.57, 0.0], std::time::Duration::new(1, 0),)
-            .is_err());
+        assert!(
+            collision_check_client
+                .send_joint_positions(vec![0.0; 2], std::time::Duration::new(1, 0),)
+                .is_ok()
+        );
+        assert!(
+            collision_check_client
+                .send_joint_positions(vec![1.57, 0.0], std::time::Duration::new(1, 0),)
+                .is_err()
+        );
 
         let point_ok = TrajectoryPoint::new([0.0; 2].to_vec(), std::time::Duration::new(1, 0));
         let trajectory_ok = vec![point_ok];
-        assert!(collision_check_client
-            .send_joint_trajectory(trajectory_ok)
-            .is_ok());
+        assert!(
+            collision_check_client
+                .send_joint_trajectory(trajectory_ok)
+                .is_ok()
+        );
 
         let point_err = TrajectoryPoint::new([1.57, 0.0].to_vec(), std::time::Duration::new(2, 0));
         let trajectory_err = vec![point_err];
-        assert!(collision_check_client
-            .send_joint_trajectory(trajectory_err)
-            .is_err());
+        assert!(
+            collision_check_client
+                .send_joint_trajectory(trajectory_err)
+                .is_err()
+        );
     }
 }

--- a/openrr-client/src/clients/ik_client.rs
+++ b/openrr-client/src/clients/ik_client.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use arci::{Error, JointTrajectoryClient, TrajectoryPoint, WaitFuture};
-use k::{nalgebra as na, Constraints, Isometry3};
-use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
+use k::{Constraints, Isometry3, nalgebra as na};
+use schemars::{JsonSchema, r#gen::SchemaGenerator, schema::Schema};
 use serde::{Deserialize, Serialize};
 
 pub fn isometry(x: f64, y: f64, z: f64, roll: f64, pitch: f64, yaw: f64) -> k::Isometry3<f64> {
@@ -346,7 +346,7 @@ fn default_num_max_try() -> usize {
     300
 }
 
-fn constraints_schema(gen: &mut SchemaGenerator) -> Schema {
+fn constraints_schema(generator: &mut SchemaGenerator) -> Schema {
     fn default_true() -> bool {
         true
     }
@@ -383,7 +383,7 @@ fn constraints_schema(gen: &mut SchemaGenerator) -> Schema {
         }
     }
 
-    ConstraintsSchema::json_schema(gen)
+    ConstraintsSchema::json_schema(generator)
 }
 
 pub fn create_ik_solver_with_chain(

--- a/openrr-client/src/robot_client.rs
+++ b/openrr-client/src/robot_client.rs
@@ -9,19 +9,19 @@ use arci::{
     BaseVelocity, Error as ArciError, JointTrajectoryClient, JointTrajectoryClientsContainer,
     Localization, MoveBase, Navigation, Speaker, WaitFuture,
 };
-use k::{nalgebra::Isometry2, Chain, Isometry3};
+use k::{Chain, Isometry3, nalgebra::Isometry2};
 use openrr_planner::{
-    collision::parse_colon_separated_pairs, JointPathPlannerConfig, SelfCollisionChecker,
-    SelfCollisionCheckerConfig,
+    JointPathPlannerConfig, SelfCollisionChecker, SelfCollisionCheckerConfig,
+    collision::parse_colon_separated_pairs,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::{
-    create_collision_avoidance_client, create_collision_check_client, create_ik_solver_with_chain,
     CollisionAvoidanceClient, CollisionCheckClient, Error, IkClient, IkSolverConfig,
-    IkSolverWithChain,
+    IkSolverWithChain, create_collision_avoidance_client, create_collision_check_client,
+    create_ik_solver_with_chain,
 };
 
 type ArcCollisionAvoidanceClient = Arc<CollisionAvoidanceClient<Arc<dyn JointTrajectoryClient>>>;

--- a/openrr-client/tests/test_robot_client.rs
+++ b/openrr-client/tests/test_robot_client.rs
@@ -258,9 +258,11 @@ async fn test_joint_positions() {
 
     // reference of the 4th joint (2.0) is larger than its upper limit (1.5)
     let invalid_positions = vec![0.1, -0.1, 1.0, 2.0, -1.0, 0.2];
-    assert!(client
-        .send_joint_positions("arm_collision_checked", &invalid_positions, 0.1)
-        .is_err());
+    assert!(
+        client
+            .send_joint_positions("arm_collision_checked", &invalid_positions, 0.1)
+            .is_err()
+    );
     let p2 = client.current_joint_positions("arm").unwrap();
     // positions are not changed with invalid commands
     for (l, r) in p2.iter().zip(valid_positions.iter()) {

--- a/openrr-command/src/robot_command.rs
+++ b/openrr-command/src/robot_command.rs
@@ -13,8 +13,8 @@ use async_recursion::async_recursion;
 use clap::Parser;
 use clap_complete::Shell;
 use k::nalgebra::{Isometry2, Vector2};
-use openrr_client::{isometry, RobotClient};
-use rustyline::{error::ReadlineError, DefaultEditor};
+use openrr_client::{RobotClient, isometry};
+use rustyline::{DefaultEditor, error::ReadlineError};
 use tracing::{error, info};
 
 use crate::Error as OpenrrCommandError;

--- a/openrr-config/src/evaluate.rs
+++ b/openrr-config/src/evaluate.rs
@@ -1,6 +1,6 @@
 use std::{env, path::Path, process::Command};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 /// Evaluates the given string and returns a concatenated string of the results.
 ///
@@ -111,7 +111,7 @@ mod tests {
         );
         evaluate("$(echo a", None).unwrap_err();
         evaluate("${OPENRR_CONFIG_TEST_ENV}", None).unwrap_err();
-        env::set_var("OPENRR_CONFIG_TEST_ENV", "a");
+        unsafe { env::set_var("OPENRR_CONFIG_TEST_ENV", "a") }
         assert_eq!(evaluate("${OPENRR_CONFIG_TEST_ENV}", None).unwrap(), "a");
         assert_eq!(evaluate("${OPENRR_CONFIG_TEST_ENV}b", None).unwrap(), "ab");
         assert_eq!(evaluate("${OPENRR_CONFIG_TEST_ENV}}", None).unwrap(), "a}");

--- a/openrr-config/src/overwrite.rs
+++ b/openrr-config/src/overwrite.rs
@@ -1,7 +1,7 @@
 use std::{iter, mem};
 
-use anyhow::{bail, Context, Result};
-use toml::{value, Value};
+use anyhow::{Context, Result, bail};
+use toml::{Value, value};
 use toml_query::{delete::TomlValueDeleteExt, insert::TomlValueInsertExt, read::TomlValueReadExt};
 use tracing::debug;
 
@@ -545,22 +545,25 @@ mod tests {
                 "urdf_viz_clients_configs[0].wrap_with_joint_position_limiter =",
             )
             .unwrap();
-            assert!(v
-                .read("urdf_viz_clients_configs[0].wrap_with_joint_position_limiter")
-                .unwrap()
-                .is_none());
+            assert!(
+                v.read("urdf_viz_clients_configs[0].wrap_with_joint_position_limiter")
+                    .unwrap()
+                    .is_none()
+            );
             overwrite(
                 v,
                 "urdf_viz_clients_configs[0].wrap_with_joint_position_limiter = false",
             )
             .unwrap();
-            assert!(!read(
-                v,
-                "urdf_viz_clients_configs[0].wrap_with_joint_position_limiter"
-            )
-            .unwrap()
-            .as_bool()
-            .unwrap());
+            assert!(
+                !read(
+                    v,
+                    "urdf_viz_clients_configs[0].wrap_with_joint_position_limiter"
+                )
+                .unwrap()
+                .as_bool()
+                .unwrap()
+            );
         }
 
         let s = r#"
@@ -607,12 +610,14 @@ axis_map = [
                     .unwrap(),
                 "DPadN"
             );
-            assert!(read(v, "gil_gamepad_config.map.axis_map[0]")
-                .unwrap()
-                .as_array()
-                .unwrap()
-                .get(1)
-                .is_none());
+            assert!(
+                read(v, "gil_gamepad_config.map.axis_map[0]")
+                    .unwrap()
+                    .as_array()
+                    .unwrap()
+                    .get(1)
+                    .is_none()
+            );
         }
     }
 }

--- a/openrr-planner/benches/collision_detection.rs
+++ b/openrr-planner/benches/collision_detection.rs
@@ -1,11 +1,11 @@
 use std::{f64::consts::PI, path::Path};
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use k::joint::Range;
 use na::RealField;
 use nalgebra as na;
 use openrr_planner::collision::{
-    create_all_collision_pairs, create_robot_collision_detector, RobotCollisionDetectorConfig,
+    RobotCollisionDetectorConfig, create_all_collision_pairs, create_robot_collision_detector,
 };
 
 fn generate_random_joint_angles_from_limits<T>(limits: &[Option<k::joint::Range<T>>]) -> Vec<T>

--- a/openrr-planner/examples/reach.rs
+++ b/openrr-planner/examples/reach.rs
@@ -23,7 +23,7 @@ use k::nalgebra as na;
 use ncollide3d::shape::Compound;
 use openrr_planner::FromUrdf;
 use urdf_rs::Robot;
-use urdf_viz::{kiss3d::window::Window, Action, Key, Modifiers, WindowEvent};
+use urdf_viz::{Action, Key, Modifiers, WindowEvent, kiss3d::window::Window};
 
 struct CollisionAvoidApp {
     planner: openrr_planner::JointPathPlannerWithIk<

--- a/openrr-planner/src/collision/collision_detector.rs
+++ b/openrr-planner/src/collision/collision_detector.rs
@@ -392,10 +392,12 @@ mod tests {
         let target = Cuboid::new(Vector3::new(0.2, 0.3, 0.1));
         let target_pose = Isometry3::new(Vector3::new(0.7, 0.0, 0.6), na::zero());
 
-        assert!(detector
-            .detect_env(&robot, &target, &target_pose)
-            .next()
-            .is_none());
+        assert!(
+            detector
+                .detect_env(&robot, &target, &target_pose)
+                .next()
+                .is_none()
+        );
 
         let angles = [
             -0.7, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -434,10 +436,12 @@ mod tests {
 
         let angles = [0.0; 16];
         robot.set_joint_positions(&angles).unwrap();
-        assert!(detector
-            .detect_self(&robot, &collision_check_pairs)
-            .next()
-            .is_none());
+        assert!(
+            detector
+                .detect_self(&robot, &collision_check_pairs)
+                .next()
+                .is_none()
+        );
 
         let angles = [
             -1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,

--- a/openrr-planner/src/collision/collision_detector.rs
+++ b/openrr-planner/src/collision/collision_detector.rs
@@ -305,10 +305,10 @@ where
                 })
                 .collect::<Vec<_>>();
             debug!("name={}, ln={}", l.name, col_pose_vec.len());
-            if !col_pose_vec.is_empty() {
-                if let Some(joint_name) = link_joint_map.get(&l.name) {
-                    name_collision_model_map.insert(joint_name.to_owned(), col_pose_vec);
-                }
+            if !col_pose_vec.is_empty()
+                && let Some(joint_name) = link_joint_map.get(&l.name)
+            {
+                name_collision_model_map.insert(joint_name.to_owned(), col_pose_vec);
             }
         }
         CollisionDetector {

--- a/openrr-planner/src/collision/mesh.rs
+++ b/openrr-planner/src/collision/mesh.rs
@@ -1,6 +1,6 @@
 use std::{io, path::Path};
 
-use k::{nalgebra as na, RealField};
+use k::{RealField, nalgebra as na};
 use ncollide3d::shape::TriMesh;
 
 use crate::errors::*;

--- a/openrr-planner/src/collision/self_collision_checker.rs
+++ b/openrr-planner/src/collision/self_collision_checker.rs
@@ -7,10 +7,11 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::{
-    collision::{parse_colon_separated_pairs, RobotCollisionDetector},
+    CollisionDetector, TrajectoryPoint,
+    collision::{RobotCollisionDetector, parse_colon_separated_pairs},
     errors::*,
     funcs::create_chain_from_joint_names,
-    interpolate, CollisionDetector, TrajectoryPoint,
+    interpolate,
 };
 
 pub struct SelfCollisionChecker<N>
@@ -224,16 +225,22 @@ fn test_create_self_collision_checker() {
         robot,
     );
 
-    assert!(self_collision_checker
-        .check_joint_positions(&[0.0; 16], &[0.0; 16], std::time::Duration::new(1, 0),)
-        .is_ok());
-    assert!(self_collision_checker
-        .check_joint_positions(
-            &[0.0; 16],
-            &[1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-            std::time::Duration::new(1, 0),
-        )
-        .is_err());
+    assert!(
+        self_collision_checker
+            .check_joint_positions(&[0.0; 16], &[0.0; 16], std::time::Duration::new(1, 0),)
+            .is_ok()
+    );
+    assert!(
+        self_collision_checker
+            .check_joint_positions(
+                &[0.0; 16],
+                &[
+                    1.57, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+                ],
+                std::time::Duration::new(1, 0),
+            )
+            .is_err()
+    );
 
     let l_shoulder_yaw_node = self_collision_checker
         .collision_check_robot()
@@ -245,20 +252,24 @@ fn test_create_self_collision_checker() {
         .map(|j| j.name.to_owned())
         .collect::<Vec<String>>();
 
-    assert!(self_collision_checker
-        .check_partial_joint_positions(
-            using_joint_names.as_slice(),
-            &[0.0],
-            &[0.0],
-            std::time::Duration::new(1, 0),
-        )
-        .is_ok());
-    assert!(self_collision_checker
-        .check_partial_joint_positions(
-            using_joint_names.as_slice(),
-            &[0.0],
-            &[1.57],
-            std::time::Duration::new(1, 0),
-        )
-        .is_err());
+    assert!(
+        self_collision_checker
+            .check_partial_joint_positions(
+                using_joint_names.as_slice(),
+                &[0.0],
+                &[0.0],
+                std::time::Duration::new(1, 0),
+            )
+            .is_ok()
+    );
+    assert!(
+        self_collision_checker
+            .check_partial_joint_positions(
+                using_joint_names.as_slice(),
+                &[0.0],
+                &[1.57],
+                std::time::Duration::new(1, 0),
+            )
+            .is_err()
+    );
 }

--- a/openrr-planner/src/collision/urdf.rs
+++ b/openrr-planner/src/collision/urdf.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use k::{nalgebra as na, RealField, Vector3};
+use k::{RealField, Vector3, nalgebra as na};
 use ncollide3d::{
     procedural::IndexBuffer::{Split, Unified},
     shape::{Ball, Cuboid, Cylinder, ShapeHandle, TriMesh},

--- a/openrr-planner/src/ik.rs
+++ b/openrr-planner/src/ik.rs
@@ -17,7 +17,7 @@ limitations under the License.
 
 use std::sync::Mutex;
 
-use k::{nalgebra as na, InverseKinematicsSolver, SubsetOf};
+use k::{InverseKinematicsSolver, SubsetOf, nalgebra as na};
 use na::RealField;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 

--- a/openrr-planner/src/planner/joint_path_planner.rs
+++ b/openrr-planner/src/planner/joint_path_planner.rs
@@ -469,17 +469,23 @@ mod tests {
             .map(|j| j.name.to_owned())
             .collect::<Vec<String>>();
 
-        assert!(planner
-            .plan_avoid_self_collision(using_joint_names.as_slice(), &[0.0], &[0.0],)
-            .is_ok());
+        assert!(
+            planner
+                .plan_avoid_self_collision(using_joint_names.as_slice(), &[0.0], &[0.0],)
+                .is_ok()
+        );
         // an error occurs in the start
-        assert!(planner
-            .plan_avoid_self_collision(using_joint_names.as_slice(), &[1.57], &[0.0],)
-            .is_err());
+        assert!(
+            planner
+                .plan_avoid_self_collision(using_joint_names.as_slice(), &[1.57], &[0.0],)
+                .is_err()
+        );
         // an error occurs in the goal
-        assert!(planner
-            .plan_avoid_self_collision(using_joint_names.as_slice(), &[0.0], &[1.57],)
-            .is_err());
+        assert!(
+            planner
+                .plan_avoid_self_collision(using_joint_names.as_slice(), &[0.0], &[1.57],)
+                .is_err()
+        );
     }
 
     // This test potentially fails because of RRT-based planning,
@@ -512,16 +518,20 @@ mod tests {
             .collect::<Vec<String>>();
 
         // an error occurs since the arms collide
-        assert!(planner
-            .plan_avoid_self_collision(using_joint_names.as_slice(), &[0.0; 6], &[0.0; 6],)
-            .is_err());
+        assert!(
+            planner
+                .plan_avoid_self_collision(using_joint_names.as_slice(), &[0.0; 6], &[0.0; 6],)
+                .is_err()
+        );
         // the planner PROBABLY generates a trajectory avoiding self-collisions
-        assert!(planner
-            .plan_avoid_self_collision(
-                using_joint_names.as_slice(),
-                &[0.0, -0.3, 0.0, 0.0, 0.0, 0.0],
-                &[0.0, 0.3, 0.0, 0.0, 0.0, 0.0],
-            )
-            .is_ok());
+        assert!(
+            planner
+                .plan_avoid_self_collision(
+                    using_joint_names.as_slice(),
+                    &[0.0, -0.3, 0.0, 0.0, 0.0, 0.0],
+                    &[0.0, 0.3, 0.0, 0.0, 0.0, 0.0],
+                )
+                .is_ok()
+        );
     }
 }

--- a/openrr-plugin/benches/proxy.rs
+++ b/openrr-plugin/benches/proxy.rs
@@ -106,7 +106,7 @@ use std::{env, path::PathBuf, process::Command, time::Duration};
 
 use anyhow::Result;
 use arci::{DummyJointTrajectoryClient, JointTrajectoryClient};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use fs_err as fs;
 use openrr_plugin::{JointTrajectoryClientProxy, PluginProxy};
 
@@ -231,7 +231,7 @@ fn test_plugin() -> Result<PathBuf> {
         r#"
 [package]
 name = "test_plugin"
-edition = "2021"
+edition = "2024"
 
 [workspace]
 

--- a/openrr-plugin/src/proxy.rs
+++ b/openrr-plugin/src/proxy.rs
@@ -12,14 +12,13 @@ mod impls;
 use std::{sync::Arc, time::SystemTime};
 
 use abi_stable::{
-    declare_root_module_statics,
+    StableAbi, declare_root_module_statics,
     library::RootModule,
     package_version_strings,
     prefix_type::PrefixTypeTrait,
     rtry, sabi_trait,
     sabi_types::VersionStrings,
     std_types::{RBoxError, RDuration, ROk, ROption, RString, RVec},
-    StableAbi,
 };
 use anyhow::format_err;
 use arci::nalgebra;

--- a/openrr-plugin/tests/test.rs
+++ b/openrr-plugin/tests/test.rs
@@ -4,10 +4,10 @@ use std::{
 };
 
 use arci::{
-    gamepad::GamepadEvent, BaseVelocity, DummyGamepad, DummyJointTrajectoryClient,
-    DummyLocalization, DummyMoveBase, DummyNavigation, DummySpeaker, DummyTransformResolver,
-    Gamepad, Isometry2, JointTrajectoryClient, Localization, MoveBase, Navigation, Speaker,
-    TrajectoryPoint, TransformResolver, Vector2,
+    BaseVelocity, DummyGamepad, DummyJointTrajectoryClient, DummyLocalization, DummyMoveBase,
+    DummyNavigation, DummySpeaker, DummyTransformResolver, Gamepad, Isometry2,
+    JointTrajectoryClient, Localization, MoveBase, Navigation, Speaker, TrajectoryPoint,
+    TransformResolver, Vector2, gamepad::GamepadEvent,
 };
 use assert_approx_eq::assert_approx_eq;
 use openrr_plugin::{

--- a/openrr-remote/tests/test.rs
+++ b/openrr-remote/tests/test.rs
@@ -1,18 +1,18 @@
 use std::{
     net::SocketAddr,
     sync::{
-        atomic::{AtomicU16, Ordering},
         Arc,
+        atomic::{AtomicU16, Ordering},
     },
     time::{Duration, SystemTime},
 };
 
 use anyhow::Result;
 use arci::{
-    gamepad::GamepadEvent, BaseVelocity, DummyGamepad, DummyJointTrajectoryClient,
-    DummyLaserScan2D, DummyLocalization, DummyMoveBase, DummyNavigation, DummySpeaker,
-    DummyTransformResolver, Gamepad, Isometry2, JointTrajectoryClient, LaserScan2D, Localization,
-    MoveBase, Navigation, Scan2D, Speaker, TrajectoryPoint, TransformResolver, Vector2,
+    BaseVelocity, DummyGamepad, DummyJointTrajectoryClient, DummyLaserScan2D, DummyLocalization,
+    DummyMoveBase, DummyNavigation, DummySpeaker, DummyTransformResolver, Gamepad, Isometry2,
+    JointTrajectoryClient, LaserScan2D, Localization, MoveBase, Navigation, Scan2D, Speaker,
+    TrajectoryPoint, TransformResolver, Vector2, gamepad::GamepadEvent,
 };
 use assert_approx_eq::assert_approx_eq;
 use openrr_remote::{
@@ -37,7 +37,7 @@ async fn joint_trajectory_client() -> Result<()> {
     {
         let client =
             RemoteJointTrajectoryClientReceiver::new(DummyJointTrajectoryClient::new(vec![
-                "a".to_owned()
+                "a".to_owned(),
             ]));
         tokio::spawn(client.serve(addr));
         tokio::time::sleep(Duration::from_secs(1)).await;
@@ -266,7 +266,7 @@ async fn multiple() -> Result<()> {
     {
         let client =
             RemoteJointTrajectoryClientReceiver::new(DummyJointTrajectoryClient::new(vec![
-                "a".to_owned()
+                "a".to_owned(),
             ]));
         let speaker = RemoteSpeakerReceiver::new(recv_speaker.clone());
         let base = RemoteMoveBaseReceiver::new(DummyMoveBase::new());

--- a/openrr-teleop/src/control_modes_config.rs
+++ b/openrr-teleop/src/control_modes_config.rs
@@ -75,10 +75,10 @@ impl ControlModesConfig {
             )));
         }
 
-        if let Some(mode) = &self.move_base_mode {
-            if let Some(m) = move_base {
-                modes.push(Arc::new(MoveBaseMode::new(mode.clone(), m.clone())));
-            }
+        if let Some(mode) = &self.move_base_mode
+            && let Some(m) = move_base
+        {
+            modes.push(Arc::new(MoveBaseMode::new(mode.clone(), m.clone())));
         }
 
         for ik_mode_teleop_config in &self.ik_mode_teleop_configs {
@@ -117,11 +117,12 @@ impl ControlModesConfig {
             modes.push(Arc::new(ik_mode));
         }
 
-        if !joints_poses.is_empty() {
-            if let Some(sender_config) = &self.joints_pose_sender_config {
-                let mut joint_trajectory_clients = HashMap::new();
-                for joints_pose in &joints_poses {
-                    joint_trajectory_clients.insert(
+        if !joints_poses.is_empty()
+            && let Some(sender_config) = &self.joints_pose_sender_config
+        {
+            let mut joint_trajectory_clients = HashMap::new();
+            for joints_pose in &joints_poses {
+                joint_trajectory_clients.insert(
                         joints_pose.client_name.to_owned(),
                         joint_trajectory_client_map
                             .get(&joints_pose.client_name)
@@ -137,27 +138,25 @@ impl ControlModesConfig {
                             })?
                             .clone(),
                     );
-                }
-                modes.push(Arc::new(JointsPoseSender::new_from_config(
-                    sender_config.clone(),
-                    joints_poses,
-                    joint_trajectory_clients,
-                    speaker.clone(),
-                )));
             }
+            modes.push(Arc::new(JointsPoseSender::new_from_config(
+                sender_config.clone(),
+                joints_poses,
+                joint_trajectory_clients,
+                speaker.clone(),
+            )));
         }
 
-        if !self.command_configs.is_empty() {
-            if let Some(base_path) = base_path {
-                if let Some(e) = RobotCommandExecutor::new(
-                    base_path,
-                    self.command_configs.clone(),
-                    robot_client,
-                    speaker.clone(),
-                ) {
-                    modes.push(Arc::new(e));
-                }
-            }
+        if !self.command_configs.is_empty()
+            && let Some(base_path) = base_path
+            && let Some(e) = RobotCommandExecutor::new(
+                base_path,
+                self.command_configs.clone(),
+                robot_client,
+                speaker.clone(),
+            )
+        {
+            modes.push(Arc::new(e));
         }
 
         Ok(modes)

--- a/openrr-teleop/src/control_modes_config.rs
+++ b/openrr-teleop/src/control_modes_config.rs
@@ -172,8 +172,8 @@ mod tests {
         DummyJointTrajectoryClient, DummyLocalization, DummyMoveBase, DummyNavigation, DummySpeaker,
     };
     use openrr_client::{
-        create_random_jacobian_ik_solver, IkSolverParameters, IkSolverWithChain,
-        OpenrrClientsConfig,
+        IkSolverParameters, IkSolverWithChain, OpenrrClientsConfig,
+        create_random_jacobian_ik_solver,
     };
 
     use super::*;

--- a/openrr-teleop/src/ik.rs
+++ b/openrr-teleop/src/ik.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use arci::{
-    gamepad::{Axis, Button, GamepadEvent},
     JointTrajectoryClient, Speaker,
+    gamepad::{Axis, Button, GamepadEvent},
 };
 use async_trait::async_trait;
 use k::{Translation3, Vector3};

--- a/openrr-teleop/src/joints.rs
+++ b/openrr-teleop/src/joints.rs
@@ -1,8 +1,8 @@
 use std::{sync::Mutex, time::Duration};
 
 use arci::{
-    gamepad::{Axis, Button, GamepadEvent},
     JointTrajectoryClient, Speaker,
+    gamepad::{Axis, Button, GamepadEvent},
 };
 use async_trait::async_trait;
 use schemars::JsonSchema;

--- a/openrr-teleop/src/joints_pose_sender.rs
+++ b/openrr-teleop/src/joints_pose_sender.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, sync::Mutex, time::Duration};
 
 use arci::{
-    gamepad::{Button, GamepadEvent},
     JointTrajectoryClient, Speaker,
+    gamepad::{Button, GamepadEvent},
 };
 use async_trait::async_trait;
 use openrr_client::JointsPose;

--- a/openrr-teleop/src/move_base.rs
+++ b/openrr-teleop/src/move_base.rs
@@ -1,8 +1,8 @@
 use std::sync::Mutex;
 
 use arci::{
-    gamepad::{Axis, Button, GamepadEvent},
     BaseVelocity, MoveBase,
+    gamepad::{Axis, Button, GamepadEvent},
 };
 use async_trait::async_trait;
 

--- a/openrr-teleop/src/robot_command_executor.rs
+++ b/openrr-teleop/src/robot_command_executor.rs
@@ -4,13 +4,13 @@ use std::{
 };
 
 use arci::{
-    gamepad::{Button, GamepadEvent},
     Speaker,
+    gamepad::{Button, GamepadEvent},
 };
 use async_trait::async_trait;
 use clap::Parser;
-use openrr_client::{resolve_relative_path, ArcRobotClient};
-use openrr_command::{load_command_file_and_filter, RobotCommand};
+use openrr_client::{ArcRobotClient, resolve_relative_path};
+use openrr_command::{RobotCommand, load_command_file_and_filter};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
@@ -288,12 +288,14 @@ mod test {
             String::from("file_path")
         );
 
-        assert!(RobotCommandExecutor::new(
-            PathBuf::from("path"),
-            vec![],
-            robot_client,
-            DummySpeaker::new()
-        )
-        .is_none());
+        assert!(
+            RobotCommandExecutor::new(
+                PathBuf::from("path"),
+                vec![],
+                robot_client,
+                DummySpeaker::new()
+            )
+            .is_none()
+        );
     }
 }

--- a/openrr-teleop/src/switcher.rs
+++ b/openrr-teleop/src/switcher.rs
@@ -1,14 +1,14 @@
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
 
 use arci::{
-    gamepad::{Button, Gamepad, GamepadEvent},
     Speaker,
+    gamepad::{Button, Gamepad, GamepadEvent},
 };
 use tokio::sync::Mutex as TokioMutex;
 use tracing::{debug, warn};

--- a/openrr-tracing/src/de.rs
+++ b/openrr-tracing/src/de.rs
@@ -2,7 +2,7 @@
 
 use std::time::{Duration, SystemTime};
 
-use arci::{nalgebra, BaseVelocity};
+use arci::{BaseVelocity, nalgebra};
 use serde::Deserialize;
 
 pub type Timestamp = chrono::DateTime<chrono::Utc>;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,4 +2,4 @@ unstable_features = true
 imports_granularity = "Crate"
 reorder_impl_items = true
 group_imports = "StdExternalCrate"
-edition = "2021"
+edition = "2024"

--- a/tools/codegen/src/main.rs
+++ b/tools/codegen/src/main.rs
@@ -59,12 +59,11 @@ fn arci_types(
 }
 
 fn is_str(ty: &syn::Type) -> bool {
-    if let syn::Type::Reference(ty) = ty {
-        if let Some(path) = get_ty_path(&ty.elem) {
-            if path.is_ident("str") {
-                return true;
-            }
-        }
+    if let syn::Type::Reference(ty) = ty
+        && let Some(path) = get_ty_path(&ty.elem)
+        && path.is_ident("str")
+    {
+        return true;
     }
     false
 }
@@ -78,62 +77,62 @@ fn get_ty_path(ty: &syn::Type) -> Option<&syn::Path> {
 
 fn is_option(ty: &syn::Type) -> Option<&syn::Type> {
     let path = get_ty_path(ty)?;
-    if path.segments.len() == 1 && path.segments[0].ident == "Option" {
-        if let syn::PathArguments::AngleBracketed(args) = &path.segments.last().unwrap().arguments {
-            if let syn::GenericArgument::Type(ty) = &args.args[0] {
-                return Some(ty);
-            }
-        }
+    if path.segments.len() == 1
+        && path.segments[0].ident == "Option"
+        && let syn::PathArguments::AngleBracketed(args) = &path.segments.last().unwrap().arguments
+        && let syn::GenericArgument::Type(ty) = &args.args[0]
+    {
+        return Some(ty);
     }
     None
 }
 
 fn is_result(ty: &syn::Type) -> Option<&syn::Type> {
     let path = get_ty_path(ty)?;
-    if path.segments.len() == 1 && path.segments[0].ident == "Result" {
-        if let syn::PathArguments::AngleBracketed(args) = &path.segments.last().unwrap().arguments {
-            if let syn::GenericArgument::Type(ty) = &args.args[0] {
-                return Some(ty);
-            }
-        }
+    if path.segments.len() == 1
+        && path.segments[0].ident == "Result"
+        && let syn::PathArguments::AngleBracketed(args) = &path.segments.last().unwrap().arguments
+        && let syn::GenericArgument::Type(ty) = &args.args[0]
+    {
+        return Some(ty);
     }
     None
 }
 
 fn is_vec(ty: &syn::Type) -> Option<&syn::Type> {
     let path = get_ty_path(ty)?;
-    if path.segments.len() == 1 && path.segments[0].ident == "Vec" {
-        if let syn::PathArguments::AngleBracketed(args) = &path.segments.last().unwrap().arguments {
-            if let syn::GenericArgument::Type(ty) = &args.args[0] {
-                return Some(ty);
-            }
-        }
+    if path.segments.len() == 1
+        && path.segments[0].ident == "Vec"
+        && let syn::PathArguments::AngleBracketed(args) = &path.segments.last().unwrap().arguments
+        && let syn::GenericArgument::Type(ty) = &args.args[0]
+    {
+        return Some(ty);
     }
     None
 }
 
 pub(crate) fn is_primitive(ty: &syn::Type) -> bool {
-    if let Some(path) = get_ty_path(ty) {
-        if let Some(ident) = path.get_ident() {
-            return matches!(
-                ident.to_string().as_str(),
-                "isize"
-                    | "i8"
-                    | "i16"
-                    | "i32"
-                    | "i64"
-                    | "i128"
-                    | "usize"
-                    | "u8"
-                    | "u16"
-                    | "u32"
-                    | "u64"
-                    | "u128"
-                    | "f32"
-                    | "f64"
-                    | "bool"
-            );
-        }
+    if let Some(path) = get_ty_path(ty)
+        && let Some(ident) = path.get_ident()
+    {
+        return matches!(
+            ident.to_string().as_str(),
+            "isize"
+                | "i8"
+                | "i16"
+                | "i32"
+                | "i64"
+                | "i128"
+                | "usize"
+                | "u8"
+                | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "f32"
+                | "f64"
+                | "bool"
+        );
     }
     false
 }

--- a/tools/codegen/src/main.rs
+++ b/tools/codegen/src/main.rs
@@ -3,14 +3,14 @@ mod rpc;
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{format_err, Result};
+use anyhow::{Result, format_err};
 use fs_err as fs;
 use proc_macro2::TokenStream;
 
 fn main() -> Result<()> {
     let workspace_root = workspace_root();
-    plugin::gen(&workspace_root)?;
-    rpc::gen(&workspace_root)?;
+    plugin::r#gen(&workspace_root)?;
+    rpc::r#gen(&workspace_root)?;
     Ok(())
 }
 

--- a/tools/codegen/src/plugin.rs
+++ b/tools/codegen/src/plugin.rs
@@ -8,14 +8,13 @@ use heck::ToSnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    parse_quote,
+    Ident, parse_quote,
     visit_mut::{self, VisitMut},
-    Ident,
 };
 
 use super::*;
 
-pub(crate) fn gen(workspace_root: &Path) -> Result<()> {
+pub(crate) fn r#gen(workspace_root: &Path) -> Result<()> {
     const FULLY_IGNORE: &[&str] = &["SetCompleteCondition"];
     const IGNORE: &[&str] = &["SetCompleteCondition"];
     const USE_TRY_INTO: &[&str] = &["SystemTime"];

--- a/tools/codegen/src/rpc.rs
+++ b/tools/codegen/src/rpc.rs
@@ -230,12 +230,11 @@ fn gen_server_impl(trait_name: &Ident, item: &ItemTrait, pb_traits: &[ItemTrait]
                     syn::FnArg::Typed(arg) => {
                         let pat = &arg.pat;
                         let mut into = quote! { .into() };
-                        if let Some(path) = get_ty_path(&arg.ty) {
-                            if USE_TRY_INTO
+                        if let Some(path) = get_ty_path(&arg.ty)
+                            && USE_TRY_INTO
                                 .contains(&&*path.segments.last().unwrap().ident.to_string())
-                            {
-                                into = quote! { .try_into().unwrap() }
-                            }
+                        {
+                            into = quote! { .try_into().unwrap() }
                         }
                         Some(match arg_len {
                             0 => unreachable!(),
@@ -265,10 +264,10 @@ fn gen_server_impl(trait_name: &Ident, item: &ItemTrait, pb_traits: &[ItemTrait]
                 .items
                 .iter()
                 .find_map(|m| {
-                    if let syn::TraitItem::Fn(m) = m {
-                        if m.sig.ident == *name {
-                            return Some(m.clone());
-                        }
+                    if let syn::TraitItem::Fn(m) = m
+                        && m.sig.ident == *name
+                    {
+                        return Some(m.clone());
                     }
                     None
                 })

--- a/tools/codegen/src/rpc.rs
+++ b/tools/codegen/src/rpc.rs
@@ -8,13 +8,13 @@ use heck::ToSnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    visit_mut::{self, VisitMut},
     Ident, ItemTrait,
+    visit_mut::{self, VisitMut},
 };
 
 use super::*;
 
-pub(crate) fn gen(workspace_root: &Path) -> Result<()> {
+pub(crate) fn r#gen(workspace_root: &Path) -> Result<()> {
     const FULLY_IGNORE: &[&str] = &["SetCompleteCondition"];
     const IGNORE: &[&str] = &["JointTrajectoryClient", "SetCompleteCondition", "Gamepad"];
 


### PR DESCRIPTION
This fixes clippy warning added in Rust 1.89. 

This also migrates all crates to Rust 2024, because the best way to address the above warning required the latest edition. Rust 2024 changes affected here are:
- rustfmt changes
- Environment variable modification functions are now unsafe
- "gen" is now keyword