### PR TITLE
Use #[non_exhaustive] on more types

### DIFF
--- a/arci/src/traits/gamepad.rs
+++ b/arci/src/traits/gamepad.rs
@@ -4,6 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
 pub enum Button {
     South,
     East,
@@ -26,6 +27,7 @@ pub enum Button {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
+#[non_exhaustive]
 pub enum Axis {
     LeftStickX,
     LeftStickY,
@@ -39,6 +41,7 @@ pub enum Axis {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum GamepadEvent {
     ButtonPressed(Button),
     ButtonReleased(Button),

--- a/openrr-apps/src/bin/robot_teleop.rs
+++ b/openrr-apps/src/bin/robot_teleop.rs
@@ -201,6 +201,7 @@ async fn main() -> Result<()> {
                 }
             }
         }
+        _ => unreachable!(),
     }
 
     Ok(())

--- a/openrr-apps/src/robot_config.rs
+++ b/openrr-apps/src/robot_config.rs
@@ -28,6 +28,7 @@ use crate::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum BuiltinClient {
     /// [ROS1](https://ros.org)
     Ros,
@@ -37,6 +38,7 @@ pub enum BuiltinClient {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ClientKind {
     // Use builtin client, ros or urdf-viz.
     Builtin(BuiltinClient),

--- a/openrr-apps/src/robot_teleop_config.rs
+++ b/openrr-apps/src/robot_teleop_config.rs
@@ -15,6 +15,7 @@ use crate::{Error, resolve_plugin_path};
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
 pub enum BuiltinGamepad {
     Gilrs,
     Keyboard,
@@ -23,6 +24,7 @@ pub enum BuiltinGamepad {
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum GamepadKind {
     Builtin(BuiltinGamepad),
     Plugin(String),

--- a/openrr-command/src/robot_command.rs
+++ b/openrr-command/src/robot_command.rs
@@ -34,6 +34,7 @@ where
 
 #[derive(Parser, Debug)]
 #[clap(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum RobotCommand {
     /// Send joint positions.
     SendJoints {

--- a/openrr-planner/src/errors.rs
+++ b/openrr-planner/src/errors.rs
@@ -19,6 +19,7 @@ use std::io;
 use thiserror::Error;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum UnfeasibleTrajectoryPoint {
     Start,
     WayPoint,

--- a/openrr-plugin/src/gen/proxy.rs
+++ b/openrr-plugin/src/gen/proxy.rs
@@ -595,7 +595,7 @@ impl From<arci::gamepad::Button> for RButton {
             arci::gamepad::Button::DPadDown => Self::DPadDown,
             arci::gamepad::Button::DPadLeft => Self::DPadLeft,
             arci::gamepad::Button::DPadRight => Self::DPadRight,
-            arci::gamepad::Button::Unknown => Self::Unknown,
+            arci::gamepad::Button::Unknown | _ => Self::Unknown,
         }
     }
 }
@@ -648,7 +648,7 @@ impl From<arci::gamepad::Axis> for RAxis {
             arci::gamepad::Axis::RightTrigger => Self::RightTrigger,
             arci::gamepad::Axis::DPadX => Self::DPadX,
             arci::gamepad::Axis::DPadY => Self::DPadY,
-            arci::gamepad::Axis::Unknown => Self::Unknown,
+            arci::gamepad::Axis::Unknown | _ => Self::Unknown,
         }
     }
 }
@@ -692,7 +692,7 @@ impl From<arci::gamepad::GamepadEvent> for RGamepadEvent {
             }
             arci::gamepad::GamepadEvent::Connected => Self::Connected,
             arci::gamepad::GamepadEvent::Disconnected => Self::Disconnected,
-            arci::gamepad::GamepadEvent::Unknown => Self::Unknown,
+            arci::gamepad::GamepadEvent::Unknown | _ => Self::Unknown,
         }
     }
 }


### PR DESCRIPTION
Add #[non_exhaustive] attribute to public enums that may have variants added in future versions:

- arci: Button, Axis, GamepadEvent
- openrr-apps: BuiltinClient, ClientKind, BuiltinGamepad, GamepadKind
- openrr-planner: UnfeasibleTrajectoryPoint
- openrr-command: RobotCommand

Also update downstream match statements to handle future variants.

Closes #112